### PR TITLE
use static max log levels

### DIFF
--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 hidapi = "2.6.3"
 hyper = { version = "0.14.26", features = ["full"] }
-log = "0.4.27"
+log = { version = "0.4.27", features = ["release_max_level_info"] }
 md5 = "0.8.0"
 mime = "0.3.17"
 mime_guess = "2.0.5"

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -167,6 +167,7 @@ fn configure_tauri_plugin_log() -> TauriPlugin<Wry> {
         .rotation_strategy(RotationStrategy::KeepAll);
 
     builder = builder
+        //also set in Cargo.toml
         .level(LevelFilter::Info)
         .target(tauri_plugin_log::Target::new(
             tauri_plugin_log::TargetKind::Stdout,


### PR DESCRIPTION
should (in theory) imarginally improve performance if any crate is using a lot of trace!() or debug!()  
didn't test if the difference is measurable but it certainly doesn't break logging