### PR TITLE
fix: Align browser overlay routes with SvelteKit trailing-slash output

### DIFF
--- a/src-overlay-sidecar/Overlays/DashboardOverlay.cs
+++ b/src-overlay-sidecar/Overlays/DashboardOverlay.cs
@@ -17,7 +17,7 @@ public class DashboardOverlay : BaseWebOverlay {
   public event Action? OnClose;
 
   public DashboardOverlay() :
-    base("/dashboard", 1024, "co.raphii.oyasumivr:DashboardOverlay_" + Guid.NewGuid(), "OyasumiVR Dashboard Overlay")
+    base("/dashboard/", 1024, "co.raphii.oyasumivr:DashboardOverlay_" + Guid.NewGuid(), "OyasumiVR Dashboard Overlay")
   {
     Browser!.JavascriptObjectRepository.Register("OyasumiIPCOut_Dashboard", this);
     _tooltipOverlay = new TooltipOverlay();

--- a/src-overlay-sidecar/Overlays/NotificationOverlay.cs
+++ b/src-overlay-sidecar/Overlays/NotificationOverlay.cs
@@ -10,7 +10,7 @@ public class NotificationOverlay : BaseWebOverlay {
   private bool _updatedPositionOnce;
 
   public NotificationOverlay() :
-    base("/notifications", 1024, "co.raphii.oyasumivr:NotificationOverlay", "OyasumiVR Notification Overlay")
+    base("/notifications/", 1024, "co.raphii.oyasumivr:NotificationOverlay", "OyasumiVR Notification Overlay")
   {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);

--- a/src-overlay-sidecar/Overlays/SplashOverlay.cs
+++ b/src-overlay-sidecar/Overlays/SplashOverlay.cs
@@ -8,7 +8,7 @@ public class SplashOverlay : BaseWebOverlay {
   private bool _updatedPositionOnce;
 
   public SplashOverlay() :
-    base("/splash", 1024, "co.raphii.oyasumivr:SplashOverlay", "OyasumiVR Splash Overlay")
+    base("/splash/", 1024, "co.raphii.oyasumivr:SplashOverlay", "OyasumiVR Splash Overlay")
   {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);

--- a/src-overlay-sidecar/Overlays/TooltipOverlay.cs
+++ b/src-overlay-sidecar/Overlays/TooltipOverlay.cs
@@ -14,7 +14,7 @@ public class TooltipOverlay : BaseWebOverlay {
   private string? _text = "";
 
   public TooltipOverlay() :
-    base("/tooltip", 512, "co.raphii.oyasumivr:TooltipOverlay_" + Guid.NewGuid(), "OyasumiVR Tooltip Overlay")
+    base("/tooltip/", 512, "co.raphii.oyasumivr:TooltipOverlay_" + Guid.NewGuid(), "OyasumiVR Tooltip Overlay")
   {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);


### PR DESCRIPTION
## Summary

This PR changes browser overlay routes to use trailing slashes:

- `/dashboard` -> `/dashboard/`
- `/splash` -> `/splash/`
- `/notifications` -> `/notifications/`
- `/tooltip` -> `/tooltip/`

The overlay UI is built with SvelteKit static output and `trailingSlash = 'always'`, which emits these routes as directory index files such as:

- `build/dashboard/index.html`
- `build/splash/index.html`
- `build/notifications/index.html`
- `build/tooltip/index.html`

References:

- SvelteKit `trailingSlash`: https://svelte.dev/docs/kit/page-options#trailingSlash
- ASP.NET Core static/default files: https://learn.microsoft.com/aspnet/core/fundamentals/static-files

## Why

Before this change, release-mode overlay URLs were built as extensionless paths, for example:

```text
/static/dashboard?corePort=...
````

With ASP.NET Core `UseFileServer`, this does not directly return the generated `dashboard/index.html`. In a local check using the same static file serving setup, it returned:

```text
/static/dashboard?corePort=12345
-> 301 /static/dashboard/?corePort=12345
-> 200 text/html
```

The trailing-slash URL returns the HTML directly:

```text
/static/dashboard/?corePort=12345
-> 200 text/html
```

So this PR does not claim that the old route always caused a 404. It simply makes the CEF overlay URLs match the SvelteKit static output directly and avoids depending on a redirect during initial browser overlay navigation.
(I found 404 error on overlay UI once and doubt this was the cause, but no evidence honestly.)

## Testing

* `dotnet build` in `src-overlay-sidecar`: passed.
* `npm run build` in `src-overlay-ui`: passed.
* Confirmed the static build contains:

  * `build/dashboard/index.html`
  * `build/splash/index.html`
  * `build/notifications/index.html`
  * `build/tooltip/index.html`
* Verified with a minimal ASP.NET Core server using the same `UseFileServer` setup:

  * slashless routes return `301` to trailing-slash routes
  * trailing-slash routes return `200 text/html` directly
* Regression-tested the equivalent change in a downstream fork with the same overlay sidecar/static routing structure under SteamVR + Virtual Desktop + Quest 3.

  * No abnormal behavior was observed.