### PR TITLE
Pin text files to LF on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# eol=lf overrides core.autocrlf, so every platform checks out the same bytes.
+* text=auto eol=lf
+
+# Visual Studio rewrites this with CRLF.
+*.sln text eol=crlf


### PR DESCRIPTION
Line endings currently depend on each contributor's `core.autocrlf` rather than on the repository. With it enabled, git writes CRLF into the working tree on Windows while `.prettierrc` sets `endOfLine: lf`, so `prettier --check` fails on every freshly checked out file and `npm run format` rewrites hundreds of files across `src-ui`, `src-shared-ts` and `scripts` without changing a single committed byte.

Adding `.gitattributes` with `eol=lf` makes the checkout rule a property of the project, so it no longer matters what any individual has configured globally.

**This changes no content.** Every blob in the repository is already pure LF, so `git add --renormalize .` reports nothing. Only what git writes to disk changes.

`*.sln` is pinned to CRLF because Visual Studio rewrites it that way and would otherwise fight the repository. There are no `.bat` or `.cmd` files, which are the only other genuinely line-ending sensitive type here. `scripts/ts-proto-gen.ps1` is fine as LF, as PowerShell reads either.

## What a reviewer should check

That you are happy with an LF working tree on Windows. Visual Studio, VS Code, Rider, PowerShell, Node, cargo and dotnet all handle LF, so in practice nothing changes except that prettier and git stop disagreeing.

## After merging

Existing clones need a one-time refresh, because git does not consider the current CRLF files modified: the clean filter normalises them to LF before comparing, so they match the index. Commit any work first, then:

```
git rm --cached -r .
git reset --hard
```

Fresh clones need nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized line endings across the project.
  * Configured Visual Studio solution files to use Windows-style line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->