### PR TITLE
Clarify player count condition description in ja.json

### DIFF
--- a/src-ui/assets/i18n/ja.json
+++ b/src-ui/assets/i18n/ja.json
@@ -118,7 +118,7 @@
       },
       "onlyBelowPlayerCount": {
         "description": "これにはあなた自身も含まれます",
-        "title": "ワールド内のプレイヤーが<strong>{count}</strong>人以下の場合にのみ"
+        "title": "ワールド内のプレイヤーが<strong>{count}</strong>人未満の場合にのみ"
       },
       "onlyIfSleepModeEnabled": {
         "title": "睡眠モード有効時のみ"
@@ -695,7 +695,7 @@
         "statusChangedOnPlayerCountChange": {
           "reason": {
             "AT_LIMIT_OR_ABOVE": "ワールド人数が{threshold}人に達した",
-            "BELOW_LIMIT": "ワールド人数が{threshold}人以下になった"
+            "BELOW_LIMIT": "ワールド人数が{threshold}人未満になった"
           },
           "title": "VRChatステータスを{oldStatus}から{newStatus}に変更"
         },


### PR DESCRIPTION
## EN
The conditions for automatic invite request approval and automatic status changes based on the player count are determined by checking whether the player count is *less than* the configured value (player count < configured value). However, the current Japanese translation uses “以下,” which translates to "less than or equal to" in English, even though “未満” better conveys the intended meaning of "less than."

## JP
招待リクエストの自動承認におけるプレイヤー数の条件や、プレイヤー数によるステータスの自動変更は、プレイヤー数が設定値未満かどうか `プレイヤー数 < 設定値` をチェックすることで決定されます。
しかし、現在の翻訳に使用されている日本語の「以下」は英語で "less than or equals" であり、「未満」の方がより正しい意図で伝わります。