### PR TITLE
Log and exit when CEF fails to initialize in the overlay sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
   (Thanks to help from [coolGi](https://github.com/coolGi69))
 - Fixed OyasumiVR getting stuck on "Initializing" for SteamVR, which only a restart cleared
 - Fixed the VR overlay crashing on startup, and when SteamVR was restarted
+- The VR overlay now stops with an explanation in its log when its browser engine cannot start, instead of crashing
 - Various stability improvements
 
 ### Removed

--- a/src-overlay-sidecar/Program.cs
+++ b/src-overlay-sidecar/Program.cs
@@ -100,7 +100,11 @@ public static class Program {
       if (File.Exists(cefDebugLogPath)) File.Delete(cefDebugLogPath);
     }
 
-    Cef.Initialize(settings);
+    if (!Cef.Initialize(settings))
+    {
+      Log.Fatal("CEF failed to initialize. The overlays cannot run without it.");
+      Environment.Exit(1);
+    }
   }
 
   private static void CleanUpCefCacheDirectories(string cacheRoot)


### PR DESCRIPTION
`Program.cs` called `Cef.Initialize(settings)` and threw away the return value. When CEF failed to start, the sidecar went on to construct the overlays. The `ChromiumWebBrowser` constructor then threw `InvalidOperationException` ("Cef.IsInitialized was false!"). Nothing catches it, and the sidecar installs no `AppDomain.UnhandledException` handler, so the process died with a crash dump and no log line. The path is `OvrManager.MainLoop` -> `NotificationOverlay..ctor` -> `BaseWebOverlay..ctor` -> `BrowserManager.GetBrowser` -> `ChromiumWebBrowser..ctor`.

The sidecar now checks the return value, logs a fatal error, and exits with code 1.

## What to check

- `src-overlay-sidecar/Program.cs:103`. That is the whole code change, 5 lines.
- The changelog wording. I described this as "stops with an explanation in its log", because the user-visible result is still "no overlays".

## What this does not do

It does not restore the overlays on a machine where CEF keeps failing to initialize. The core restarts the sidecar, which fails the same way, now with the 300s backoff. Real recovery needs a distinct exit code plus a relaunch with `--disable-gpu-acceleration` from the core, because CEF cannot be initialized twice in one process. `SidecarManager::set_arg` already exists for it.

I left that out on purpose. #188 suspects a GPU driver fault on CEF 138 and .NET 8. The sidecar is now on CefSharp 150 and .NET 10, and nobody has reported the crash against that yet. Writing the fallback now means writing recovery for a failure that may already be gone.

Closes #202.

This does not resolve issue 188. That reporter needs working overlays, not a clean exit. Issue 188 stays open until a build with CEF 150 reaches the reporters.

