### PR TITLE
fix: overlay brightness slider jumping to 100%

### DIFF
--- a/src-overlay-ui/src/lib/components/BrightnessSlider.svelte
+++ b/src-overlay-ui/src/lib/components/BrightnessSlider.svelte
@@ -12,6 +12,7 @@
 	export let onValueChange: (value: number) => void = () => {};
 
 	let dragging = false;
+	let rangeGuideEl: HTMLElement;
 
 	let dragProgression = 0.65;
 
@@ -25,9 +26,9 @@
 	}
 
 	function handleMouseMove(event: MouseEvent) {
-		if (!dragging) return;
-		const rangeGuide = document.querySelector('.brightness-slider-bar-range-guide') as HTMLElement;
-		const barBounds = rangeGuide.getBoundingClientRect();
+		if (!dragging || !rangeGuideEl) return;
+		const barBounds = rangeGuideEl.getBoundingClientRect();
+		if (barBounds.width <= 0) return;
 		const progress = clamp((event.pageX - barBounds.left) / barBounds.width, 0.0, 1.0);
 		dragProgression = progress;
 		onValueChange(Math.round(progress * (max - min) + min));
@@ -62,7 +63,7 @@
 			<span>{renderPercentage}%</span>
 		</div>
 		<div class="brightness-slider-bar-post glow-80" style="flex: {(1 - renderProgression) * 100}" />
-		<div class="brightness-slider-bar-range-guide" />
+		<div class="brightness-slider-bar-range-guide" bind:this={rangeGuideEl} />
 	</div>
 </div>
 

--- a/src-overlay-ui/src/lib/components/ColorTempSlider.svelte
+++ b/src-overlay-ui/src/lib/components/ColorTempSlider.svelte
@@ -17,6 +17,7 @@
 	export let onValueChange: (value: number) => void = () => {};
 
 	let dragging = false;
+	let rangeGuideEl: HTMLElement;
 
 	let dragProgression = 0.65;
 
@@ -31,10 +32,10 @@
 	}
 
 	function handleMouseMove(event: MouseEvent) {
-		if (!dragging) return;
+		if (!dragging || !rangeGuideEl) return;
 		// Determine the progress
-		const rangeGuide = document.querySelector('.brightness-slider-bar-range-guide') as HTMLElement;
-		const barBounds = rangeGuide.getBoundingClientRect();
+		const barBounds = rangeGuideEl.getBoundingClientRect();
+		if (barBounds.width <= 0) return;
 		let progress = clamp((event.pageX - barBounds.left) / barBounds.width, 0.0, 1.0);
 		// Convert the progress to the value
 		let value = Math.round(progress * (max - min) + min);
@@ -82,7 +83,7 @@
 		<div class="brightness-slider-bar-pre glow-80" style="flex: {renderProgression * 100}" />
 		<div class="brightness-slider-thumb glow-80" style:background-color={cssColorForCCT} />
 		<div class="brightness-slider-bar-post glow-80" style="flex: {(1 - renderProgression) * 100}" />
-		<div class="brightness-slider-bar-range-guide" />
+		<div class="brightness-slider-bar-range-guide" bind:this={rangeGuideEl} />
 	</div>
 </div>
 


### PR DESCRIPTION
## Problem

In the VR overlay, dragging the brightness sliders occasionally
snaps to 100% (roughly 1 in 10–20 interactions). It only happens with the VR
controller pointer, not in the desktop window.

## Cause

`handleMouseMove` used a global `document.querySelector('.brightness-slider-bar-range-guide')`
(shared by every slider instance) and divided by `getBoundingClientRect().width`
with no guard. A zero-width/wrong element yields `Infinity`, which `clamp()` pins
to `1` → 100%. The overlay injects mouse-move events at headset refresh rate
(90–144 Hz), which makes the edge case surface far more often than with a mouse.

## Change

- Reference each slider's **own** range-guide element via `bind:this` instead of
  the global query (also removes a `querySelector` from the per-frame drag path).
- Skip the update when `getBoundingClientRect().width <= 0` to avoid the
  divide-by-zero → 100% jump.
