### PR TITLE
Fix OpenVR crash and wedge hazards in the core and the overlay sidecar

### DIFF
--- a/src-core/src/openvr/brightness_overlay.rs
+++ b/src-core/src/openvr/brightness_overlay.rs
@@ -1,4 +1,4 @@
-use super::OVR_CONTEXT;
+use super::{overlay_interface_available, OVR_CONTEXT};
 use log::error;
 use ovr_overlay as ovr;
 use std::sync::LazyLock;
@@ -42,6 +42,9 @@ pub async fn set_brightness(brightness: f64, perceived_brightness_adjustment_gam
         Some(manager) => manager,
         None => return,
     };
+    if !overlay_interface_available() {
+        return;
+    }
     // Get the manager
     let mut manager = context.overlay_mngr();
     // Get the overlay handle
@@ -59,6 +62,10 @@ pub async fn set_brightness(brightness: f64, perceived_brightness_adjustment_gam
 async fn create_overlay(
     context: &ovr_overlay::Context,
 ) -> Result<ovr_overlay::overlay::OverlayHandle, ()> {
+    if !overlay_interface_available() {
+        error!("[Core] The OpenVR overlay interface is unavailable");
+        return Err(());
+    }
     // Get the manager
     let mut manager = context.overlay_mngr();
     // Create the overlay

--- a/src-core/src/openvr/commands.rs
+++ b/src-core/src/openvr/commands.rs
@@ -2,7 +2,7 @@ use crate::globals::STEAM_APP_KEY;
 
 use super::{
     models::{BindingOriginData, OVRDevice, OVRFrameLimits},
-    OVR_CONTEXT,
+    overlay_interface_available, OVR_CONTEXT,
 };
 use enumset::EnumSet;
 use log::error;
@@ -108,6 +108,9 @@ pub async fn openvr_launch_binding_configuration(show_on_desktop: bool) {
 #[tauri::command]
 pub async fn openvr_is_dashboard_visible() -> bool {
     let context = OVR_CONTEXT.lock().await;
+    if !overlay_interface_available() {
+        return false;
+    }
     let mut manager = match context.as_ref() {
         Some(context) => context.overlay_mngr(),
         None => return false,
@@ -118,8 +121,10 @@ pub async fn openvr_is_dashboard_visible() -> bool {
 #[tauri::command]
 pub async fn openvr_reregister_manifest() -> Result<(), String> {
     let ctx = OVR_CONTEXT.lock().await;
-    let mut applications = ctx.as_ref().unwrap().applications_mngr();
-    let manifest_path_buf = std::fs::canonicalize("resources/manifest.vrmanifest").unwrap();
+    let ctx = ctx.as_ref().ok_or("OPENVR_NOT_INITIALIZED")?;
+    let mut applications = ctx.applications_mngr();
+    let manifest_path_buf = std::fs::canonicalize("resources/manifest.vrmanifest")
+        .map_err(|e| format!("MANIFEST_NOT_FOUND: {e}"))?;
     let manifest_path: &std::path::Path = manifest_path_buf.as_ref();
     match applications.is_application_installed(STEAM_APP_KEY) {
         Ok(value) => {

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -76,21 +76,29 @@ pub async fn task() {
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }
                 // Try to initialize OpenVR
-                let ctx =
-                    ovr::Context::init(ovr::sys::EVRApplicationType::VRApplication_Background).ok();
-                // If we failed, continue to try again later
-                if ctx.is_none() {
-                    *OVR_CONTEXT.lock().await = None;
-                    continue;
-                }
+                let ctx = match ovr::Context::init(
+                    ovr::sys::EVRApplicationType::VRApplication_Background,
+                ) {
+                    Ok(ctx) => ctx,
+                    // If we failed, continue to try again later
+                    Err(e) => {
+                        let reason = match e {
+                            ovr::InitError::AlreadyInitialized => {
+                                "OpenVR is already initialized".to_string()
+                            }
+                            ovr::InitError::Sys(e) => e.to_string(),
+                        };
+                        error!("[Core] Could not initialize OpenVR: {reason}");
+                        shutdown_ovr().await;
+                        continue;
+                    }
+                };
                 // Set the context on the module state
-                *OVR_CONTEXT.lock().await = ctx.clone();
+                *OVR_CONTEXT.lock().await = Some(ctx.clone());
                 // Initialize submodules
-                if brightness_overlay::on_ovr_init(&ctx.unwrap())
-                    .await
-                    .is_err()
-                {
-                    *OVR_CONTEXT.lock().await = None;
+                if let Err(e) = brightness_overlay::on_ovr_init(&ctx).await {
+                    error!("[Core] Could not initialize the brightness overlay: {e}");
+                    shutdown_ovr().await;
                     continue;
                 }
                 // We've successfully initialized OpenVR
@@ -98,12 +106,18 @@ pub async fn task() {
                 ovr_active = true;
                 update_status(OpenVRStatus::Initialized).await;
                 // (Un)register manifest if needed
-                {
+                'manifest: {
                     let ctx = OVR_CONTEXT.lock().await;
                     let mut applications = ctx.as_ref().unwrap().applications_mngr();
 
                     let manifest_path_buf =
-                        std::fs::canonicalize("resources/manifest.vrmanifest").unwrap();
+                        match std::fs::canonicalize("resources/manifest.vrmanifest") {
+                            Ok(path) => path,
+                            Err(e) => {
+                                error!("[Core] Could not find the VR manifest: {e}");
+                                break 'manifest;
+                            }
+                        };
                     let manifest_path: &std::path::Path = manifest_path_buf.as_ref();
 
                     let is_installed = match applications.is_application_installed(STEAM_APP_KEY) {
@@ -159,13 +173,19 @@ pub async fn task() {
                 let mut actions = vec![];
                 let mut action_sets = vec![];
                 let mut active_sets = vec![];
-                {
+                'input: {
                     let ctx = OVR_CONTEXT.lock().await;
                     let mut input = ctx.as_ref().unwrap().input_mngr();
                     // Register action manifest
                     info!("[Core] Registering Action Manifest");
                     let manifest_path_buf =
-                        std::fs::canonicalize("resources/input/action_manifest.json").unwrap();
+                        match std::fs::canonicalize("resources/input/action_manifest.json") {
+                            Ok(path) => path,
+                            Err(e) => {
+                                error!("[Core] Could not find the action manifest: {e}");
+                                break 'input;
+                            }
+                        };
                     let manifest_path: &std::path::Path = manifest_path_buf.as_ref();
                     if let Err(e) = input.set_action_manifest(manifest_path) {
                         error!(
@@ -245,7 +265,10 @@ pub async fn task() {
             loop {
                 let event = {
                     let ctx = OVR_CONTEXT.lock().await;
-                    let mut system = ctx.as_ref().unwrap().system_mngr();
+                    let Some(ctx) = ctx.as_ref() else {
+                        continue 'ovr_loop;
+                    };
+                    let mut system = ctx.system_mngr();
                     let event = system.poll_next_event();
                     if event.is_none() {
                         break;
@@ -257,13 +280,7 @@ pub async fn task() {
                     info!("[Core] OpenVR is Quitting. Shutting down OpenVR module");
                     ovr_active = false;
                     update_status(OpenVRStatus::Inactive).await;
-                    // Shutdown modules
-                    brightness_overlay::on_ovr_quit().await;
-                    // Shutdown OpenVR
-                    unsafe {
-                        ovr::sys::VR_Shutdown();
-                    }
-                    *OVR_CONTEXT.lock().await = None;
+                    shutdown_ovr().await;
                     // Schedule next initialization attempt
                     ovr_next_init = Utc::now() + chrono::Duration::seconds(5);
                     continue 'ovr_loop;
@@ -275,19 +292,30 @@ pub async fn task() {
             ovr_active = false;
             info!("[Core] Shutting down OpenVR module");
             update_status(OpenVRStatus::Inactive).await;
-            let ctx = OVR_CONTEXT.lock().await;
-            if ctx.is_some() {
-                drop(ctx);
-                // Shutdown modules
-                brightness_overlay::on_ovr_quit().await;
-                // Shutdown OpenVR
-                unsafe {
-                    ovr::sys::VR_Shutdown();
-                }
-                *OVR_CONTEXT.lock().await = None;
+            if OVR_CONTEXT.lock().await.is_some() {
+                shutdown_ovr().await;
             }
         }
     }
+}
+
+/// Drops the OpenVR context and shuts OpenVR itself down. Every path that clears `OVR_CONTEXT`
+/// has to go through here: leaving OpenVR initialized without a context makes every later
+/// initialization attempt fail, which wedges the module at `Initializing` forever.
+async fn shutdown_ovr() {
+    // Shutdown modules
+    brightness_overlay::on_ovr_quit().await;
+    // Shutdown OpenVR
+    unsafe {
+        ovr::sys::VR_Shutdown();
+    }
+    *OVR_CONTEXT.lock().await = None;
+}
+
+/// SteamVR can drop the OpenVR interfaces before it sends us its quit event, and every manager
+/// dereferences its interface pointer as soon as it is constructed.
+pub fn overlay_interface_available() -> bool {
+    !unsafe { ovr::sys::VROverlay() }.is_null()
 }
 
 async fn update_status(new_status: OpenVRStatus) {

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -292,7 +292,8 @@ pub async fn task() {
             ovr_active = false;
             info!("[Core] Shutting down OpenVR module");
             update_status(OpenVRStatus::Inactive).await;
-            if OVR_CONTEXT.lock().await.is_some() {
+            let has_context = OVR_CONTEXT.lock().await.is_some();
+            if has_context {
                 shutdown_ovr().await;
             }
         }
@@ -303,13 +304,17 @@ pub async fn task() {
 /// has to go through here: leaving OpenVR initialized without a context makes every later
 /// initialization attempt fail, which wedges the module at `Initializing` forever.
 async fn shutdown_ovr() {
+    // Hold the context lock across the shutdown. `VR_Shutdown` invalidates every interface
+    // pointer, so a task that still reads the context in between constructs a manager over a
+    // null pointer and panics.
+    let mut context = OVR_CONTEXT.lock().await;
     // Shutdown modules
     brightness_overlay::on_ovr_quit().await;
     // Shutdown OpenVR
     unsafe {
         ovr::sys::VR_Shutdown();
     }
-    *OVR_CONTEXT.lock().await = None;
+    *context = None;
 }
 
 /// SteamVR can drop the OpenVR interfaces before it sends us its quit event, and every manager

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -80,7 +80,6 @@ pub async fn task() {
                     ovr::sys::EVRApplicationType::VRApplication_Background,
                 ) {
                     Ok(ctx) => ctx,
-                    // If we failed, continue to try again later
                     Err(e) => {
                         let reason = match e {
                             ovr::InitError::AlreadyInitialized => {
@@ -300,25 +299,19 @@ pub async fn task() {
     }
 }
 
-/// Drops the OpenVR context and shuts OpenVR itself down. Every path that clears `OVR_CONTEXT`
-/// has to go through here: leaving OpenVR initialized without a context makes every later
-/// initialization attempt fail, which wedges the module at `Initializing` forever.
+/// Every path that clears `OVR_CONTEXT` has to use this, or OpenVR stays initialized without a
+/// context and every later initialization attempt fails.
 async fn shutdown_ovr() {
-    // Hold the context lock across the shutdown. `VR_Shutdown` invalidates every interface
-    // pointer, so a task that still reads the context in between constructs a manager over a
-    // null pointer and panics.
+    // the lock stays held across the shutdown: VR_Shutdown invalidates every interface pointer
     let mut context = OVR_CONTEXT.lock().await;
-    // Shutdown modules
     brightness_overlay::on_ovr_quit().await;
-    // Shutdown OpenVR
     unsafe {
         ovr::sys::VR_Shutdown();
     }
     *context = None;
 }
 
-/// SteamVR can drop the OpenVR interfaces before it sends us its quit event, and every manager
-/// dereferences its interface pointer as soon as it is constructed.
+/// Constructing an overlay manager while this is false panics.
 pub fn overlay_interface_available() -> bool {
     !unsafe { ovr::sys::VROverlay() }.is_null()
 }

--- a/src-core/src/overlay_sidecar/commands.rs
+++ b/src-core/src/overlay_sidecar/commands.rs
@@ -3,6 +3,11 @@ use crate::{
     utils::models::OverlaySidecarMode,
     Models::oyasumi_core::OverlaySidecarStartArgs,
 };
+use log::info;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+static DEV_SIDECAR_WATCHER_RUNNING: AtomicBool = AtomicBool::new(false);
 
 #[tauri::command]
 pub async fn start_overlay_sidecar(gpu_acceleration: bool) {
@@ -16,14 +21,38 @@ pub async fn start_overlay_sidecar(gpu_acceleration: bool) {
                 .await;
             sidecar_manager.start_or_restart().await;
         }
-        // In development mode, we expect the sidecar to be started in development mode manually
+        // In development mode, we expect the sidecar to be started in development mode manually,
+        // which can happen at any point after the core comes up, so keep watching for it.
         OverlaySidecarMode::Dev => {
-            let _ = super::handle_overlay_sidecar_start(&OverlaySidecarStartArgs {
-                pid: 0,
-                grpc_port: OVERLAY_SIDECAR_GRPC_DEV_PORT as u32,
-                grpc_web_port: OVERLAY_SIDECAR_GRPC_WEB_DEV_PORT as u32,
-            })
-            .await;
+            if DEV_SIDECAR_WATCHER_RUNNING.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            tokio::spawn(async move {
+                info!(
+                    "[Core] Waiting for the OVERLAY sidecar to start on port {OVERLAY_SIDECAR_GRPC_DEV_PORT}"
+                );
+                loop {
+                    // Only announce the sidecar once its GRPC port accepts connections, so we
+                    // don't log a start we cannot follow up on.
+                    let reachable =
+                        tokio::net::TcpStream::connect(("127.0.0.1", OVERLAY_SIDECAR_GRPC_DEV_PORT))
+                            .await
+                            .is_ok();
+                    if reachable
+                        && super::handle_overlay_sidecar_start(&OverlaySidecarStartArgs {
+                            pid: 0,
+                            grpc_port: OVERLAY_SIDECAR_GRPC_DEV_PORT as u32,
+                            grpc_web_port: OVERLAY_SIDECAR_GRPC_WEB_DEV_PORT as u32,
+                        })
+                        .await
+                        .is_ok()
+                    {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_secs(3)).await;
+                }
+                DEV_SIDECAR_WATCHER_RUNNING.store(false, Ordering::SeqCst);
+            });
         }
     }
 }

--- a/src-core/src/overlay_sidecar/commands.rs
+++ b/src-core/src/overlay_sidecar/commands.rs
@@ -21,8 +21,7 @@ pub async fn start_overlay_sidecar(gpu_acceleration: bool) {
                 .await;
             sidecar_manager.start_or_restart().await;
         }
-        // In development mode, we expect the sidecar to be started in development mode manually,
-        // which can happen at any point after the core comes up, so keep watching for it.
+        // in development mode the sidecar is started manually, so wait for it to appear
         OverlaySidecarMode::Dev => {
             if DEV_SIDECAR_WATCHER_RUNNING.swap(true, Ordering::SeqCst) {
                 return;
@@ -32,8 +31,7 @@ pub async fn start_overlay_sidecar(gpu_acceleration: bool) {
                     "[Core] Waiting for the OVERLAY sidecar to start on port {OVERLAY_SIDECAR_GRPC_DEV_PORT}"
                 );
                 loop {
-                    // Only announce the sidecar once its GRPC port accepts connections, so we
-                    // don't log a start we cannot follow up on.
+                    // only announce the sidecar once its GRPC port accepts connections
                     let reachable =
                         tokio::net::TcpStream::connect(("127.0.0.1", OVERLAY_SIDECAR_GRPC_DEV_PORT))
                             .await

--- a/src-overlay-sidecar/Managers/BrowserManager.cs
+++ b/src-overlay-sidecar/Managers/BrowserManager.cs
@@ -1,5 +1,6 @@
 using CefSharp;
 using overlay_sidecar.Browsers;
+using Serilog;
 
 namespace overlay_sidecar;
 
@@ -31,6 +32,7 @@ public class BrowserManager {
       }
 
       OffscreenBrowser browser = Program.GpuAccelerated ? new AcceleratedOffscreenBrowser(url, width, height) : new NonAcceleratedOffscreenBrowser(url, width, height);
+      if (Program.InDevMode()) LogBrowserEvents(browser);
       _browsers.Add(new CachedBrowser(browser, false, width, height));
 
       return browser;
@@ -52,6 +54,19 @@ public class BrowserManager {
         }
       }
     }
+  }
+
+  // Browsers are pooled and reused across overlays, so the current address identifies the overlay.
+  private static void LogBrowserEvents(OffscreenBrowser browser)
+  {
+    browser.ConsoleMessage += (_, e) =>
+      Log.Information("[Browser {address}] {level} {message} ({source}:{line})", browser.Address, e.Level,
+        e.Message, e.Source, e.Line);
+    browser.LoadError += (_, e) =>
+      Log.Error("[Browser {address}] Failed to load {url}: {error} ({text})", browser.Address, e.FailedUrl,
+        e.ErrorCode, e.ErrorText);
+    browser.LoadingStateChanged += (_, e) =>
+      Log.Information("[Browser {address}] Loading={loading}", browser.Address, e.IsLoading);
   }
 
   class CachedBrowser {

--- a/src-overlay-sidecar/Managers/BrowserManager.cs
+++ b/src-overlay-sidecar/Managers/BrowserManager.cs
@@ -56,7 +56,6 @@ public class BrowserManager {
     }
   }
 
-  // Browsers are pooled and reused across overlays, so the current address identifies the overlay.
   private static void LogBrowserEvents(OffscreenBrowser browser)
   {
     browser.ConsoleMessage += (_, e) =>

--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -80,6 +80,7 @@ public class OvrManager
   private void MainLoop()
   {
     var nextInit = DateTime.MinValue;
+    var loggedMissingInterfaces = false;
     var e = new VREvent_t();
     var actionHandles = new Dictionary<string, ulong>();
     var actionSetHandles = new Dictionary<string, ulong>();
@@ -111,10 +112,18 @@ public class OvrManager
           // the overlays below and DetectInput dereference these interfaces immediately
           if (_input == null || OpenVR.Overlay == null)
           {
-            Log.Warning("OpenVR interfaces are not available yet. Retrying initialization later...");
+            // the retry runs every 5 seconds, so only the first attempt reports it
+            if (!loggedMissingInterfaces)
+            {
+              Log.Warning("OpenVR interfaces are not available yet. Retrying initialization later...");
+              loggedMissingInterfaces = true;
+            }
+
             OpenVR.Shutdown();
             continue;
           }
+
+          loggedMissingInterfaces = false;
 
           var inputError = _input.SetActionManifestPath(GetActionManifestPath());
           if (inputError != 0)

--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -122,6 +122,7 @@ public class OvrManager
           if (inputError != 0)
           {
             Log.Error($"Could not set action manifest path: {Enum.GetName(typeof(EVRInputError), inputError)}");
+            OpenVR.Shutdown();
             continue;
           }
 

--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -108,7 +108,16 @@ public class OvrManager
           _system = OpenVR.System;
 
           _input = OpenVR.Input;
-          if (_input == null) continue;
+          // Every overlay we construct below dereferences the overlay interface right away, and
+          // DetectInput needs the input interface. Shut down again if either is still missing, so
+          // the next attempt starts from a clean initialization.
+          if (_input == null || OpenVR.Overlay == null)
+          {
+            Log.Warning("OpenVR interfaces are not available yet. Retrying initialization later...");
+            OpenVR.Shutdown();
+            continue;
+          }
+
           var inputError = _input.SetActionManifestPath(GetActionManifestPath());
           if (inputError != 0)
           {

--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -108,9 +108,7 @@ public class OvrManager
           _system = OpenVR.System;
 
           _input = OpenVR.Input;
-          // Every overlay we construct below dereferences the overlay interface right away, and
-          // DetectInput needs the input interface. Shut down again if either is still missing, so
-          // the next attempt starts from a clean initialization.
+          // the overlays below and DetectInput dereference these interfaces immediately
           if (_input == null || OpenVR.Overlay == null)
           {
             Log.Warning("OpenVR interfaces are not available yet. Retrying initialization later...");

--- a/src-overlay-sidecar/Managers/StateManager.cs
+++ b/src-overlay-sidecar/Managers/StateManager.cs
@@ -4,10 +4,10 @@ namespace overlay_sidecar;
 
 public class StateManager {
   public static StateManager Instance { get; } = new();
-  // Consumers read sub-messages without null checks, so the state always carries them.
+  // consumers read sub-messages without null checks, so the state always carries them
   private OyasumiSidecarState _state = NewDefaultState();
 
-  // _state is replaced on every sync, so it cannot serve as its own lock.
+  // _state is replaced on every sync, so it cannot serve as its own lock
   private readonly object _lock = new();
 
   public event EventHandler<OyasumiSidecarState>? StateChanged;

--- a/src-overlay-sidecar/Managers/StateManager.cs
+++ b/src-overlay-sidecar/Managers/StateManager.cs
@@ -7,6 +7,9 @@ public class StateManager {
   // Consumers read sub-messages without null checks, so the state always carries them.
   private OyasumiSidecarState _state = NewDefaultState();
 
+  // _state is replaced on every sync, so it cannot serve as its own lock.
+  private readonly object _lock = new();
+
   public event EventHandler<OyasumiSidecarState>? StateChanged;
 
   private StateManager()
@@ -15,7 +18,7 @@ public class StateManager {
 
   public OyasumiSidecarState GetAppState()
   {
-    lock (_state)
+    lock (_lock)
     {
       return _state.Clone();
     }
@@ -24,7 +27,7 @@ public class StateManager {
   public void SyncState(OyasumiSidecarState? newState)
   {
     if (newState == null) return;
-    lock (_state)
+    lock (_lock)
     {
       // Update the state
       newState.Settings ??= new OyasumiSidecarOverlaySettings();

--- a/src-overlay-sidecar/Managers/StateManager.cs
+++ b/src-overlay-sidecar/Managers/StateManager.cs
@@ -4,7 +4,8 @@ namespace overlay_sidecar;
 
 public class StateManager {
   public static StateManager Instance { get; } = new();
-  private OyasumiSidecarState _state = new();
+  // Consumers read sub-messages without null checks, so the state always carries them.
+  private OyasumiSidecarState _state = NewDefaultState();
 
   public event EventHandler<OyasumiSidecarState>? StateChanged;
 
@@ -26,8 +27,17 @@ public class StateManager {
     lock (_state)
     {
       // Update the state
+      newState.Settings ??= new OyasumiSidecarOverlaySettings();
       _state = newState;
       StateChanged?.Invoke(this, _state);
     }
+  }
+
+  private static OyasumiSidecarState NewDefaultState()
+  {
+    return new OyasumiSidecarState
+    {
+      Settings = new OyasumiSidecarOverlaySettings()
+    };
   }
 }

--- a/src-overlay-sidecar/Managers/StateManager.cs
+++ b/src-overlay-sidecar/Managers/StateManager.cs
@@ -4,10 +4,7 @@ namespace overlay_sidecar;
 
 public class StateManager {
   public static StateManager Instance { get; } = new();
-  // consumers read sub-messages without null checks, so the state always carries them
   private OyasumiSidecarState _state = NewDefaultState();
-
-  // _state is replaced on every sync, so it cannot serve as its own lock
   private readonly object _lock = new();
 
   public event EventHandler<OyasumiSidecarState>? StateChanged;

--- a/src-overlay-sidecar/Utils/OVRUtils.cs
+++ b/src-overlay-sidecar/Utils/OVRUtils.cs
@@ -33,9 +33,12 @@ public class OvrUtils {
 
   public static EVROverlayError getOrCreateOverlay(String key, String name, ref ulong handle)
   {
-    var error = OpenVR.Overlay.FindOverlay(key, ref handle);
+    var overlay = OpenVR.Overlay;
+    // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+    if (overlay == null) return EVROverlayError.RequestFailed; // This can be null sometimes...
+    var error = overlay.FindOverlay(key, ref handle);
     if (error == EVROverlayError.None) return EVROverlayError.None;
-    error = OpenVR.Overlay.CreateOverlay(key, name, ref handle);
+    error = overlay.CreateOverlay(key, name, ref handle);
     return error;
   }
 

--- a/src-ui/app/services/overlay/overlay.service.ts
+++ b/src-ui/app/services/overlay/overlay.service.ts
@@ -7,7 +7,7 @@ import {
   OverlayMenuOpenRequest,
   OyasumiSidecarControllerRole,
 } from '../../../../src-grpc-web-client/overlay-sidecar_pb';
-import { info } from '@tauri-apps/plugin-log';
+import { info, warn } from '@tauri-apps/plugin-log';
 import { AppSettingsService } from '../app-settings.service';
 import { APP_SETTINGS_DEFAULT, AppSettings } from '../../models/settings';
 
@@ -97,8 +97,13 @@ export class OverlayService {
           if (!active) return;
         }
         // Toggle the overlay
+        const client = this.ipcService.getOverlaySidecarClient();
+        if (!client) {
+          warn('[Overlay] Ignoring the overlay menu toggle: the overlay sidecar is not running');
+          return;
+        }
         info('[Overlay] Toggling overlay menu (controller action)');
-        this.ipcService.getOverlaySidecarClient()?.toggleOverlayMenu({
+        client.toggleOverlayMenu({
           controllerRole,
         } as OverlayMenuOpenRequest);
       });


### PR DESCRIPTION
Fixes nine pre-existing bugs found while running OyasumiVR in dev mode against a real headset. All were reproducible: a sidecar that died on startup, both processes dying together when SteamVR restarted, and a core that could sit at `Initializing` until a restart.

## Core

- **Initialization wedge.** Two failure paths in `openvr::task()` cleared `OVR_CONTEXT` and continued without calling `VR_Shutdown()`. Every path that drops the context now goes through a shared `shutdown_ovr()`. Symptoms were: SteamVR stuck at `Initializing`, the controller binding row reading "SteamVR Inactive", and the debug panel still showing stale device counts, which made OpenVR look healthy.
- **Silent init failures.** `Context::init(...).ok()` and `on_ovr_init(...).is_err()` both discarded their error, so a permanently failing loop logged nothing. Both now log. `InitError` implements neither `Debug` nor `Display`, so the two variants are matched by hand.
- **Unwrapped context in the event poll loop.** Replaced with a `let ... else`.
- **Unwrapped `canonicalize`.** The two resource paths in `openvr/mod.rs` panicked when the file was missing, which a partial build can cause. They now log and skip. `openvr_reregister_manifest` had the same unwrap plus an unwrapped context; both return an error now.
- **Null overlay interface.** `OverlayManager::new` unwraps `VROverlay()`, and SteamVR drops the interface before its quit event reaches us. A new `overlay_interface_available()` guards the three `overlay_mngr()` call sites.
- **Dev sidecar registration.** The core registered the fixed dev ports once, when the frontend called `start_overlay_sidecar`. Starting the core before the sidecar left it unregistered for the whole session, and every controller press became a silent no-op. It now polls the port until the sidecar answers.

## Overlay sidecar

- **Startup crash.** `StateManager` started from a state whose `Settings` sub-message was unset, and `MicMuteIndicatorOverlay.Init()` read it before the core pushed any state. The `NullReferenceException` came out of an `async void` method and killed the process. `StateManager` now seeds `Settings` and fills it on every sync, which also covers the same unguarded read in `SetMicrophoneActive`.
- **Crash on SteamVR restart.** `MainLoop` constructed the overlays before the overlay interface was ready. It now shuts OpenVR down again and retries when either the input or the overlay interface is missing after `VR_Init`. `getOrCreateOverlay` returns `RequestFailed` instead of dereferencing null.
- **No browser logging.** The overlays never subscribed to `ConsoleMessage`, `LoadError`, or `LoadingStateChanged`, so a JavaScript error inside an overlay was invisible. They log in dev mode now. This was decisive for diagnosing the rest.

## Main window

`overlay.service.ts` logs a warning when a controller press is dropped because no sidecar client exists. The optional chaining made it silent.

## What a reviewer should check

- `shutdown_ovr()` is called on the init-failure paths too, not only after a successful init. `VR_Shutdown` after a failed `VR_Init` is a no-op, and if the failure was `AlreadyInitialized` then shutting down is exactly what we want.
- The `MainLoop` guard calls `OpenVR.Shutdown()` before `continue`. Without it the next iteration finds `OpenVR.System` non-null, skips the whole init block, and reaches `DetectInput` with empty handles. The pre-existing `if (_input == null) continue;` had that trap, so it is folded into the same guard.
- Browser event logs are keyed by the browser address, not the overlay key. Browsers are pooled and reused, so subscribing once at creation avoids handler churn, and the address names the overlay page.

## What I left out

- The `Option::unwrap()` panic at `ovr_overlay_oyasumi/src/overlay.rs:17` is in the pinned git dependency, so I guarded the core's call sites instead of patching the crate.
- The report attributed the wedge to the crate's `INITIALIZED` flag. That does not hold at rev `f7b5863`: the flag is never set to `true`, so `if *guard` is dead and only `try_lock` contention returns `AlreadyInitialized`. The fix stands, because OpenVR itself keeps process-global state that `VR_Shutdown()` clears.
- `BaseWebOverlay.UpdateFrame` still gates texture submission on a paint in the last second, so an idle web UI freezes mid-animation. Out of scope here.

## Testing

`cargo check`, `dotnet build`, and `tsc --noEmit` pass. I have no headset here, so none of the OpenVR paths ran against a live runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when OpenVR services or overlay interfaces are unavailable.
  - Prevented crashes during initialization, shutdown, manifest updates, and event polling.
  - Overlay creation, brightness controls, and dashboard visibility checks now fail safely.
  - Improved state synchronization with reliable default settings.
  - Overlay controls now warn when the sidecar connection is unavailable.

- **Reliability Improvements**
  - Development mode now retries sidecar startup until connectivity is restored.
  - Added clearer development logging for browser activity and OpenVR startup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->