### PR TITLE
Add VRChat microphone mute homeassistant integration service

### DIFF
--- a/src-ui/app/services/mqtt/integrations/vrchat-mic-mute.mqtt-integration.service.ts
+++ b/src-ui/app/services/mqtt/integrations/vrchat-mic-mute.mqtt-integration.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { MqttDiscoveryService } from '../mqtt-discovery.service';
+import { VRChatMicMuteAutomationService } from '../../osc-automations/vrchat-mic-mute-automation.service';
+import { MqttToggleProperty } from '../../../models/mqtt';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class VRChatMicMuteMqttIntegrationService {
+  constructor(
+    private mqtt: MqttDiscoveryService,
+    private vrchatMicMute: VRChatMicMuteAutomationService
+  ) {}
+
+  async init() {
+    // Init property
+    await this.mqtt.initProperty({
+      type: 'TOGGLE',
+      id: 'vrchatMicMute',
+      topicPath: 'vrchatMicMute',
+      displayName: 'VRChat Microphone Mute',
+      value: false,
+    });
+    // Report state
+    this.vrchatMicMute.muted.subscribe((muted) => {
+      if (muted === null) return;
+      this.mqtt.setTogglePropertyValue('vrchatMicMute', muted);
+    });
+    // Handle commands
+    this.mqtt
+      .getCommandStreamForProperty<MqttToggleProperty>('vrchatMicMute')
+      .subscribe((command) => {
+        this.vrchatMicMute.setMute(command.current.value);
+      });
+  }
+}

--- a/src-ui/app/services/mqtt/mqtt-integration.service.ts
+++ b/src-ui/app/services/mqtt/mqtt-integration.service.ts
@@ -11,6 +11,7 @@ import { BrightnessMqttIntegrationService } from './integrations/brightness.mqtt
 import { BigscreenBeyondMqttIntegrationService } from './integrations/bigscreen-beyond.mqtt-integration.service';
 import { HeartRateMqttIntegrationService } from './integrations/heart-rate.mqtt-integration.service';
 import { ShutdownSequenceMqttIntegrationService } from './integrations/shutdown-sequence.mqtt-integration.service';
+import { VRChatMicMuteMqttIntegrationService } from './integrations/vrchat-mic-mute.mqtt-integration.service';
 
 @Injectable({
   providedIn: 'root',
@@ -28,7 +29,8 @@ export class MqttIntegrationService {
     private brightnessMqttIntegrationService: BrightnessMqttIntegrationService,
     private bsbMqttIntegrationService: BigscreenBeyondMqttIntegrationService,
     private heartRateMqttIntegrationService: HeartRateMqttIntegrationService,
-    private shutdownSequenceMqttIntegrationService: ShutdownSequenceMqttIntegrationService
+    private shutdownSequenceMqttIntegrationService: ShutdownSequenceMqttIntegrationService,
+    private vrchatMicMuteMqttIntegrationService: VRChatMicMuteMqttIntegrationService
   ) {}
 
   async init() {
@@ -45,6 +47,7 @@ export class MqttIntegrationService {
       this.bsbMqttIntegrationService.init(),
       this.heartRateMqttIntegrationService.init(),
       this.shutdownSequenceMqttIntegrationService.init(),
+      this.vrchatMicMuteMqttIntegrationService.init(),
     ]);
   }
 }


### PR DESCRIPTION
This change adds the ability to access the VRChat mic state from within HomeAssistant.

Honest Disclaimer:

Neither do I have any idea what I'm doing here (I live in React, not real code), nor do I know whether the code in this PR makes sense, es even slightly coherent or is a feature that makes sense in oyasumi in the first place.

What I can say, it looks reasonable to me, and it definitely works:

https://github.com/user-attachments/assets/03825435-3ec4-41a0-a9fb-7237755d44d7

