### PR TITLE
overlay-sidecard use WasHidden

### DIFF
--- a/src-overlay-sidecar/Overlays/DashboardOverlay.cs
+++ b/src-overlay-sidecar/Overlays/DashboardOverlay.cs
@@ -44,6 +44,7 @@ public class DashboardOverlay : BaseWebOverlay {
       ref transform
     );
     _closing = false;
+    Browser.GetBrowserHost().WasHidden(false);
     OvrManager.Instance.OverlayPointer!.StartForOverlay(this);
     ShowDashboard();
     OpenVR.Overlay.ShowOverlay(OverlayHandle);
@@ -62,6 +63,7 @@ public class DashboardOverlay : BaseWebOverlay {
       OnClose?.Invoke();
       _isOpen = false;
       OpenVR.Overlay.DestroyOverlay(OverlayHandle);
+        Browser.GetBrowserHost().WasHidden(true);
     }, TimeSpan.FromSeconds(1));
   }
 


### PR DESCRIPTION
WasHidden seems to tell the browser to pause (it won't call on_paint for example)
this should reduce cef's cpu/gpu usage to 0 when overlay is hidden
i only partially looked at how overlay is implemented so this may not be the right place to put it