### PR TITLE
feat: expose the VRChat microphone mute as an MQTT switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 - OSC Settings view
   - Custom target for OSC messages (e.g. for use with Resonite, OSC routers, or when OSCQuery is not available)
   - VRChat (OSCQuery) target (allows for disabling OSC messages being sent to VRChat)
+- Home Assistant switch for the VRChat microphone mute
 
 ### Changed
 

--- a/src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts
+++ b/src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { MqttDiscoveryService } from '../mqtt-discovery.service';
 import { VRChatService } from '../../vrchat-api/vrchat.service';
 import { combineLatest, firstValueFrom } from 'rxjs';
+import { VRChatMicMuteAutomationService } from '../../osc-automations/vrchat-mic-mute-automation.service';
+import { MqttToggleProperty } from '../../../models/mqtt';
 
 @Injectable({
   providedIn: 'root',
@@ -9,7 +11,8 @@ import { combineLatest, firstValueFrom } from 'rxjs';
 export class VRChatMqttIntegrationService {
   constructor(
     private mqtt: MqttDiscoveryService,
-    private vrchat: VRChatService
+    private vrchat: VRChatService,
+    private micMute: VRChatMicMuteAutomationService
   ) {}
 
   async init() {
@@ -43,6 +46,23 @@ export class VRChatMqttIntegrationService {
       value: 'null',
       available: false,
     });
+    await this.mqtt.initProperty({
+      type: 'TOGGLE',
+      id: 'vrcMicMuted',
+      topicPath: 'vrcMicMuted',
+      displayName: 'VRChat Microphone Muted',
+      value: false,
+      available: false,
+    });
+    this.micMute.muted.subscribe(async (muted) => {
+      await this.mqtt.setPropertyAvailability('vrcMicMuted', muted !== null);
+      await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
+    });
+    this.mqtt
+      .getCommandStreamForProperty<MqttToggleProperty>('vrcMicMuted')
+      .subscribe(async (command) => {
+        await this.micMute.setMute(command.current.value);
+      });
     this.vrchat.user.subscribe(async (user) => {
       await this.mqtt.setSensorPropertyValue('vrcPlayerName', user?.displayName ?? 'null');
       await this.mqtt.setSensorPropertyValue(

--- a/src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts
+++ b/src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts
@@ -54,13 +54,21 @@ export class VRChatMqttIntegrationService {
       value: false,
       available: false,
     });
-    this.micMute.muted.subscribe(async (muted) => {
-      await this.mqtt.setPropertyAvailability('vrcMicMuted', muted !== null);
-      await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
-    });
+    combineLatest([this.micMute.muted, this.vrchat.vrchatProcessActive]).subscribe(
+      async ([muted, vrcActive]) => {
+        await this.mqtt.setPropertyAvailability('vrcMicMuted', muted !== null && vrcActive);
+        await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
+      }
+    );
     this.mqtt
       .getCommandStreamForProperty<MqttToggleProperty>('vrcMicMuted')
       .subscribe(async (command) => {
+        const muted = await firstValueFrom(this.micMute.muted);
+        const vrcActive = await firstValueFrom(this.vrchat.vrchatProcessActive);
+        if (muted === null || !vrcActive) {
+          await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
+          return;
+        }
         await this.micMute.setMute(command.current.value);
       });
     this.vrchat.user.subscribe(async (user) => {

--- a/src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts
+++ b/src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts
@@ -54,19 +54,16 @@ export class VRChatMqttIntegrationService {
       value: false,
       available: false,
     });
-    combineLatest([this.micMute.muted, this.vrchat.vrchatProcessActive]).subscribe(
-      async ([muted, vrcActive]) => {
-        await this.mqtt.setPropertyAvailability('vrcMicMuted', muted !== null && vrcActive);
-        await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
-      }
-    );
+    this.micMute.muted.subscribe(async (muted) => {
+      await this.mqtt.setPropertyAvailability('vrcMicMuted', muted !== null);
+      await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
+    });
     this.mqtt
       .getCommandStreamForProperty<MqttToggleProperty>('vrcMicMuted')
       .subscribe(async (command) => {
         const muted = await firstValueFrom(this.micMute.muted);
-        const vrcActive = await firstValueFrom(this.vrchat.vrchatProcessActive);
-        if (muted === null || !vrcActive) {
-          await this.mqtt.setTogglePropertyValue('vrcMicMuted', muted ?? false);
+        if (muted === null) {
+          await this.mqtt.setTogglePropertyValue('vrcMicMuted', false);
           return;
         }
         await this.micMute.setMute(command.current.value);

--- a/src-ui/app/services/osc-automations/vrchat-mic-mute-automation.service.ts
+++ b/src-ui/app/services/osc-automations/vrchat-mic-mute-automation.service.ts
@@ -24,6 +24,7 @@ import { EventLogService } from '../event-log.service';
 import { EventLogChangedVRChatMicMuteState } from '../../models/event-log-entry';
 import { info } from '@tauri-apps/plugin-log';
 import { fetch } from '@tauri-apps/plugin-http';
+import { VRChatService } from '../vrchat-api/vrchat.service';
 
 const READ_ADDR = '/avatar/parameters/MuteSelf';
 const WRITE_ADDR = '/input/Voice';
@@ -34,6 +35,8 @@ const WRITE_ADDR = '/input/Voice';
 export class VRChatMicMuteAutomationService {
   private _muted = new BehaviorSubject<boolean | null>(null);
   public muted = this._muted.asObservable();
+  // Serializes the OSC button pulses, as two overlapping pulses read as a single press in VRChat.
+  private muteQueue: Promise<void> = Promise.resolve();
   private config: VRChatMicMuteAutomationsConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.VRCHAT_MIC_MUTE_AUTOMATIONS
   );
@@ -43,13 +46,18 @@ export class VRChatMicMuteAutomationService {
     private automationConfigs: AutomationConfigService,
     private sleep: SleepService,
     private sleepPreparation: SleepPreparationService,
-    private eventLog: EventLogService
+    private eventLog: EventLogService,
+    private vrchat: VRChatService
   ) {}
 
   async init() {
     this.automationConfigs.configs.subscribe((configs) => {
       this.config = configs.VRCHAT_MIC_MUTE_AUTOMATIONS;
     });
+    // Forget the muted state when VRChat stops, as the next session reports its own
+    this.vrchat.vrchatProcessActive
+      .pipe(filter((active) => !active))
+      .subscribe(() => this._muted.next(null));
     // Listen for the muted state
     this.osc.messages.subscribe((message) => {
       if (message.address === READ_ADDR) {
@@ -140,10 +148,14 @@ export class VRChatMicMuteAutomationService {
   }
 
   async setMute(state: boolean) {
-    if (this._muted.value !== state) {
-      if (this._muted.value !== null) this._muted.next(state);
-      await this.toggleMute(false);
-    }
+    const run = this.muteQueue.then(async () => {
+      if (this._muted.value !== state) {
+        if (this._muted.value !== null) this._muted.next(state);
+        await this.toggleMute(false);
+      }
+    });
+    this.muteQueue = run.catch(() => undefined);
+    return run;
   }
 
   private async fetchMutedState(): Promise<boolean> {

--- a/src-ui/app/services/osc-automations/vrchat-mic-mute-automation.service.ts
+++ b/src-ui/app/services/osc-automations/vrchat-mic-mute-automation.service.ts
@@ -37,6 +37,7 @@ export class VRChatMicMuteAutomationService {
   public muted = this._muted.asObservable();
   // Serializes the OSC button pulses, as two overlapping pulses read as a single press in VRChat.
   private muteQueue: Promise<void> = Promise.resolve();
+  private vrcActive = false;
   private config: VRChatMicMuteAutomationsConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.VRCHAT_MIC_MUTE_AUTOMATIONS
   );
@@ -55,14 +56,15 @@ export class VRChatMicMuteAutomationService {
       this.config = configs.VRCHAT_MIC_MUTE_AUTOMATIONS;
     });
     // Forget the muted state when VRChat stops, as the next session reports its own
-    this.vrchat.vrchatProcessActive
-      .pipe(filter((active) => !active))
-      .subscribe(() => this._muted.next(null));
+    this.vrchat.vrchatProcessActive.subscribe((active) => {
+      this.vrcActive = active;
+      if (!active) this._muted.next(null);
+    });
     // Listen for the muted state
     this.osc.messages.subscribe((message) => {
       if (message.address === READ_ADDR) {
         const value = message.values[0];
-        if (value.kind === 'bool') {
+        if (value.kind === 'bool' && this.vrcActive) {
           const muted = (value as OSCBoolValue).value;
           this._muted.next(muted);
         }
@@ -166,6 +168,7 @@ export class VRChatMicMuteAutomationService {
       const resp = await fetch(`http://${oscqAddr}/avatar/parameters/MuteSelf`);
       const data: { VALUE?: boolean[] } = await resp.json().catch(() => {});
       if (
+        this.vrcActive &&
         data.VALUE &&
         isArray(data.VALUE) &&
         data.VALUE.length &&


### PR DESCRIPTION
Home Assistant now gets a `switch` entity for the VRChat microphone mute, instead of nothing. It reports the state and can change it.

The whole change is one property in `src-ui/app/services/mqtt/integrations/vrchat.mqtt-integration.service.ts`:

- New `TOGGLE` property `vrcMicMuted`, display name "VRChat Microphone Muted". `MqttDiscoveryService` publishes `TOGGLE` properties as a Home Assistant `switch`, so state and command both work.
- State comes from `VRChatMicMuteAutomationService.muted`.
- A command calls `VRChatMicMuteAutomationService.setMute()`, which sends the same OSC `/input/Voice` sequence the sleep automations use.
- `muted` is `null` until VRChat reports the state over OSC or OSCQuery. While it is `null`, the entity is marked unavailable, so Home Assistant does not show a wrong state.

What a reviewer must check:

- The mute state does not oscillate when you flip the switch in Home Assistant. The command handler sets the property value first, then `setMute` sends OSC, then VRChat echoes `MuteSelf` back with the same value.
- Injecting `VRChatMicMuteAutomationService` into the MQTT integration does not create a dependency cycle. Its own dependencies (OSC, automation config, sleep, sleep preparation, event log) do not reach the MQTT services.

What I left out:

- No event log entry when Home Assistant changes the mute state. The existing `changedVRChatMicMuteState` reasons are sleep-related only, and the other MQTT integrations (for example sleep mode) do not log either.
- No entry for the system microphone mute. You asked for VRChat only.

I checked this with `tsc -p tsconfig.app.json --noEmit`. I did not run it against a live VRChat and broker.
