### PR TITLE
Replace the Index brightness sample table with its gamma curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 - Fixed the "GPU acceleration" setting for the VR overlay. Turning it off left the overlay blank instead of switching
   to software rendering
 - The VR overlay no longer leaves temporary files on your disk
+- Fixed the Valve Index's hardware brightness being slightly off at levels in between the ones OyasumiVR had measured
+  (Thanks to help from [coolGi](https://github.com/coolGi69))
 - Various stability improvements
 
 ### Removed

--- a/src-ui/app/services/brightness-control/hardware-brightness-drivers/valve-index-hardware-brightness-control-driver.ts
+++ b/src-ui/app/services/brightness-control/hardware-brightness-drivers/valve-index-hardware-brightness-control-driver.ts
@@ -2,10 +2,16 @@ import {
   HardwareBrightnessControlDriver,
   HardwareBrightnessControlDriverBounds,
 } from './hardware-brightness-control-driver';
-import { clamp, ensurePrecision, lerp } from '../../../utils/number-utils';
+import { clamp } from '../../../utils/number-utils';
 import { OpenVRService } from '../../openvr.service';
 import { combineLatest, debounceTime, map, Observable } from 'rxjs';
 import { AppSettings } from '../../../models/settings';
+
+// Up to an analog gain of 1.0, the Index's panel maps gain to perceived
+// brightness along a gamma curve: percentage = 100 * gain^(1/2.2). Past 1.0 the
+// panel is driven linearly into overdrive, up to 1.6 (160%).
+const VALVE_INDEX_BRIGHTNESS_GAMMA = 2.2;
+const VALVE_INDEX_MAX_ANALOG_GAIN = 1.6;
 
 export const VALVE_INDEX_HARDWARE_BRIGHTNESS_CONTROL_DRIVER_BOUNDS: HardwareBrightnessControlDriverBounds =
   {
@@ -33,9 +39,7 @@ export class ValveIndexHardwareBrightnessControlDriver extends HardwareBrightnes
   }
 
   async getBrightnessPercentage(): Promise<number> {
-    let analogGain = await this.openvr.getAnalogGain();
-    analogGain = ensurePrecision(analogGain, 3);
-    return this.analogGainToPercentage(analogGain);
+    return Math.round(this.analogGainToPercentage(await this.openvr.getAnalogGain()));
   }
 
   async setBrightnessPercentage(percentage: number): Promise<void> {
@@ -60,122 +64,12 @@ export class ValveIndexHardwareBrightnessControlDriver extends HardwareBrightnes
   }
 
   private analogGainToPercentage(analogGain: number): number {
-    analogGain = ensurePrecision(analogGain, 3);
-    // 1 and above is linear
-    if (analogGain >= 1) return Math.round(clamp(analogGain * 100, 10, 160));
-    // Why Volvo?
-    // Why?
-    // What is this?
-    // What is the calculation?
-    // Why is it not linear?
-    // I don't understand.
-    // Don't make me do this.
-    // Show me the inner workings of your number magic ;_;
-    // EDIT: Ok I figured this might have something to do with gamma correction.
-    //       Remind me to look into this some later time when I've got fuck all to do.
-    analogGain = clamp(analogGain, 0, 1);
-    // Find surrounding samples
-    const sampleKeys = Array.from(VALVE_INDEX_BRIGHTNESS_SAMPLE_MAP.keys());
-    const lowerBound: number = parseFloat(
-      [...sampleKeys].reverse().find((k) => parseFloat(k) <= analogGain)!
-    );
-    const upperBound: number =
-      lowerBound == 1 ? 1 : parseFloat(sampleKeys[sampleKeys.indexOf(lowerBound.toString()) + 1]);
-    // Linearly interpolate between the two samples
-    return ensurePrecision(
-      lerp(
-        VALVE_INDEX_BRIGHTNESS_SAMPLE_MAP.get(lowerBound.toString())!,
-        VALVE_INDEX_BRIGHTNESS_SAMPLE_MAP.get(upperBound.toString())!,
-        (analogGain - lowerBound) / (upperBound - lowerBound)
-      ),
-      0
-    );
+    if (analogGain >= 1) return clamp(analogGain, 1, VALVE_INDEX_MAX_ANALOG_GAIN) * 100;
+    return Math.pow(clamp(analogGain, 0, 1), 1 / VALVE_INDEX_BRIGHTNESS_GAMMA) * 100;
   }
 
   private percentageToAnalogGain(percentage: number): number {
-    // 100 and above are linear
-    if (percentage >= 100) return ensurePrecision(clamp(percentage / 100, 1, 1.6), 2);
-    // Valve whyyyyyyyyyyyyyyYYYYYYYY  (edit: ???)
-    const sampleMap = new Map(
-      [...VALVE_INDEX_BRIGHTNESS_SAMPLE_MAP].map(([key, value]) => [
-        value.toString(),
-        parseFloat(key),
-      ])
-    );
-    const sampleKeys = Array.from(sampleMap.keys());
-    const lowerBound: number = parseFloat(
-      [...sampleKeys].reverse().find((k) => parseFloat(k) <= percentage)!
-    );
-    const upperBound: number =
-      lowerBound == 100
-        ? 100
-        : parseFloat(sampleKeys[sampleKeys.indexOf(lowerBound.toString()) + 1]);
-    // Linearly interpolate between the two samples
-    return ensurePrecision(
-      lerp(
-        sampleMap.get(lowerBound.toString())!,
-        sampleMap.get(upperBound.toString())!,
-        upperBound == lowerBound ? 0.5 : (percentage - lowerBound) / (upperBound - lowerBound)
-      ),
-      3
-    );
+    if (percentage >= 100) return clamp(percentage / 100, 1, VALVE_INDEX_MAX_ANALOG_GAIN);
+    return Math.pow(clamp(percentage, 0, 100) / 100, VALVE_INDEX_BRIGHTNESS_GAMMA);
   }
 }
-
-// ANALOG_GAIN: PERCENTAGE
-// Please forgive me for this.
-const VALVE_INDEX_BRIGHTNESS_SAMPLE_MAP: Map<string, number> = new Map([
-  ['0.03', 20],
-  ['0.04', 23],
-  ['0.05', 26],
-  ['0.055', 27],
-  ['0.06', 28],
-  ['0.07', 30],
-  ['0.08', 32],
-  ['0.09', 33],
-  ['0.095', 34],
-  ['0.1', 35],
-  ['0.105', 36],
-  ['0.11', 37],
-  ['0.115', 37],
-  ['0.12', 38],
-  ['0.125', 39],
-  ['0.13', 40],
-  ['0.135', 40],
-  ['0.14', 41],
-  ['0.145', 42],
-  ['0.15', 42],
-  ['0.155', 43],
-  ['0.16', 43],
-  ['0.165', 44],
-  ['0.17', 45],
-  ['0.175', 45],
-  ['0.18', 46],
-  ['0.185', 46],
-  ['0.19', 47],
-  ['0.195', 48],
-  ['0.2', 48],
-  ['0.21', 49],
-  ['0.25', 53],
-  ['0.3', 58],
-  ['0.315', 59],
-  ['0.32', 60],
-  ['0.33', 60],
-  ['0.34', 61],
-  ['0.35', 62],
-  ['0.4', 66],
-  ['0.445', 69],
-  ['0.45', 70],
-  ['0.46', 70],
-  ['0.465', 71],
-  ['0.47', 71],
-  ['0.475', 71],
-  ['0.48', 72],
-  ['0.49', 72],
-  ['0.5', 73],
-  ['0.6', 79],
-  ['0.7', 85],
-  ['0.8', 90],
-  ['0.9', 95],
-  ['1', 100],
-]);

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.html
@@ -72,6 +72,12 @@
           ></span>
         </div>
         <div class="contributor-list-entry">
+          <span
+            ><a href="https://github.com/coolGi69" target="_blank">coolGi</a> |
+            <span transloco="about.contributionType.programming"></span
+          ></span>
+        </div>
+        <div class="contributor-list-entry">
           <span>spaecd | <span transloco="about.contributionType.soundFx"></span></span>
         </div>
       </div>


### PR DESCRIPTION
Supersedes #196. Same idea as @coolGi69's PR: drop the 53-entry sample table and compute the analog gain directly. This version fixes the exponent direction and keeps the clamping the old code relied on.

## The curve

The samples were measuring a gamma curve. A least-squares fit of all 53 entries on log-log axes gives:

```
1/gamma = 0.454688  =>  gamma = 2.199308
```

So 2.2 is the value the table was approximating. The driver now uses:

```
percentage = 100 * gain^(1/2.2)
gain       = (percentage / 100)^2.2
```

Above a gain of 1.0 the panel stays linear, up to 1.6.

## Fix relative to #196

#196 had the two exponents swapped, which Codex flagged. It sent a gain of 0.481 for 20% brightness instead of 0.03, and reported 0.045% when reading back a gain of 0.03. This PR applies `1/2.2` on the gain-to-percentage side and `2.2` on the percentage-to-gain side.

## Verification

I ran the old implementation and the new one side by side over the full range. Numbers below are in percentage points (pp).

**Against the 53 hand-measured samples**, the curve deviates by at most 0.475pp, rms 0.278pp. The table stores integers, so every sample still rounds to exactly its recorded value. Gamma 2.15 and 2.25 both miss more than 37 of the 53 samples by over 0.5pp, so 2.2 is not an arbitrary pick.

**Gain to percentage**, stepping gain by 0.001 from 0.03 to 1.6: max deviation 1pp, rms 0.328pp. The single 1pp case is gain 0.031, where the table interpolates to 20.3 and the curve gives 20.53, landing on either side of a rounding boundary.

**Percentage to gain**, stepping by 0.1 from 20 to 160, compared in brightness terms: max 0.539pp, rms 0.258pp. The worst case is 33.1%, where the table's inverse is coarse because it was built from integer percentages.

**Round trip** (set X%, read it back) is exact for every whole percentage from 20 to 160, matching the old behaviour.

Where the new code is better than the old:

- Between samples the table was piecewise linear across gaps as wide as 0.1 in gain. The curve is exact there.
- `percentageToAnalogGain` no longer rounds the gain to 2 or 3 decimals, so fractional percentages from brightness transitions map precisely.

The 20% software stop stays where it was. The panel does not go below it, so the range under it is not a case this driver needs to handle.

## Other commits

- Credit coolGi in the contributor list on the About page.
- One changelog line under Unreleased / Fixed.

## Testing

I have no Index to test on, same as the original PR, so this is verified numerically rather than on hardware. The math checks out against your own sample data, but the panel behaviour still wants a look from someone with the headset.
