### PR TITLE
Invalid ambient declaration in src-overlay-ui/src/app.d.ts

### DIFF
--- a/src-overlay-ui/src/app.d.ts
+++ b/src-overlay-ui/src/app.d.ts
@@ -5,7 +5,7 @@ import type {
 } from '$lib/models/OyasumiOverlayIPC';
 
 declare global {
-	declare interface Window {
+	interface Window {
 		OyasumiIPCIn: OyasumiOverlayIPCIn;
 		OyasumiIPCOut: OyasumiOverlayIPCOut;
 		OyasumiIPCOut_Dashboard: OyasumiOverlayIPCOut_Dashboard;


### PR DESCRIPTION
## Problem

`src-overlay-ui/src/app.d.ts` currently contains:

```ts
declare global {
  declare interface Window {
    ...
  }
}
```

Using `declare interface` inside `declare global` appears redundant and can trigger the TypeScript error:

> A 'declare' modifier cannot be used in an already ambient context

## Expected

It should likely be:

```ts
declare global {
  interface Window {
    ...
  }
}
```

## Why this matters

This causes unnecessary TypeScript errors/noise when validating the overlay typings.

## Additional context

While validating a fork, the error disappeared after removing the inner `declare`.