### PR TITLE
Make the Lighthouse power-off delay optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 ### Fixed
 
 - Fixed SteamVR sometimes crashing when OyasumiVR turned off several base stations at once
+- Fixed OyasumiVR turning off several controllers or trackers at the same time when more than one automation,
+  hotkey or button asked for it at once
 - Fixed OyasumiVR shutting down on its own when SteamVR reported an event it did not recognise
 - Fixed the brightness and color temperature sliders in the VR overlay jumping to 100%
 - Fixed the VR overlay restarting itself over and over again on some systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
   - Custom target for OSC messages (e.g. for use with Resonite, OSC routers, or when OSCQuery is not available)
   - VRChat (OSCQuery) target (allows for disabling OSC messages being sent to VRChat)
 - Home Assistant switch for the VRChat microphone mute
-- Setting to wait a moment between turning off each controller and tracker, for systems where turning them off
-  crashes SteamVR or leaves some devices on
+- Setting to wait a moment between turning off each controller and tracker, for systems where turning them off crashes SteamVR
 
 ### Changed
 
@@ -28,8 +27,6 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 ### Fixed
 
 - Fixed SteamVR sometimes crashing when OyasumiVR turned off several base stations at once
-- Fixed OyasumiVR turning off several controllers or trackers at the same time when more than one automation,
-  hotkey or button asked for it at once
 - Fixed OyasumiVR shutting down on its own when SteamVR reported an event it did not recognise
 - Fixed the brightness and color temperature sliders in the VR overlay jumping to 100%
 - Fixed the VR overlay restarting itself over and over again on some systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
   - Custom target for OSC messages (e.g. for use with Resonite, OSC routers, or when OSCQuery is not available)
   - VRChat (OSCQuery) target (allows for disabling OSC messages being sent to VRChat)
 - Home Assistant switch for the VRChat microphone mute
+- Setting to wait a moment between turning off each controller and tracker, for systems where turning them off
+  crashes SteamVR or leaves some devices on
 
 ### Changed
 

--- a/src-ui/app/models/settings.ts
+++ b/src-ui/app/models/settings.ts
@@ -38,6 +38,7 @@ export interface AppSettings {
   lighthouseConsolePath: string;
   lighthousePowerControl: boolean;
   lighthousePowerOffState: LighthouseDevicePowerState;
+  lighthousePowerOffDelay: boolean;
   v1LighthouseIdentifiers: {
     [deviceId: string]: string;
   };
@@ -128,6 +129,7 @@ export const APP_SETTINGS_DEFAULT: AppSettings = {
     'C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\tools\\lighthouse\\bin\\win64\\lighthouse_console.exe',
   lighthousePowerControl: true,
   lighthousePowerOffState: 'sleep',
+  lighthousePowerOffDelay: false,
   v1LighthouseIdentifiers: {},
   // Discord Rich Presence
   discordActivityMode: 'ENABLED',

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -91,18 +91,14 @@ export class LighthouseConsoleService {
   }
 
   async turnOffDevices(ovrDevices: OVRDevice[]) {
-    const lighthouseConsolePath = await firstValueFrom(this.appSettings.settings).then(
-      (settings) => settings.lighthouseConsolePath
-    );
+    const settings = await firstValueFrom(this.appSettings.settings);
+    const lighthouseConsolePath = settings.lighthouseConsolePath;
     if (this._consoleStatus.value !== 'SUCCESS') return;
     ovrDevices = ovrDevices.filter(
       (device) => device.canPowerOff && device.dongleId && !device.isTurningOff
     );
-    // Issue poweroff calls sequentially with a small delay between them.
-    // Firing all calls in parallel saturates SteamVR's lighthouse driver and
-    // can cause its HMD RunFrame thread to stall long enough to trip vrserver's
-    // watchdog (CLighthouseHmdDriver::RunFrame), crashing SteamVR.
-    for (const device of ovrDevices) {
+    // these calls must stay sequential: parallel poweroffs can crash SteamVR
+    for (const [index, device] of ovrDevices.entries()) {
       this.openvr.onDeviceUpdate(Object.assign({}, device, { isTurningOff: true }));
       info(`[Lighthouse] Turning off device ${device.class}:${device.serialNumber}`);
       try {
@@ -116,7 +112,9 @@ export class LighthouseConsoleService {
           `[Lighthouse] Could not turn off device ${device.class}:${device.serialNumber}: ${e}`
         );
       }
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      if (settings.lighthousePowerOffDelay && index < ovrDevices.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
     }
   }
 }

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -15,6 +15,8 @@ export class LighthouseConsoleService {
   private _consoleStatus: BehaviorSubject<ExecutableReferenceStatus> =
     new BehaviorSubject<ExecutableReferenceStatus>('UNKNOWN');
   public consoleStatus: Observable<ExecutableReferenceStatus> = this._consoleStatus.asObservable();
+  // every caller shares this queue, so power-off batches never overlap
+  private powerOffQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private appSettings: AppSettingsService,
@@ -91,13 +93,25 @@ export class LighthouseConsoleService {
   }
 
   async turnOffDevices(ovrDevices: OVRDevice[]) {
+    const batch = this.powerOffQueue.then(() => this.runTurnOffDevices(ovrDevices));
+    this.powerOffQueue = batch.catch(() => {});
+    return batch;
+  }
+
+  private async runTurnOffDevices(requestedDevices: OVRDevice[]) {
     const settings = await firstValueFrom(this.appSettings.settings);
     const lighthouseConsolePath = settings.lighthouseConsolePath;
     if (this._consoleStatus.value !== 'SUCCESS') return;
-    ovrDevices = ovrDevices.filter(
-      (device) => device.canPowerOff && device.dongleId && !device.isTurningOff
+    // the queue can hold a batch back, so work from the device state as it is now
+    const requestedIndices = requestedDevices.map((device) => device.index);
+    const ovrDevices = (await firstValueFrom(this.openvr.devices)).filter(
+      (device) =>
+        requestedIndices.includes(device.index) &&
+        device.canPowerOff &&
+        device.dongleId &&
+        !device.isTurningOff
     );
-    // these calls must stay sequential: parallel poweroffs can crash SteamVR
+    // sequential on purpose: parallel poweroffs can crash SteamVR
     for (const [index, device] of ovrDevices.entries()) {
       this.openvr.onDeviceUpdate(Object.assign({}, device, { isTurningOff: true }));
       info(`[Lighthouse] Turning off device ${device.class}:${device.serialNumber}`);

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -15,7 +15,6 @@ export class LighthouseConsoleService {
   private _consoleStatus: BehaviorSubject<ExecutableReferenceStatus> =
     new BehaviorSubject<ExecutableReferenceStatus>('UNKNOWN');
   public consoleStatus: Observable<ExecutableReferenceStatus> = this._consoleStatus.asObservable();
-  // every caller shares this queue, so power-off batches never overlap
   private powerOffQueue: Promise<void> = Promise.resolve();
 
   constructor(

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -102,7 +102,7 @@ export class LighthouseConsoleService {
     const settings = await firstValueFrom(this.appSettings.settings);
     const lighthouseConsolePath = settings.lighthouseConsolePath;
     if (this._consoleStatus.value !== 'SUCCESS') return;
-    // the queue can hold a batch back, so work from the device state as it is now
+    // resolve the devices as they are now, not as the caller saw them
     const requestedIndices = requestedDevices.map((device) => device.index);
     const ovrDevices = (await firstValueFrom(this.openvr.devices)).filter(
       (device) =>

--- a/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.html
@@ -39,6 +39,22 @@
               </label>
             </div>
           </div>
+          <div class="setting-row">
+            <div class="setting-row-label">
+              <span transloco="settings.general.lighthouseConsole.powerOffDelay.title"></span>
+              <span transloco="settings.general.lighthouseConsole.powerOffDelay.description"></span>
+            </div>
+            <div class="setting-row-action">
+              <label class="switch-toggle">
+                <input
+                  type="checkbox"
+                  [checked]="lighthousePowerOffDelay"
+                  (change)="setLighthousePowerOffDelay(!lighthousePowerOffDelay)"
+                />
+                <span class="switch-toggle-slider"></span>
+              </label>
+            </div>
+          </div>
         </div>
       </div>
       <div class="setting-category">

--- a/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.ts
@@ -59,6 +59,7 @@ export class SettingsAdvancedViewComponent {
   memoryWatcherActive = FLAVOUR === 'DEV';
   overlayGpuAcceleration = true;
   openVrInitDelayFix = false;
+  lighthousePowerOffDelay = false;
 
   constructor(
     private router: Router,
@@ -72,6 +73,7 @@ export class SettingsAdvancedViewComponent {
     this.settingsService.settings.pipe(takeUntilDestroyed()).subscribe((settings) => {
       this.overlayGpuAcceleration = settings.overlayGpuAcceleration;
       this.openVrInitDelayFix = settings.openVrInitDelayFix;
+      this.lighthousePowerOffDelay = settings.lighthousePowerOffDelay;
     });
   }
 
@@ -302,5 +304,9 @@ export class SettingsAdvancedViewComponent {
 
   setOpenVrInitDelayFix(enabled: boolean) {
     this.settingsService.updateSettings({ openVrInitDelayFix: enabled });
+  }
+
+  setLighthousePowerOffDelay(enabled: boolean) {
+    this.settingsService.updateSettings({ lighthousePowerOffDelay: enabled });
   }
 }

--- a/src-ui/app/views/dashboard-view/views/settings-general-view/settings-general-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/settings-general-view/settings-general-view.component.html
@@ -250,6 +250,24 @@
             </div>
           }
         </div>
+        <div class="settings">
+          <div class="setting-row">
+            <div class="setting-row-label">
+              <span transloco="settings.general.lighthouseConsole.powerOffDelay.title"></span>
+              <span transloco="settings.general.lighthouseConsole.powerOffDelay.description"></span>
+            </div>
+            <div class="setting-row-action">
+              <label class="switch-toggle">
+                <input
+                  type="checkbox"
+                  [checked]="appSettings.lighthousePowerOffDelay"
+                  (change)="setLighthousePowerOffDelay(!appSettings.lighthousePowerOffDelay)"
+                />
+                <span class="switch-toggle-slider"></span>
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="setting-category">

--- a/src-ui/app/views/dashboard-view/views/settings-general-view/settings-general-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-general-view/settings-general-view.component.ts
@@ -192,6 +192,10 @@ export class SettingsGeneralViewComponent implements OnInit {
     this.settingsService.updateSettings({ lighthousePowerControl: enabled });
   }
 
+  setLighthousePowerOffDelay(enabled: boolean) {
+    this.settingsService.updateSettings({ lighthousePowerOffDelay: enabled });
+  }
+
   onChangeLighthousePowerOffMode(option: SelectBoxItem | undefined) {
     if (!option) return;
     this.settingsService.updateSettings({

--- a/src-ui/assets/i18n/en.json
+++ b/src-ui/assets/i18n/en.json
@@ -2048,6 +2048,10 @@
       },
       "lighthouseConsole": {
         "description": "OyasumiVR needs to know about the location of your SteamVR installation's <strong>lighthouse_console.exe</strong>.\nIf OyasumiVR cannot find it in the default location, you need to set where it can be found.",
+        "powerOffDelay": {
+          "description": "Enabling this makes OyasumiVR wait a moment between turning off each controller and tracker. If turning off your devices crashes SteamVR or leaves some devices on, this can help.",
+          "title": "Delay Between Device Power-Offs"
+        },
         "status": {
           "CHECKING": "Checking for valid <strong>lighthouse_console.exe</strong>",
           "INVALID_EXECUTABLE": "The <strong>lighthouse_console.exe</strong> at this location could not be verified as working.",


### PR DESCRIPTION
Turning off controllers and trackers waited 250ms between each `lighthouse_console.exe poweroff` call. That delay only exists as a compatibility measure, and it makes powering off a full set of devices slow for everyone else.

Three changes in `src-ui/app/services/lighthouse-console.service.ts`:

- The delay is 100ms instead of 250ms.
- It runs only when the new `lighthousePowerOffDelay` setting is on. The setting defaults to off.
- It no longer runs after the last device.

The calls stay sequential in every case. That is what stops SteamVR's lighthouse driver from being saturated by parallel calls, which was the original crash.

The toggle appears twice, bound to the same setting, so both switches always show the same state:

- Settings > General > Lighthouse Console, under the exe path field.
- Settings > Advanced > Application, next to "Delay OpenVR Initialization", where people go to troubleshoot.

Both templates use the same translation keys, `settings.general.lighthouseConsole.powerOffDelay`, so translators fill in one entry.

No settings migration. `from2to3` records that missing keys are filled from the defaults, so existing users get `false`.

To check: turn off several controllers and trackers with the toggle off, then with it on. I could not check this against real hardware, since SteamVR was not running here (`EVRInitError(121)`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a setting to enable a short delay between powering off individual Lighthouse controllers and trackers.
  - The option is available in both General and Advanced settings.
  - The delay is disabled by default and can be enabled at any time.

- **Documentation**
  - Added a changelog entry and English localization for the new power-off delay setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->