### PR TITLE
optimize sleep detection 

### DIFF
--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -350,6 +350,7 @@ fn configure_command_handlers() -> impl Fn(tauri::ipc::Invoke) -> bool {
         openvr::commands::openvr_set_analog_color_temp,
         openvr::commands::openvr_set_app_framelimit,
         openvr::commands::openvr_get_app_framelimit,
+        openvr::commands::head_shake_detection_needed,
         hardware::beyond::commands::bigscreen_beyond_is_connected,
         hardware::beyond::commands::bigscreen_beyond_set_brightness,
         hardware::beyond::commands::bigscreen_beyond_set_led_color,

--- a/src-core/src/openvr/commands.rs
+++ b/src-core/src/openvr/commands.rs
@@ -1,4 +1,4 @@
-use crate::globals::STEAM_APP_KEY;
+use crate::{globals::STEAM_APP_KEY, openvr::devices::HEAD_SHAKE_DETECTION_NEEDED};
 
 use super::{
     models::{BindingOriginData, OVRDevice, OVRFrameLimits},
@@ -87,6 +87,10 @@ pub async fn openvr_set_analog_color_temp(
     temperature: Option<u32>,
 ) -> Result<(f64, f64, f64), String> {
     super::colortemp_analog::set_color_temp(temperature).await
+}
+#[tauri::command]
+pub async fn head_shake_detection_needed(v:bool){
+    unsafe {HEAD_SHAKE_DETECTION_NEEDED=v;}
 }
 
 #[tauri::command]

--- a/src-core/src/openvr/devices.rs
+++ b/src-core/src/openvr/devices.rs
@@ -274,7 +274,7 @@ async fn update_device(device_index: ovr::TrackedDeviceIndex, emit: bool) {
         send_event("OVR_DEVICE_UPDATE", event).await;
     }
 }
-
+pub static mut HEAD_SHAKE_DETECTION_NEEDED:bool=false;
 async fn refresh_device_poses() {
     let poses = {
         let context = OVR_CONTEXT.lock().await;
@@ -323,11 +323,13 @@ async fn refresh_device_poses() {
                     .await
                     .log_pose(pos.v)
                     .await;
+                if unsafe{HEAD_SHAKE_DETECTION_NEEDED}{
                 GESTURE_DETECTOR
                     .lock()
                     .await
                     .log_pose(pos.v, [q.x as f32, q.y as f32, q.z as f32, q.w as f32])
                     .await;
+                }
             }
             // Emit event
             if n == 0 {

--- a/src-core/src/openvr/devices.rs
+++ b/src-core/src/openvr/devices.rs
@@ -326,7 +326,7 @@ async fn refresh_device_poses() {
                 GESTURE_DETECTOR
                     .lock()
                     .await
-                    .log_pose(pos.v, [q.x, q.y, q.z, q.w])
+                    .log_pose(pos.v, [q.x as f32, q.y as f32, q.z as f32, q.w as f32])
                     .await;
             }
             // Emit event

--- a/src-core/src/openvr/devices.rs
+++ b/src-core/src/openvr/devices.rs
@@ -321,7 +321,7 @@ async fn refresh_device_poses() {
                 SLEEP_DETECTOR
                     .lock()
                     .await
-                    .log_pose(pos.v, [q.x, q.y, q.z, q.w])
+                    .log_pose(pos.v)
                     .await;
                 GESTURE_DETECTOR
                     .lock()

--- a/src-core/src/openvr/gesture_detector.rs
+++ b/src-core/src/openvr/gesture_detector.rs
@@ -67,7 +67,7 @@ impl GestureDetector {
             movements.push(yaw_diff);
         }
         // Detect head shake
-        if get_time() - self.last_detection >= 5000 && self.detect_head_shake(movements) {
+        if now - self.last_detection >= 5000 && self.detect_head_shake(movements) {
             self.last_detection = get_time();
             send_event(
                 "GESTURE_DETECTED",

--- a/src-core/src/openvr/gesture_detector.rs
+++ b/src-core/src/openvr/gesture_detector.rs
@@ -2,7 +2,6 @@ use nalgebra::{Quaternion, UnitQuaternion};
 
 use crate::utils::{get_time, send_event};
 
-
 const MAX_EVENT_AGE_MS: u64 = 5000; // 5 seconds
 
 #[derive(Clone, Copy)]
@@ -26,7 +25,7 @@ impl GestureDetector {
     }
 
     pub async fn log_pose(&mut self, _position: [f32; 3], quaternion: [f32; 4]) {
-        let now=get_time();
+        let now = get_time();
         // Determine yaw
         let q = UnitQuaternion::from_quaternion(Quaternion::new(
             quaternion[3],
@@ -34,13 +33,10 @@ impl GestureDetector {
             quaternion[1],
             quaternion[2],
         ));
-        let yaw = (2.0 * q.as_ref().imag().y.atan2(q.as_ref().scalar())).to_radians()
-            + 180.0;
+        let yaw = (2.0 * q.as_ref().imag().y.atan2(q.as_ref().scalar())).to_radians() + 180.0;
         // Log yaw event
-        let event = YawEvent {
-            yaw,
-        };
-        debug_assert_eq!(self.events.len(),self.events_timestamps.len());
+        let event = YawEvent { yaw };
+        debug_assert_eq!(self.events.len(), self.events_timestamps.len());
         self.events.push(event);
         self.events_timestamps.push(now);
         // Remove old events
@@ -52,7 +48,7 @@ impl GestureDetector {
             .count();
         self.events.drain(..old_event_count);
         // Convert events to relative movements
-        let mut movements = Vec::new();
+        let mut movements = Vec::with_capacity(self.events.len());
         for i in 0..self.events.len() - 1 {
             let yaw1 = self.events[i].yaw;
             let yaw2 = self.events[i + 1].yaw;
@@ -67,22 +63,18 @@ impl GestureDetector {
             movements.push(yaw_diff);
         }
         // Detect head shake
-        if now - self.last_detection >= 5000 && self.detect_head_shake(movements) {
-            self.last_detection = get_time();
-            send_event(
-                "GESTURE_DETECTED",
-                "",
-            )
-            .await;
+        if now - self.last_detection >= 5000 && self.detect_head_shake(&movements) {
+            self.last_detection = now;
+            send_event("GESTURE_DETECTED", "").await;
         }
     }
 
-    fn detect_head_shake(&self, movements: Vec<f32>) -> bool {
+    fn detect_head_shake(&self, movements: &[f32]) -> bool {
         let mut data = movements;
         let mut offset_dir = 1.0;
         let mut change: Option<usize>;
-        let change_dir_a = self.detect_angular_change(data.clone(), -15.0);
-        let change_dir_b = self.detect_angular_change(data.clone(), 15.0);
+        let change_dir_a = self.detect_angular_change(data, -15.0);
+        let change_dir_b = self.detect_angular_change(data, 15.0);
         if change_dir_a.is_some() {
             change = change_dir_a;
         } else if change_dir_b.is_some() {
@@ -91,12 +83,12 @@ impl GestureDetector {
         } else {
             return false;
         }
-        data = data[change.unwrap()..].to_vec();
-        change = self.detect_angular_change(data.clone(), 30.0 * offset_dir);
+        data = &data[change.unwrap()..];
+        change = self.detect_angular_change(data, 30.0 * offset_dir);
         if change.is_none() {
             return false;
         }
-        data = data[change.unwrap()..].to_vec();
+        data = &data[change.unwrap()..];
         change = self.detect_angular_change(data, -15.0 * offset_dir);
         if change.is_none() {
             return false;
@@ -104,23 +96,43 @@ impl GestureDetector {
         true
     }
 
-    fn detect_angular_change(&self, mut data: Vec<f32>, mut offset: f32) -> Option<usize> {
+    fn detect_angular_change(&self, data: &[f32], mut offset: f32) -> Option<usize> {
         let mut delta = 0.0;
+        let mut flip = false;
         // Flip data if we're looking for a negative offset
         if offset < 0.0 {
-            data = data.iter().map(|x| -x).collect();
+            flip = true;
+            // data = data.iter().map(|x| -x).collect();
             offset *= -1.0;
         }
-        // Loop over all data points
-        for (i, item) in data.iter().enumerate() {
-            delta += item;
-            // if delta is negative, reset to 0
-            if delta < 0.0 {
-                delta = 0.0;
+        //manually unroled for 'z' opt level
+        //https://godbolt.org/z/jrcshvc17
+        //https://godbolt.org/z/Kdq37336a
+        //https://godbolt.org/z/hrPfhMzds
+        if !flip {
+            // Loop over all data points
+            for (i, item) in data.iter().enumerate() {
+                delta += item;
+                // if delta is negative, reset to 0
+                if delta < 0.0 {
+                    delta = 0.0;
+                }
+                // If we have passed the given offset, angular change has been detected
+                if delta >= offset {
+                    return Some(i);
+                }
             }
-            // If we have passed the given offset, angular change has been detected
-            if delta >= offset {
-                return Some(i);
+        } else {
+            for (i, item) in data.iter().enumerate() {
+                delta -= item;
+                // if delta is negative, reset to 0
+                if delta < 0.0 {
+                    delta = 0.0;
+                }
+                // If we have passed the given offset, angular change has been detected
+                if delta >= offset {
+                    return Some(i);
+                }
             }
         }
         // Desired angular change could not be found

--- a/src-core/src/openvr/gesture_detector.rs
+++ b/src-core/src/openvr/gesture_detector.rs
@@ -8,7 +8,7 @@ const MAX_EVENT_AGE_MS: u64 = 5000; // 5 seconds
 
 #[derive(Clone, Copy)]
 struct YawEvent {
-    yaw: f32,
+    yaw: f64,
     timestamp: u64,
 }
 

--- a/src-core/src/openvr/gesture_detector.rs
+++ b/src-core/src/openvr/gesture_detector.rs
@@ -4,17 +4,17 @@ use crate::utils::{get_time, send_event};
 
 use super::models::GestureDetected;
 
-const MAX_EVENT_AGE_MS: u128 = 5000; // 5 seconds
+const MAX_EVENT_AGE_MS: u64 = 5000; // 5 seconds
 
 #[derive(Clone, Copy)]
 struct YawEvent {
-    yaw: f64,
-    timestamp: u128,
+    yaw: f32,
+    timestamp: u64,
 }
 
 pub struct GestureDetector {
     events: Vec<YawEvent>,
-    last_detection: u128,
+    last_detection: u64,
 }
 
 impl GestureDetector {

--- a/src-core/src/openvr/gesture_detector.rs
+++ b/src-core/src/openvr/gesture_detector.rs
@@ -2,7 +2,6 @@ use nalgebra::{Quaternion, UnitQuaternion};
 
 use crate::utils::{get_time, send_event};
 
-use super::models::GestureDetected;
 
 const MAX_EVENT_AGE_MS: u64 = 5000; // 5 seconds
 
@@ -72,9 +71,7 @@ impl GestureDetector {
             self.last_detection = get_time();
             send_event(
                 "GESTURE_DETECTED",
-                GestureDetected {
-                    gesture: "head_shake".to_string(),
-                },
+                "",
             )
             .await;
         }

--- a/src-core/src/openvr/gesture_detector.rs
+++ b/src-core/src/openvr/gesture_detector.rs
@@ -33,7 +33,7 @@ impl GestureDetector {
             quaternion[1],
             quaternion[2],
         ));
-        let yaw = (2.0 * q.as_ref().imag().y.atan2(q.as_ref().scalar())).to_radians() + 180.0;
+        let yaw = (2.0 * q.as_ref().imag().y.atan2(q.as_ref().scalar())).to_degrees() + 180.0;
         // Log yaw event
         let event = YawEvent { yaw };
         debug_assert_eq!(self.events.len(), self.events_timestamps.len());

--- a/src-core/src/openvr/models.rs
+++ b/src-core/src/openvr/models.rs
@@ -209,15 +209,7 @@ pub struct DeviceUpdateEvent {
 #[serde(rename_all = "camelCase")]
 pub struct SleepDetectorStateReport {
     pub distance_in_last_15_minutes: f64,
-    pub distance_in_last_10_minutes: f64,
-    pub distance_in_last_5_minutes: f64,
-    pub distance_in_last_1_minute: f64,
     pub distance_in_last_10_seconds: f64,
-    pub rotation_in_last_15_minutes: f64,
-    pub rotation_in_last_10_minutes: f64,
-    pub rotation_in_last_5_minutes: f64,
-    pub rotation_in_last_1_minute: f64,
-    pub rotation_in_last_10_seconds: f64,
     pub start_time: u128,
     pub last_log: u128,
 }

--- a/src-core/src/openvr/models.rs
+++ b/src-core/src/openvr/models.rs
@@ -216,12 +216,6 @@ pub struct SleepDetectorStateReport {
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GestureDetected {
-    pub gesture: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct OVRFrameLimits {
     pub additional_frames_to_predict: u8,
     pub frames_to_throttle: u8,

--- a/src-core/src/openvr/models.rs
+++ b/src-core/src/openvr/models.rs
@@ -208,10 +208,10 @@ pub struct DeviceUpdateEvent {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SleepDetectorStateReport {
-    pub distance_in_last_15_minutes: f64,
-    pub distance_in_last_10_seconds: f64,
-    pub start_time: u128,
-    pub last_log: u128,
+    pub distance_in_last_15_minutes: f32,
+    pub distance_in_last_10_seconds: f32,
+    pub start_time: u64,
+    pub last_log: u64,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src-core/src/openvr/sleep_detector.rs
+++ b/src-core/src/openvr/sleep_detector.rs
@@ -96,9 +96,9 @@ impl SleepDetector {
     fn distance_in_window(&mut self, window_ms: u64) -> f32 {
         let start_time = get_time() - window_ms;
         let start_index = self
-            .events
+            .events_timestamps
             .iter()
-            .position(|e| e.timestamp >= start_time)
+            .position(|t| *t >= start_time)
             .unwrap_or(0);
         let events = &self.events[start_index..];
         let mut total_distance = 0.0;

--- a/src-core/src/openvr/sleep_detector.rs
+++ b/src-core/src/openvr/sleep_detector.rs
@@ -2,7 +2,7 @@ use crate::utils::{get_time, send_event};
 
 use super::models::SleepDetectorStateReport;
 
-const MAX_EVENT_AGE_MS: u128 = 900000; // 15 minutes
+const MAX_EVENT_AGE_MS: u64 = 900000; // 15 minutes
 
 #[derive(Clone, Copy)]
 struct PoseEvent {
@@ -10,15 +10,16 @@ struct PoseEvent {
     y: f32,
     z: f32,
     // quaternion: [f64; 4],
-    timestamp: u128, // in milliseconds
+    timestamp: u64, // in milliseconds
 }
 
 impl PoseEvent {
-    fn distance_to(&self, other: &PoseEvent) -> f64 {
-        let dx: f64 = (self.x - other.x).into();
-        let dy: f64 = (self.y - other.y).into();
-        let dz: f64 = (self.z - other.z).into();
+    fn distance_to(&self, other: &PoseEvent) -> f32 {
+        let dx: f32 = (self.x - other.x).into();
+        let dy: f32 = (self.y - other.y).into();
+        let dz: f32 = (self.z - other.z).into();
         (dx * dx + dy * dy + dz * dz).sqrt()
+
     }
     // fn angular_distance_degrees(&self, other: &PoseEvent) -> f64 {
     //     let q1 = self.quaternion;
@@ -32,12 +33,12 @@ impl PoseEvent {
 
 pub struct SleepDetector {
     events: Vec<PoseEvent>,
-    distance_in_last_15_minutes: f64,
-    distance_in_last_10_seconds: f64,
+    distance_in_last_15_minutes: f32,
+    distance_in_last_10_seconds: f32,
     // reqwest_client: reqwest::Client,
-    start_time: u128,
-    last_log: u128,
-    next_state_report: u128,
+    start_time: u64,
+    last_log: u64,
+    next_state_report: u64,
 }
 
 impl SleepDetector {
@@ -86,7 +87,7 @@ impl SleepDetector {
         }
     }
 
-    fn distance_in_window(&mut self, window_ms: u128) -> f64 {
+    fn distance_in_window(&mut self, window_ms: u64) -> f32 {
         let start_time = get_time() - window_ms;
         let start_index = self
             .events

--- a/src-core/src/openvr/sleep_detector.rs
+++ b/src-core/src/openvr/sleep_detector.rs
@@ -9,7 +9,7 @@ struct PoseEvent {
     x: f32,
     y: f32,
     z: f32,
-    quaternion: [f64; 4],
+    // quaternion: [f64; 4],
     timestamp: u128, // in milliseconds
 }
 
@@ -20,28 +20,20 @@ impl PoseEvent {
         let dz: f64 = (self.z - other.z).into();
         (dx * dx + dy * dy + dz * dz).sqrt()
     }
-    fn angular_distance_degrees(&self, other: &PoseEvent) -> f64 {
-        let q1 = self.quaternion;
-        let q2 = other.quaternion;
-        let dot_product = q1[0] * q2[0] + q1[1] * q2[1] + q1[2] * q2[2] + q1[3] * q2[3];
-        let angle = 2.0 * dot_product.abs().clamp(-1.0, 1.0).acos();
+    // fn angular_distance_degrees(&self, other: &PoseEvent) -> f64 {
+    //     let q1 = self.quaternion;
+    //     let q2 = other.quaternion;
+    //     let dot_product = q1[0] * q2[0] + q1[1] * q2[1] + q1[2] * q2[2] + q1[3] * q2[3];
+    //     let angle = 2.0 * dot_product.abs().clamp(-1.0, 1.0).acos();
 
-        angle * 180.0 / std::f64::consts::PI
-    }
+    //     angle * 180.0 / std::f64::consts::PI
+    // }
 }
 
 pub struct SleepDetector {
     events: Vec<PoseEvent>,
     distance_in_last_15_minutes: f64,
-    distance_in_last_10_minutes: f64,
-    distance_in_last_5_minutes: f64,
-    distance_in_last_1_minute: f64,
     distance_in_last_10_seconds: f64,
-    rotation_in_last_15_minutes: f64,
-    rotation_in_last_10_minutes: f64,
-    rotation_in_last_5_minutes: f64,
-    rotation_in_last_1_minute: f64,
-    rotation_in_last_10_seconds: f64,
     // reqwest_client: reqwest::Client,
     start_time: u128,
     last_log: u128,
@@ -53,15 +45,7 @@ impl SleepDetector {
         Self {
             events: Vec::new(),
             distance_in_last_10_seconds: 0.0,
-            distance_in_last_1_minute: 0.0,
-            distance_in_last_5_minutes: 0.0,
-            distance_in_last_10_minutes: 0.0,
             distance_in_last_15_minutes: 0.0,
-            rotation_in_last_10_seconds: 0.0,
-            rotation_in_last_1_minute: 0.0,
-            rotation_in_last_5_minutes: 0.0,
-            rotation_in_last_10_minutes: 0.0,
-            rotation_in_last_15_minutes: 0.0,
             // reqwest_client: reqwest::Client::new(),
             start_time: 0,
             last_log: 0,
@@ -69,13 +53,12 @@ impl SleepDetector {
         }
     }
 
-    pub async fn log_pose(&mut self, position: [f32; 3], quaternion: [f64; 4]) {
+    pub async fn log_pose(&mut self, position: [f32; 3]) {
         // Add the event
         let event = PoseEvent {
             x: position[0],
             y: position[1],
             z: position[2],
-            quaternion,
             timestamp: get_time(),
         };
         self.events.push(event);
@@ -89,15 +72,7 @@ impl SleepDetector {
         self.events.drain(..old_event_count);
         // Calculate new distances
         self.distance_in_last_15_minutes = self.distance_in_window(900000);
-        self.distance_in_last_10_minutes = self.distance_in_window(600000);
-        self.distance_in_last_5_minutes = self.distance_in_window(300000);
-        self.distance_in_last_1_minute = self.distance_in_window(60000);
         self.distance_in_last_10_seconds = self.distance_in_window(10000);
-        self.rotation_in_last_15_minutes = self.rotation_in_window(900000);
-        self.rotation_in_last_10_minutes = self.rotation_in_window(600000);
-        self.rotation_in_last_5_minutes = self.rotation_in_window(300000);
-        self.rotation_in_last_1_minute = self.rotation_in_window(60000);
-        self.rotation_in_last_10_seconds = self.rotation_in_window(10000);
         // Set new start time if there hasn't been any data in over a minute
         if get_time().saturating_sub(self.last_log) > 60000 {
             self.start_time = get_time();
@@ -131,40 +106,12 @@ impl SleepDetector {
         total_distance
     }
 
-    fn rotation_in_window(&mut self, window_ms: u128) -> f64 {
-        let start_time = get_time() - window_ms;
-        let start_index = self
-            .events
-            .iter()
-            .position(|e| e.timestamp >= start_time)
-            .unwrap_or(0);
-        let events = &self.events[start_index..];
-        let mut total_rotation = 0.0;
-        let mut i = 0;
-        while i < events.len() - 1 {
-            let event_a = &events[i];
-            let event_b = &events[i + 1];
-            let rotation = event_a.angular_distance_degrees(event_b);
-            total_rotation += rotation;
-            i += 1;
-        }
-        total_rotation
-    }
-
     async fn send_state_report(&self) {
         send_event(
             "SLEEP_DETECTOR_STATE_REPORT",
             SleepDetectorStateReport {
                 distance_in_last_15_minutes: self.distance_in_last_15_minutes,
-                distance_in_last_10_minutes: self.distance_in_last_10_minutes,
-                distance_in_last_5_minutes: self.distance_in_last_5_minutes,
-                distance_in_last_1_minute: self.distance_in_last_1_minute,
                 distance_in_last_10_seconds: self.distance_in_last_10_seconds,
-                rotation_in_last_15_minutes: self.rotation_in_last_15_minutes,
-                rotation_in_last_10_minutes: self.rotation_in_last_10_minutes,
-                rotation_in_last_5_minutes: self.rotation_in_last_5_minutes,
-                rotation_in_last_1_minute: self.rotation_in_last_1_minute,
-                rotation_in_last_10_seconds: self.rotation_in_last_10_seconds,
                 start_time: self.start_time,
                 last_log: self.last_log,
             },

--- a/src-core/src/openvr/sleep_detector.rs
+++ b/src-core/src/openvr/sleep_detector.rs
@@ -14,9 +14,9 @@ struct PoseEvent {
 
 impl PoseEvent {
     fn distance_to(&self, other: &PoseEvent) -> f32 {
-        let dx: f32 = (self.x - other.x).into();
-        let dy: f32 = (self.y - other.y).into();
-        let dz: f32 = (self.z - other.z).into();
+        let dx: f32 = self.x - other.x;
+        let dy: f32 = self.y - other.y;
+        let dz: f32 = self.z - other.z;
         (dx * dx + dy * dy + dz * dz).sqrt()
 
     }

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsStr,
     os::raw::c_char,
     sync::LazyLock,
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use sysinfo::{ProcessesToUpdate, Signal, System};
 use tauri::Emitter;

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsStr,
     os::raw::c_char,
     sync::LazyLock,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use sysinfo::{ProcessesToUpdate, Signal, System};
 use tauri::Emitter;
@@ -59,10 +59,11 @@ pub async fn stop_process(process_name: &str, kill: bool) {
     }
 }
 
-pub fn get_time() -> u128 {
+pub fn get_time() -> u64 {
     let now = SystemTime::now();
     let since_the_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
-    since_the_epoch.as_millis()
+    //in a year 584544016 this will become a problem 
+    since_the_epoch.as_millis() as u64
 }
 
 pub async fn send_event<S: Serialize + Clone>(event: &str, payload: S) {

--- a/src-core/src/utils/profiling.rs
+++ b/src-core/src/utils/profiling.rs
@@ -12,7 +12,7 @@ use tokio::sync::Mutex;
 
 struct CommandInvocation {
     pub name: String,
-    pub time: u128,
+    pub time: u64,
 }
 
 static INVOCATION_COUNT: LazyLock<Mutex<HashMap<String, u64>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -125,7 +125,7 @@ pub fn profile_command_finish(invocation_id: Option<String>) {
 
 async fn detect_dead_invocations() {
     let time = super::get_time();
-    let mut dead_invocations: Vec<(String, String, u128)> = Vec::new();
+    let mut dead_invocations: Vec<(String, String, u64)> = Vec::new();
     let mut invocation_times_guard = INVOCATION_TIMES.lock().await;
     {
         let invocation_times = &mut *invocation_times_guard;

--- a/src-ui/app/models/events.ts
+++ b/src-ui/app/models/events.ts
@@ -6,15 +6,7 @@ export interface DeviceUpdateEvent {
 
 export interface SleepDetectorStateReport {
   distanceInLast15Minutes: number;
-  distanceInLast10Minutes: number;
-  distanceInLast5Minutes: number;
-  distanceInLast1Minute: number;
   distanceInLast10Seconds: number;
-  rotationInLast15Minutes: number;
-  rotationInLast10Minutes: number;
-  rotationInLast5Minutes: number;
-  rotationInLast1Minute: number;
-  rotationInLast10Seconds: number;
   startTime: number;
   lastLog: number;
 }

--- a/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
+++ b/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
@@ -25,6 +25,7 @@ import { OVRInputEventAction } from '../../models/ovr-input-event';
 import { SleepingPose } from '../../models/sleeping-pose';
 import { TelemetryService } from '../telemetry.service';
 import { getBuiltInNotificationSound } from 'src-ui/app/models/notification-sounds';
+import { invoke } from '@tauri-apps/api/core';
 
 export type SleepDetectorStateReportHandlingResult =
   | 'AUTOMATION_DISABLED'
@@ -128,6 +129,7 @@ export class SleepModeForSleepDetectorAutomationService {
 
   async dismissSleepCheck() {
     if (this.sleepEnableTimeoutId) {
+      await invoke("head_shake_detection_needed",{v:false});
       clearTimeout(this.sleepEnableTimeoutId);
       this.sleepEnableTimeoutId = null;
       this.eventLog.logEvent({
@@ -194,6 +196,7 @@ export class SleepModeForSleepDetectorAutomationService {
       return 'POSE_UPRIGHT_TOO_RECENTLY';
     // Attempt enabling sleep mode
     this.lastEnableAttempt = Date.now();
+    await invoke("head_shake_detection_needed",{v:true});
     // If necessary, first check if the user is asleep, allowing them to cancel.
     if (this.enableConfig.sleepCheck) {
       this.sleepCheckNotificationId = await this.notifications.send(
@@ -202,6 +205,7 @@ export class SleepModeForSleepDetectorAutomationService {
       );
       if (this.sleepEnableTimeoutId) return 'SLEEP_CHECK_ALREADY_IN_PROGRESS';
       this.sleepEnableTimeoutId = setTimeout(async () => {
+           await invoke("head_shake_detection_needed",{v:false});
         this.sleepEnableTimeoutId = null;
         this._lastStateReportHandlingResult.next('SLEEP_CHECK_USER_ASLEEP');
         await this.sleep.enableSleepMode({

--- a/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
+++ b/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
@@ -102,8 +102,7 @@ export class SleepModeForSleepDetectorAutomationService {
         this._lastStateReportHandlingResult.next(result);
       });
       // Dismiss sleep check for head shake
-      await listen<{ gesture: string }>('GESTURE_DETECTED', (event) => {
-        if (event.payload.gesture !== 'head_shake') return;
+      await listen<{ gesture: string }>('GESTURE_DETECTED', (_) => {
         this.dismissSleepCheck();
       });
       // Detect controller button presence indication


### PR DESCRIPTION
not tested, i only run cargo check

changes:
* gesture detector only runs when enabling sleep mode
* use u64 instead of u128 (we will be long dead before this starts to be a problem)
* f32 instead of f64 (summing distnance between 27272 randomly generated vec3 result in aprox error of 0.1 but math is faster)
* store timestamps seperatly ( math is a bit faster in a benchmark, didn't test how it affect drain() performance)
* don't calculate unused rotation and distance in sleep detector
* don't clone in GestureDetector

(this pr doesn't include stuff below, just throwing some ideas)
it's possible to remove square root from distance calculations (numbers  don't have to map to real values just be somewhat related) and avoid recalculating last 10s
as well as not storing the past positions (only the distance is needed) and doing a lot less calculations in the process

i'm gonna go touch grass