### PR TITLE
workaround for cef spamming .pma files 

### DIFF
--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -102,6 +102,8 @@ windows = { version = "0.54.0", features = [
   "Win32_UI_WindowsAndMessaging",
   "Win32_System_LibraryLoader",
   "Win32_Graphics_Gdi",
+  "Win32_System_IO",
+  "Win32_System_Ioctl",
 ], default-features = false }
 windows-sys = { version = "0.61.2", features = [
   "Win32_UI_Shell",

--- a/src-core/src/os/mod.rs
+++ b/src-core/src/os/mod.rs
@@ -14,16 +14,25 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::io::BufReader;
 use std::os::windows::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::ptr::null;
 use std::slice;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;
 use windows::core::GUID;
-use windows::Win32::Foundation::ERROR_SUCCESS;
+use windows::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE, INVALID_HANDLE_VALUE, SetLastError};
+use windows::Win32::System::Ioctl::FSCTL_SET_COMPRESSION;
 use windows::Win32::System::Power::{
     PowerEnumerate, PowerGetActiveScheme, PowerReadFriendlyName, PowerSetActiveScheme,
     ACCESS_SCHEME,
+};
+use windows::Win32::System::IO::DeviceIoControl;
+use windows_sys::Win32::Foundation::GENERIC_ALL;
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileA, COMPRESSION_FORMAT_LZNT1, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_NONE,
+    OPEN_EXISTING,
 };
 
 type PlaySoundSender = LazyLock<Mutex<Option<Sender<(String, f32)>>>>;
@@ -275,5 +284,41 @@ fn get_friendly_name_for_windows_power_policy(scheme_guid: &GUID) -> Option<Stri
     match os_str.to_string_lossy().into_owned() {
         s if !s.is_empty() => Some(s.trim_end_matches('\0').to_string()),
         _ => None,
+    }
+}
+pub fn enable_directory_compression(path: &PathBuf) -> windows::core::Result<()> {
+    debug_assert!(path.is_dir());
+    let handle = unsafe {
+        SetLastError(ERROR_SUCCESS);
+        let file_name = path.as_os_str();
+        let handle=HANDLE(CreateFileA(
+            file_name.as_encoded_bytes().as_ptr(),
+            GENERIC_ALL,
+            FILE_SHARE_NONE,
+            null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            0,
+        ));
+
+        if handle==INVALID_HANDLE_VALUE{
+            return Err(windows::core::Error::from_win32());
+        }
+        handle
+    };
+    let mode = COMPRESSION_FORMAT_LZNT1;
+    let mut idk: u32 = 0;
+    unsafe {
+        DeviceIoControl(
+            handle,
+            FSCTL_SET_COMPRESSION,
+            Some((&raw const mode).cast()),
+            size_of_val(&mode) as u32,
+            None,
+            0,
+            Some((&raw mut idk).cast()),
+            None,
+        )?;
+        CloseHandle(handle)
     }
 }

--- a/src-core/src/utils/sidecar_manager.rs
+++ b/src-core/src/utils/sidecar_manager.rs
@@ -1,8 +1,10 @@
 use log::{error, info, warn};
-use std::sync::Arc;
 use std::time::Duration;
+use std::{path::PathBuf, sync::Arc};
 use sysinfo::{Pid, System};
 use tokio::sync::{mpsc, Mutex};
+
+use crate::os::enable_directory_compression;
 
 const LAUNCH_RETRY_INTERVALS: [Duration; 9] = [
     Duration::from_millis(100),
@@ -131,6 +133,7 @@ impl SidecarManager {
                 args.push(arg.clone());
             }
         }
+        clear_overlay_cef_cache();
         let child = std::process::Command::new(exe_path)
             .current_dir(exe_dir)
             .args(args)
@@ -275,5 +278,15 @@ impl SidecarManager {
                 break;
             }
         });
+    }
+}
+pub fn clear_overlay_cef_cache() {
+    let mut path = PathBuf::from(std::env::var("LocalAppData").unwrap());
+    path.push("co.raphii.oyasumi");
+    path.push("cef_cache");
+    std::fs::remove_dir_all(&path).ok();
+    std::fs::create_dir_all(&path).ok();
+    if let Err(err)=enable_directory_compression(&path){
+        log::warn!("failed to enable compression for overlay cache: {:?}",err);
     }
 }

--- a/src-overlay-sidecar/Managers/BrowserManager.cs
+++ b/src-overlay-sidecar/Managers/BrowserManager.cs
@@ -29,7 +29,7 @@ public class BrowserManager {
           return cachedBrowser.Browser;
         }
       }
-
+      Log.Information("creating browser");
       OffscreenBrowser browser = Program.GpuAccelerated ? new AcceleratedOffscreenBrowser(url, width, height) : new NonAcceleratedOffscreenBrowser(url, width, height);
       _browsers.Add(new CachedBrowser(browser, false, width, height));
 

--- a/src-overlay-sidecar/Program.cs
+++ b/src-overlay-sidecar/Program.cs
@@ -69,6 +69,9 @@ public static class Program {
     if (InReleaseMode())
     {
       settings.LogSeverity = LogSeverity.Disable;
+       var cache_path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+      "co.raphii.oyasumi\\cef_cache");
+      settings.RootCachePath=cache_path;
       var cefDebugLogPath = Path.Combine(Path.GetDirectoryName(Environment.ProcessPath)!, @"debug.log");
       if (File.Exists(cefDebugLogPath)) File.Delete(cefDebugLogPath);
     }


### PR DESCRIPTION
#168 
winapi compression is based on:
https://learn.microsoft.com/en-us/previous-versions/windows/embedded/ms890601(v=msdn.10)
https://learn.microsoft.com/en-us/windows/win32/api/winioctl/ni-winioctl-fsctl_set_compression
i'm making it draft because it might just not work, i only run `cargo check --target x86_64-pc-windows-gnu` on modified rust-openvr branch and cherry-picked commit to develop