### PR TITLE
Ship one Steam build for both depots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 - Updated the Russian translations
 - OyasumiVR's window now does less work while it is open
 - Updated OyasumiVR's internal components
+- The Chinese Steam release is now the same build as the international Steam release. It switches to
+  CN compliance mode at runtime.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -18,12 +18,8 @@
     "build:sidecar:elevated": "run-s _build:sidecar:elevated:core _build:sidecar:elevated:post",
     "build:sidecar:overlay": "rimraf src-core/resources/overlay-sidecar && run-p _build:sidecar:overlay:ui _build:sidecar:overlay:core && run-s _build:sidecar:overlay:post",
     "//3": "=== Steam (build / upload / deploy) ===",
-    "build:steam:beta": "npm run clean && npm run build:steam:STEAM:beta && npm run build:steam:STEAM_CN:beta",
-    "build:steam:release": "npm run clean && npm run build:steam:STEAM && npm run build:steam:STEAM_CN",
-    "build:steam:STEAM": "npm run _prepare:steam:STEAM && npm run tauri -- build --no-bundle && node scripts/steam/package-steam-build.js STEAM",
-    "build:steam:STEAM:beta": "npm run _prepare:steam:STEAM && npm run tauri -- build --no-bundle --debug && node scripts/steam/package-steam-build.js STEAM",
-    "build:steam:STEAM_CN": "npm run _prepare:steam:STEAM_CN && npm run tauri -- build --no-bundle && node scripts/steam/package-steam-build.js STEAM_CN",
-    "build:steam:STEAM_CN:beta": "npm run _prepare:steam:STEAM_CN && npm run tauri -- build --no-bundle --debug && node scripts/steam/package-steam-build.js STEAM_CN",
+    "build:steam:beta": "npm run clean && npm run _prepare:steam && npm run tauri -- build --no-bundle --debug && npm run _package:steam",
+    "build:steam:release": "npm run clean && npm run _prepare:steam && npm run tauri -- build --no-bundle && npm run _package:steam",
     "upload:steam:beta": "node scripts/steam/upload-steam-build.js beta",
     "upload:steam:release": "node scripts/steam/upload-steam-build.js release",
     "deploy:steam:beta": "npm run build:steam:beta && npm run upload:steam:beta && npm run prepare:dev",
@@ -58,8 +54,8 @@
     "_build:sidecar:overlay:ui": "cd src-overlay-ui && npm run build && cd ..",
     "_build:sidecar:overlay:core": "cd src-overlay-sidecar && dotnet publish -r win-x64 -c Release && cd ..",
     "_build:sidecar:overlay:post": "node scripts/overlay-sidecar-post-build.js",
-    "_prepare:steam:STEAM": "npm run set-build-id && npm run set-flavour STEAM",
-    "_prepare:steam:STEAM_CN": "npm run set-flavour STEAM_CN"
+    "_prepare:steam": "npm run set-build-id && npm run set-flavour STEAM",
+    "_package:steam": "node scripts/steam/package-steam-build.js STEAM && node scripts/steam/package-steam-build.js STEAM_CN"
   },
   "private": true,
   "dependencies": {

--- a/scripts/set-flavour.js
+++ b/scripts/set-flavour.js
@@ -1,13 +1,13 @@
 import { readdirSync, readFileSync, writeFileSync } from 'fs';
 
 if (process.argv.length <= 2) {
-  console.error('Please provide a flavour (DEV, STANDALONE, STEAM, STEAM_CN)');
+  console.error('Please provide a flavour (DEV, STANDALONE, STEAM)');
   process.exit(1);
 }
 
 const flavour = process.argv[2].toUpperCase();
-if (!['DEV', 'STANDALONE', 'STEAM', 'STEAM_CN'].includes(flavour)) {
-  console.error('Provided flavour is not valid (DEV, STANDALONE, STEAM, STEAM_CN)');
+if (!['DEV', 'STANDALONE', 'STEAM'].includes(flavour)) {
+  console.error('Provided flavour is not valid (DEV, STANDALONE, STEAM)');
   process.exit(1);
 }
 
@@ -20,8 +20,6 @@ let appKey = (() => {
       return 'steam.overlay.2538150-STANDALONE';
     case 'STEAM':
       return 'steam.overlay.2538150-STEAM';
-    case 'STEAM_CN':
-      return 'steam.overlay.2538150-STEAM';
     default:
       console.warn('COULD NOT DETERMINE APP KEY FROM FLAVOUR');
       return 'steam.overlay.2538150-DEV';
@@ -33,7 +31,7 @@ let appKey = (() => {
   const path = 'src-ui/build.ts';
   let uiFlavour = readFileSync(path).toString();
   uiFlavour = uiFlavour.replaceAll(
-    /export const FLAVOUR: BuildFlavour = '(DEV|STANDALONE|STEAM|STEAM_CN)';/g,
+    /export const FLAVOUR: BuildFlavour = '(DEV|STANDALONE|STEAM)';/g,
     `export const FLAVOUR: BuildFlavour = '${flavour}';`
   );
   writeFileSync(path, uiFlavour);
@@ -45,7 +43,7 @@ let appKey = (() => {
   const path = 'src-core/src/flavour.rs';
   let coreFlavour = readFileSync(path).toString();
   coreFlavour = coreFlavour.replaceAll(
-    /pub const BUILD_FLAVOUR: BuildFlavour = BuildFlavour::(Dev|Standalone|Steam|SteamCn);/g,
+    /pub const BUILD_FLAVOUR: BuildFlavour = BuildFlavour::(Dev|Standalone|Steam);/g,
     `pub const BUILD_FLAVOUR: BuildFlavour = BuildFlavour::${flavour
       .split('_')
       .map((t) => t.toUpperCase().charAt(0) + t.toLowerCase().substring(1))

--- a/scripts/steam/package-steam-build.js
+++ b/scripts/steam/package-steam-build.js
@@ -1,18 +1,29 @@
-import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 
-const FLAVOURS = {
+// Both depots get the same STEAM build. The Chinese depot carries a marker file, which switches
+// OyasumiVR to CN compliance mode at runtime.
+const DEPOTS = {
   STEAM: { contentDir: 'Win64' },
-  STEAM_CN: { contentDir: 'Win64_CN' },
+  STEAM_CN: { contentDir: 'Win64_CN', cnRelease: true },
 };
 
 const WEBVIEW2_INSTALLER_URL = 'https://go.microsoft.com/fwlink/p/?LinkId=2124703';
 const WEBVIEW2_INSTALLER_NAME = 'WebView2RuntimeInstaller.exe';
 const EXECUTABLE_NAME = 'OyasumiVR.exe';
+const CN_MARKER_NAME = 'cn_release';
 
-const flavourArg = (process.argv[2] || '').toUpperCase();
-if (!FLAVOURS[flavourArg]) {
+const depotArg = (process.argv[2] || '').toUpperCase();
+if (!DEPOTS[depotArg]) {
   console.error('Usage: node scripts/steam/package-steam-build.js <STEAM|STEAM_CN>');
   process.exit(1);
 }
@@ -24,10 +35,10 @@ if (!flavourMatch) {
   process.exit(1);
 }
 const currentFlavour = flavourMatch[1];
-if (currentFlavour !== flavourArg) {
+if (currentFlavour !== 'STEAM') {
   console.error(
-    `Current build flavour is ${currentFlavour}, but packaging requested ${flavourArg}. ` +
-      `Run \`npm run set-flavour ${flavourArg}\` and rebuild before packaging.`
+    `Current build flavour is ${currentFlavour}, but Steam depots need the STEAM flavour. ` +
+      'Run `npm run set-flavour STEAM` and rebuild before packaging.'
   );
   process.exit(1);
 }
@@ -47,7 +58,7 @@ if (existsSync(join(releaseDir, EXECUTABLE_NAME))) {
   process.exit(1);
 }
 
-const { contentDir } = FLAVOURS[flavourArg];
+const { contentDir, cnRelease } = DEPOTS[depotArg];
 const outputDir = join('dist', 'steam', contentDir);
 
 rmSync(outputDir, { recursive: true, force: true });
@@ -96,4 +107,8 @@ copyFileSync(
   join(outputDir, 'runtime_dependencies.vdf')
 );
 
-console.log(`Packaged Steam ${flavourArg} build to ${outputDir}`);
+if (cnRelease) {
+  writeFileSync(join(outputDir, CN_MARKER_NAME), '');
+}
+
+console.log(`Packaged Steam ${depotArg} build to ${outputDir}`);

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -55,7 +55,7 @@ rosc = "0.11.4"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 steamlocate = "2.1.0"
-steamworks = { version = "0.13.1" }
+steamworks = { version = "0.13.1", features = ["raw-bindings"] }
 strum = "0.28.0"
 strum_macros = "0.28.0"
 substring = "1.4.5"

--- a/src-core/src/cn_compliance.rs
+++ b/src-core/src/cn_compliance.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+// Present in the content of the Chinese Steam depot only.
+const MARKER_FILE: &str = "cn_release";
+
+pub async fn is_cn_release() -> bool {
+    if Path::new(MARKER_FILE).exists() {
+        return true;
+    }
+    // The Steamworks interface pointer is only valid once the client has been initialized.
+    if crate::steam::STEAMWORKS_CLIENT.lock().await.is_none() {
+        return false;
+    }
+    unsafe {
+        let utils = steamworks::sys::SteamAPI_SteamUtils_v010();
+        !utils.is_null() && steamworks::sys::SteamAPI_ISteamUtils_IsSteamChinaLauncher(utils)
+    }
+}
+
+#[tauri::command]
+#[oyasumivr_macros::command_profiling]
+pub async fn cn_compliance_mode() -> bool {
+    is_cn_release().await
+}

--- a/src-core/src/flavour.rs
+++ b/src-core/src/flavour.rs
@@ -5,7 +5,6 @@ pub enum BuildFlavour {
     Dev,
     Standalone,
     Steam,
-    SteamCn,
 }
 
 pub const BUILD_FLAVOUR: BuildFlavour = BuildFlavour::Dev;

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod cn_compliance;
 mod commands;
 mod discord;
 mod elevated_sidecar;
@@ -418,6 +419,7 @@ fn configure_command_handlers() -> impl Fn(tauri::ipc::Invoke) -> bool {
         commands::nvml::nvml_set_power_management_limit,
         commands::debug::open_dev_tools,
         commands::debug::is_flag_set,
+        cn_compliance::cn_compliance_mode,
         commands::time::get_sunrise_sunset_time,
         grpc::commands::get_core_grpc_port,
         grpc::commands::get_core_grpc_web_port,

--- a/src-core/src/steam/mod.rs
+++ b/src-core/src/steam/mod.rs
@@ -13,7 +13,6 @@ pub static STEAMWORKS_USER_STATS_FETCHED: LazyLock<Mutex<bool>> =
 
 pub async fn init() {
     if crate::BUILD_FLAVOUR != crate::flavour::BuildFlavour::Steam
-        && crate::BUILD_FLAVOUR != crate::flavour::BuildFlavour::SteamCn
         && crate::BUILD_FLAVOUR != crate::flavour::BuildFlavour::Dev
     {
         return;

--- a/src-ui/app/cn-compliance.ts
+++ b/src-ui/app/cn-compliance.ts
@@ -1,0 +1,27 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { LANGUAGES } from './globals';
+import translationContributorData from '../../docs/translation_contributors.json';
+
+let applied = false;
+
+export async function initCnCompliance() {
+  await applyCnCompliance();
+  // The marker file answers on its own, but the Steam China launcher check only answers once
+  // Steamworks has finished initializing.
+  await listen<boolean>('STEAMWORKS_READY', () => applyCnCompliance());
+}
+
+async function applyCnCompliance() {
+  if (applied) return;
+  if (!(await invoke<boolean>('cn_compliance_mode'))) return;
+  applied = true;
+  LANGUAGES.filter((language) => language.flag === 'tw').forEach(
+    (language) => (language.flag = 'hk')
+  );
+  const contributors: Array<{ langCode: string; flagCode?: string }> = translationContributorData;
+  contributors.forEach((contributor) => {
+    if (contributor.flagCode === 'tw') contributor.flagCode = 'hk';
+    if (contributor.langCode === 'tw') contributor.langCode = 'hk';
+  });
+}

--- a/src-ui/app/globals.ts
+++ b/src-ui/app/globals.ts
@@ -1,5 +1,4 @@
 import { LazyStore } from '@tauri-apps/plugin-store';
-import { FLAVOUR } from '../build';
 
 export const SPLASH_MIN_DURATION = 3000;
 export const SETTINGS_KEY_AUTOMATION_CONFIGS = 'AUTOMATION_CONFIGS';
@@ -58,7 +57,7 @@ export const LANGUAGES: Array<{ code: string; label: string; flag?: string }> = 
   {
     code: 'tw',
     label: '繁體中文',
-    flag: FLAVOUR === 'STEAM_CN' ? 'hk' : 'tw',
+    flag: 'tw',
   },
   {
     code: 'cn',

--- a/src-ui/app/services/steam.service.ts
+++ b/src-ui/app/services/steam.service.ts
@@ -54,7 +54,7 @@ export class SteamService {
 
   public async init() {
     // Only run in Steam flavoured builds
-    if (FLAVOUR !== 'STEAM' && FLAVOUR !== 'STEAM_CN' && FLAVOUR !== 'DEV') return;
+    if (FLAVOUR !== 'STEAM' && FLAVOUR !== 'DEV') return;
     // Keep track of Steamworks status
     await this.getSteamActive();
     await listen<boolean>('STEAMWORKS_READY', (data) => this._active.next(data.payload));

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
@@ -61,21 +61,7 @@ export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private background: BackgroundService,
     private destroyRef: DestroyRef
   ) {
-    let translationContributors: TranslationContributor[] = translationContributorData;
-    // Change flags in translation contributors for CN compliance.
-    if (FLAVOUR === 'STEAM_CN') {
-      const cnComplianceFix = (author: TranslationContributor): TranslationContributor => {
-        if (author.flagCode === 'tw') author.flagCode = 'hk';
-        if (author.langCode === 'tw') author.langCode = 'hk';
-        return author;
-      };
-
-      translationContributors = translationContributors.map((contribs) =>
-        cnComplianceFix(contribs)
-      );
-    }
-
-    this.buildTranslationContributors(translationContributors, 4);
+    this.buildTranslationContributors(translationContributorData, 4);
   }
 
   private buildTranslationContributors(

--- a/src-ui/app/views/dashboard-view/views/settings-updates-view/settings-updates-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/settings-updates-view/settings-updates-view.component.html
@@ -8,13 +8,13 @@
             @if (FLAVOUR === 'DEV') {
               <img src="/assets/img/icon_150x150.png" />
             }
-            @if (FLAVOUR === 'STEAM' || FLAVOUR === 'STEAM_CN') {
+            @if (FLAVOUR === 'STEAM') {
               <img src="/assets/img/steam_icon.png" />
             }
             @if (FLAVOUR === 'DEV') {
               <span transloco="settings.updates.updatesDisabled.DEV"></span>
             }
-            @if (FLAVOUR === 'STEAM' || FLAVOUR === 'STEAM_CN') {
+            @if (FLAVOUR === 'STEAM') {
               <span transloco="settings.updates.updatesDisabled.STEAM"></span>
             }
           </div>

--- a/src-ui/build.ts
+++ b/src-ui/build.ts
@@ -3,6 +3,6 @@
 // Do not modify this file manually.
 //
 
-export type BuildFlavour = 'DEV' | 'STANDALONE' | 'STEAM' | 'STEAM_CN';
+export type BuildFlavour = 'DEV' | 'STANDALONE' | 'STEAM';
 export const FLAVOUR: BuildFlavour = 'DEV';
 export const BUILD_ID = 'd4ab5c80';

--- a/src-ui/main.ts
+++ b/src-ui/main.ts
@@ -7,6 +7,7 @@ import { attachConsole, error, info } from '@tauri-apps/plugin-log';
 import { getVersion } from './app/utils/app-utils';
 import { FLAVOUR } from './build';
 import { disableDefaultContextMenu } from './app/utils/browser-utils';
+import { initCnCompliance } from './app/cn-compliance';
 
 if (environment.production) {
   enableProdMode();
@@ -22,6 +23,10 @@ getVersion().then((version) => {
 
 disableDefaultContextMenu();
 
-platformBrowserDynamic()
-  .bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()] })
-  .catch((err) => error(err));
+initCnCompliance()
+  .catch((err) => error(err))
+  .then(() =>
+    platformBrowserDynamic()
+      .bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()] })
+      .catch((err) => error(err))
+  );


### PR DESCRIPTION
The Chinese Steam release was a separate compile. Its only difference: it showed the Hong Kong flag where the international build shows the Taiwan flag, in the language list and in the translation contributor list. Everything else matched, including the Steam app ID, the overlay app key, and the VR manifest.

Both depots now get the same binary. `npm run build:steam:release` and `npm run build:steam:beta` compile once and package the result twice, so a release takes one Rust build instead of two.

## How the app knows

CN compliance mode turns on when either signal is true:

1. The file `cn_release` sits next to the executable. `scripts/steam/package-steam-build.js` writes it into the `Win64_CN` content only, so it ships in the Chinese depot and nowhere else.
2. `ISteamUtils::IsSteamChinaLauncher()` reports that the Steam China launcher started the app.

Two signals, because each covers the gap in the other. A user can delete the marker file, and the launcher check still answers. The launcher check needs an initialized Steamworks client, and the marker file does not. Neither signal is a user-editable config value, which is why this does not use `flags.toml`.

The result is safe in both directions. A Chinese install keeps the Hong Kong flag even without the marker file. An international install keeps the Taiwan flag even when Steam is unreachable.

## What to check before merging

- Whether depot 2538152 is restricted to the Steam China launcher in the Steamworks partner site. If it is restricted some other way, signal 2 will not cover every user in that depot, and the marker file carries the whole job alone. The marker file alone is still enough, this only decides how much the second signal adds.
- The first Steam upload after this merge. `dist/steam/Win64_CN/cn_release` must exist, and `dist/steam/Win64/` must not contain it.

## Notes

- `STEAM_CN` is gone as a build flavour. It now names a depot only, in `package-steam-build.js` and `upload-steam-build.js`.
- The `steamworks` dependency gains the `raw-bindings` feature. That feature is what makes `steamworks::sys` public. The safe wrapper does not expose `IsSteamChinaLauncher`.
- The version label in the titlebar, the About page, and the telemetry payload now reads `STEAM` for Chinese users, where it read `STEAM_CN` before. Say the word if you want a separate label back.
- The About page lost its CN branch. `src-ui/app/cn-compliance.ts` rewrites the shared contributor data instead, so all CN logic lives in one file.

## Testing

`cargo check`, `ng lint`, and `ng build` pass. I did not run the packaging scripts or a Steam upload.
