### PR TITLE
Fix overlay TypeScript strict-mode issues in ipc.service.ts

### DIFF
--- a/src-overlay-ui/src/lib/services/ipc.service.ts
+++ b/src-overlay-ui/src/lib/services/ipc.service.ts
@@ -56,7 +56,7 @@ class IPCService {
 			};
 		}
 		// Define IPC IN functions
-		window.OyasumiIPCIn.setState = async (b64state) => {
+		window.OyasumiIPCIn.setState = async (b64state: string) => {
 			let state = OyasumiSidecarState.fromBinary(
 				Uint8Array.from(window.atob(b64state), (c) => c.charCodeAt(0))
 			);
@@ -66,11 +66,13 @@ class IPCService {
 				state,
 				(objValue: unknown, srcValue: unknown) => {
 					if (Array.isArray(objValue)) return srcValue;
+					return undefined;
 				}
 			);
 			this.state.set(state);
 		};
-		window.OyasumiIPCIn.showToolTip = async (tooltip) => this.events.showToolTip.set(tooltip);
+		window.OyasumiIPCIn.showToolTip = async (tooltip: string) =>
+			this.events.showToolTip.set(tooltip);
 		window.OyasumiIPCIn.clearNotification = async (notificationId: string) => {
 			this.events.clearNotification.set(notificationId);
 			await tick();


### PR DESCRIPTION
## Summary

This fixes a few small TypeScript issues in `src-overlay-ui/src/lib/services/ipc.service.ts`.

## Changes

- add an explicit `string` type to `b64state` in `window.OyasumiIPCIn.setState`
- add an explicit `string` type to `tooltip` in `window.OyasumiIPCIn.showToolTip`
- make the `mergeWith` customizer explicitly return `undefined` when no override is applied

## Why

These changes address strict TypeScript errors such as:

- parameter implicitly has an `any` type
- not all code paths return a value

The behavior should remain unchanged, but the file becomes cleaner under stricter type checking.

## Notes

I ran into these while validating TypeScript errors in the overlay code of a fork.
