### PR TITLE
Port the lighthouse BLE integration from bluest to btleplug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 
 ### Fixed
 
+- Fixed base stations being turned off when OyasumiVR was started while SteamVR was already running
 - Fixed base station control leaking memory in the Windows Bluetooth service, which could use up all
   of the system's memory
 - Fixed base stations not being controllable again after they briefly went out of Bluetooth range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 
 ### Fixed
 
+- Fixed base station control leaking memory in the Windows Bluetooth service, which could use up all
+  of the system's memory
+- Fixed base stations not being controllable again after they briefly went out of Bluetooth range
 - Fixed the Windows notification provider not showing any notifications
 - Fixed SteamVR sometimes crashing when OyasumiVR turned off several base stations at once
 - Fixed OyasumiVR shutting down on its own when SteamVR reported an event it did not recognise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project (now) adheres to [Calendar Versioning](https://calver.org/#sche
 
 ### Changed
 
+- Turning devices on when OyasumiVR starts now takes precedence over turning them off for a stopped
+  SteamVR, so devices covered by both automations are left on
 - Improved the Traditional Chinese translations
 - Updated the Russian translations
 - OyasumiVR's window now does less work while it is open

--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -142,7 +142,7 @@ version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e7b35733e3a8c1ccb90385088dd5b6eaa61325cb4d1ad56e683b5224ff352e"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "ndk-context",
  "winapi",
  "xdg",
@@ -195,7 +195,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -239,7 +239,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
- "futures-lite 2.6.0",
+ "futures-lite",
  "pin-project-lite",
  "slab",
 ]
@@ -254,7 +254,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite",
  "parking",
  "polling",
  "rustix 0.38.44",
@@ -288,7 +288,7 @@ dependencies = [
  "blocking",
  "cfg-if",
  "event-listener",
- "futures-lite 2.6.0",
+ "futures-lite",
  "rustix 0.38.44",
  "tracing",
 ]
@@ -635,62 +635,37 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite",
  "piper",
 ]
 
 [[package]]
-name = "bluer"
-version = "0.16.1"
+name = "bluez-async"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed7969360669bf94a0f4b5e478a98ce0cdde2f9e4a26cecef5fcee53ab6e373"
+checksum = "84ae4213cc2a8dc663acecac67bbdad05142be4d8ef372b6903abf878b0c690a"
 dependencies = [
- "custom_debug",
+ "bitflags 2.13.1",
+ "bluez-generated",
  "dbus",
- "dbus-crossroads",
  "dbus-tokio",
- "displaydoc",
  "futures",
- "hex",
- "lazy_static",
- "libc",
+ "itertools 0.14.0",
  "log",
- "macaddr",
- "nix",
- "num-derive",
- "num-traits",
- "pin-project",
  "serde",
- "serde_json",
- "strum 0.25.0",
+ "serde-xml-rs",
+ "thiserror 2.0.20",
  "tokio",
- "tokio-stream",
  "uuid",
 ]
 
 [[package]]
-name = "bluest"
-version = "0.6.9"
+name = "bluez-generated"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c911a419028965c201759adadc1b556d1ee50eb2dfcceec3acb765c80e96f6"
+checksum = "9676783265eadd6f11829982792c6f303f3854d014edfba384685dcf237dd062"
 dependencies = [
- "async-broadcast",
- "async-channel",
- "async-trait",
- "bluer",
- "dispatch2",
- "futures-channel",
- "futures-core",
- "futures-lite 1.13.0",
- "java-spaghetti",
- "objc2 0.6.4",
- "objc2-core-bluetooth",
- "objc2-foundation 0.3.2",
- "serde",
- "tokio",
- "tracing",
- "uuid",
- "windows 0.48.0",
+ "dbus",
 ]
 
 [[package]]
@@ -712,6 +687,33 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "btleplug"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c3264dbe2c8e29381e4e95aa2d2783ad0b9192b511240f3755b7e5e3cee87e"
+dependencies = [
+ "async-trait",
+ "bitflags 2.13.1",
+ "bluez-async",
+ "dashmap",
+ "dbus",
+ "futures",
+ "jni 0.19.0",
+ "log",
+ "objc2 0.5.2",
+ "objc2-core-bluetooth",
+ "objc2-foundation 0.2.2",
+ "once_cell",
+ "static_assertions",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows 0.62.2",
+ "windows-future 0.3.2",
 ]
 
 [[package]]
@@ -864,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -1150,7 +1152,7 @@ dependencies = [
  "alsa",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -1320,26 +1322,6 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "custom_debug"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89e0ae2c2a42be29595d05c50e3ce6096c0698a97e021c3289790f0750cc8e2"
-dependencies = [
- "custom_debug_derive",
-]
-
-[[package]]
-name = "custom_debug_derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a9f3941234c9f62ceaa2782974827749de9b0a8a6487275a278da068e1baf7"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
- "synstructure 0.12.6",
-]
 
 [[package]]
 name = "cxx"
@@ -1521,6 +1503,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,24 +1536,15 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "dbus"
-version = "0.9.7"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "futures-channel",
  "futures-util",
  "libc",
  "libdbus-sys",
- "winapi",
-]
-
-[[package]]
-name = "dbus-crossroads"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4c83437187544ba5142427746835061b330446ca8902eabd70e4afb8f76de0"
-dependencies = [
- "dbus",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2001,7 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2243,16 +2230,6 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-lite"
@@ -3314,15 +3291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "java-spaghetti"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b180a691471c73a518003db62d51c77bfe987a1f143385159647788f251b82"
-dependencies = [
- "jni-sys 0.4.0",
-]
-
-[[package]]
 name = "javascriptcore-rs"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,6 +3315,20 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
@@ -3354,7 +3336,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.0",
+ "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3366,25 +3348,6 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jni-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a312d782b8d56a1e0897d45c1af33f31f9b4a4d13d31207a8675e0223b818"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c199962dfd5610ced8eca382606e349f7940a4ac7d867b58a046123411cbb4"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "jobserver"
@@ -3517,9 +3480,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
 ]
@@ -3596,11 +3559,10 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3633,12 +3595,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "time",
 ]
-
-[[package]]
-name = "macaddr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "mach2"
@@ -3900,7 +3856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.13.1",
- "jni-sys 0.3.0",
+ "jni-sys",
  "log",
  "ndk-sys",
  "num_enum",
@@ -3920,7 +3876,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys 0.3.0",
+ "jni-sys",
 ]
 
 [[package]]
@@ -3936,17 +3892,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -3980,7 +3925,7 @@ version = "4.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
 dependencies = [
- "futures-lite 2.6.0",
+ "futures-lite",
  "log",
  "mac-notification-sys",
  "serde",
@@ -4204,15 +4149,13 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-bluetooth"
-version = "0.3.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33c82c3e375cee882b82f6a5e6dc9667b04fc18f94c080331e28b50f794d414"
+checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
 dependencies = [
  "bitflags 2.13.1",
- "dispatch2",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4438,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
@@ -4602,7 +4545,7 @@ name = "oyasumivr"
 version = "25.6.12"
 dependencies = [
  "async-recursion",
- "bluest",
+ "btleplug",
  "byteorder",
  "bytes",
  "chrono",
@@ -4637,8 +4580,8 @@ dependencies = [
  "serde_json",
  "steamlocate",
  "steamworks",
- "strum 0.28.0",
- "strum_macros 0.28.0",
+ "strum",
+ "strum_macros",
  "substring",
  "suncalc",
  "sysinfo",
@@ -4746,15 +4689,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5399,7 +5342,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5918,7 +5861,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5988,7 +5931,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -6199,6 +6142,18 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 2.0.20",
+ "xml",
 ]
 
 [[package]]
@@ -6544,6 +6499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "steamlocate"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6638,31 +6599,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
-]
 
 [[package]]
 name = "strum_macros"
@@ -6905,18 +6844,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -7033,7 +6960,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -7100,7 +7027,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http 1.3.1",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -7533,7 +7460,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.3.1",
- "jni",
+ "jni 0.21.1",
  "objc2 0.6.4",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -7556,7 +7483,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http 1.3.1",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit",
@@ -8388,12 +8315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8795,8 +8716,8 @@ dependencies = [
  "webview2-com-sys 0.38.0",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -8888,7 +8809,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8910,17 +8831,6 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
-]
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-implement 0.48.0",
- "windows-interface 0.48.0",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8972,8 +8882,8 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -8985,8 +8895,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -9016,17 +8926,6 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -9034,17 +8933,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9569,7 +9457,7 @@ dependencies = [
  "gtk",
  "http 1.3.1",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2 0.6.4",
@@ -9656,6 +9544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "xml"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f45bb2c13fec6a6cb4c0f76a7e94839e110a14ec803ec2940777a94c347bc52"
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9676,7 +9570,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -9697,7 +9591,7 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-lite 2.6.0",
+ "futures-lite",
  "hex",
  "libc",
  "ordered-stream",
@@ -9787,7 +9681,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -22,7 +22,7 @@ tauri-plugin-updater = "2.10.1"
 
 [dependencies]
 async-recursion = "1.1.1"
-bluest = { version = "0.6.9", features = ["serde"] }
+btleplug = "0.12.0"
 byteorder = "1.5.0"
 bytes = "1.12.1"
 chrono = "0.4.45"

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -49,7 +49,7 @@ static LIGHTHOUSE_DEVICE_POWER_STATES: LazyLock<Mutex<HashMap<String, Lighthouse
 static LIGHTHOUSE_DEVICE_V1_TIMEOUTS: LazyLock<Mutex<HashMap<String, u16>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static SCANNING: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
-static ADAPTER: LazyLock<Mutex<Option<Adapter>>> = LazyLock::new(Mutex::default);
+static MANAGER: LazyLock<Mutex<Option<Manager>>> = LazyLock::new(Mutex::default);
 static STATUS: LazyLock<Mutex<LighthouseStatus>> =
     LazyLock::new(|| Mutex::new(LighthouseStatus::Uninitialized));
 static PROCESSING_DEVICES: LazyLock<Mutex<HashSet<PeripheralId>>> =
@@ -57,39 +57,33 @@ static PROCESSING_DEVICES: LazyLock<Mutex<HashSet<PeripheralId>>> =
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const CONNECT_RETRY_COOLDOWN: Duration = Duration::from_secs(10);
-const SCAN_START_RETRY_DELAY: Duration = Duration::from_secs(10);
 
 pub async fn init() {
     // Initialize adapter
-    let adapter = {
-        let manager = match Manager::new().await {
-            Ok(manager) => manager,
-            Err(err) => {
-                error!("[Core] Failed to initialize the bluetooth manager: {err}");
-                set_lighthouse_status(LighthouseStatus::AdapterError).await;
-                return;
-            }
-        };
-        let adapter = match manager.adapters().await {
-            Ok(adapters) => adapters.into_iter().next(),
-            Err(err) => {
-                error!("[Core] Failed to list the bluetooth adapters: {err}");
-                set_lighthouse_status(LighthouseStatus::AdapterError).await;
-                return;
-            }
-        };
-        match adapter {
-            Some(adapter) => adapter,
-            None => {
+    let manager = match Manager::new().await {
+        Ok(manager) => manager,
+        Err(err) => {
+            error!("[Core] Failed to initialize the bluetooth manager: {err}");
+            set_lighthouse_status(LighthouseStatus::AdapterError).await;
+            return;
+        }
+    };
+    match manager.adapters().await {
+        Ok(adapters) => {
+            if adapters.is_empty() {
                 set_lighthouse_status(LighthouseStatus::NoAdapter).await;
                 warn!("[Core] No bluetooth adapter was found. Disabling lighthouse module.");
                 return;
             }
         }
-    };
-    *ADAPTER.lock().await = Some(adapter.clone());
+        Err(err) => {
+            error!("[Core] Failed to list the bluetooth adapters: {err}");
+            set_lighthouse_status(LighthouseStatus::AdapterError).await;
+            return;
+        }
+    }
+    *MANAGER.lock().await = Some(manager);
     set_lighthouse_status(LighthouseStatus::Ready).await;
-    tokio::spawn(scan_for_devices(adapter));
     // Poll the status of connected lighthouses every few seconds in a separate task
     tokio::spawn(async move {
         loop {
@@ -108,45 +102,21 @@ pub async fn init() {
     });
 }
 
-/// Runs for the lifetime of the process. The scan must be started only once: btleplug registers an
-/// advertisement handler per `start_scan` call and never removes it.
-async fn scan_for_devices(adapter: Adapter) {
-    // Subscribing after the scan starts would miss the first advertisements
-    let mut events = match adapter.events().await {
-        Ok(events) => events,
+/// Every scan needs its own adapter: btleplug registers an advertisement handler per `start_scan`
+/// call and never removes it, while a fresh adapter carries a fresh watcher.
+async fn scan_adapter() -> Option<Adapter> {
+    let manager_guard = MANAGER.lock().await;
+    let manager = manager_guard.as_ref()?;
+    match manager.adapters().await {
+        Ok(adapters) => adapters.into_iter().next(),
         Err(err) => {
-            error!("[Core] Failed to listen for bluetooth adapter events: {err}");
-            return;
-        }
-    };
-    let mut reported = false;
-    while let Err(err) = adapter.start_scan(ScanFilter::default()).await {
-        if !reported {
-            warn!("[Core] Failed to scan for lighthouse devices: {err}");
-            reported = true;
-        }
-        sleep(SCAN_START_RETRY_DELAY).await;
-    }
-    while let Some(event) = events.next().await {
-        let device_id = match event {
-            CentralEvent::DeviceDiscovered(id) | CentralEvent::DeviceUpdated(id) => id,
-            _ => continue,
-        };
-        // Advertisements are only acted on while the UI has a scan window open
-        if !*SCANNING.lock().await {
-            continue;
-        }
-        if let Ok(peripheral) = adapter.peripheral(&device_id).await {
-            tokio::spawn(handle_discovered_device(peripheral));
+            warn!("[Core] Failed to list the bluetooth adapters: {err}");
+            None
         }
     }
 }
 
 pub async fn start_scan(duration: Duration) {
-    if ADAPTER.lock().await.is_none() {
-        // No bluetooth adapter was found, we stop here
-        return;
-    }
     // Claim the scanning state, so two commands cannot open a window at the same time
     {
         let mut scanning_guard = SCANNING.lock().await;
@@ -161,8 +131,49 @@ pub async fn start_scan(duration: Duration) {
         LighthouseScanningStatusChangedEvent { scanning: true },
     )
     .await;
-    sleep(duration).await;
+    scan_for_devices(duration).await;
     set_scanning_status(false).await;
+}
+
+async fn scan_for_devices(duration: Duration) {
+    let adapter = match scan_adapter().await {
+        Some(adapter) => adapter,
+        None => return,
+    };
+    // Subscribing after the scan starts would miss the first advertisements
+    let mut events = match adapter.events().await {
+        Ok(events) => events,
+        Err(err) => {
+            warn!("[Core] Failed to listen for bluetooth adapter events: {err}");
+            return;
+        }
+    };
+    if let Err(err) = adapter.start_scan(ScanFilter::default()).await {
+        warn!("[Core] Failed to scan for lighthouse devices: {err}");
+        return;
+    }
+    // Listen for scan results
+    let mut timer = Box::pin(sleep(duration));
+    loop {
+        tokio::select! {
+            _ = timer.as_mut() => {
+                break;
+            }
+            event = events.next() => {
+                let device_id = match event {
+                    Some(CentralEvent::DeviceDiscovered(id)) | Some(CentralEvent::DeviceUpdated(id)) => id,
+                    Some(_) => continue,
+                    None => break,
+                };
+                if let Ok(peripheral) = adapter.peripheral(&device_id).await {
+                    tokio::spawn(handle_discovered_device(peripheral));
+                }
+            }
+        }
+    }
+    if let Err(err) = adapter.stop_scan().await {
+        warn!("[Core] Failed to stop scanning for lighthouse devices: {err}");
+    }
 }
 
 pub async fn get_devices() -> Vec<LighthouseDeviceModel> {
@@ -306,6 +317,7 @@ pub async fn set_device_power_state(
                             "[Core] Failed to power on lighthouse device ({}) : {}",
                             device.device_name, e
                         );
+                        let _ = peripheral.disconnect().await;
                         return Err(LighthouseError::FailedToWriteCharacteristic(e));
                     }
                 }
@@ -336,6 +348,7 @@ pub async fn set_device_power_state(
                             "[Core] Failed to power off lighthouse device ({}) : {}",
                             device.device_name, e
                         );
+                        let _ = peripheral.disconnect().await;
                         return Err(LighthouseError::FailedToWriteCharacteristic(e));
                     } else {
                         // Wait a bit for the device to actually power off
@@ -348,20 +361,26 @@ pub async fn set_device_power_state(
             };
         }
         LighthouseDeviceType::LighthouseV2 => {
-            match state {
-                LighthousePowerState::Sleep => {
-                    let _ = write_v2_power(&peripheral, &characteristic, 0x00).await;
-                }
-                LighthousePowerState::Standby => {
-                    let _ = write_v2_power(&peripheral, &characteristic, 0x02).await;
-                }
-                LighthousePowerState::On => {
-                    let _ = write_v2_power(&peripheral, &characteristic, 0x01).await;
-                }
+            let value = match state {
+                LighthousePowerState::Sleep => Some(0x00),
+                LighthousePowerState::Standby => Some(0x02),
+                LighthousePowerState::On => Some(0x01),
                 LighthousePowerState::Booting | LighthousePowerState::Unknown => {
                     warn!("[Core] Attempted to set lighthouse device power to an invalid state");
+                    None
                 }
             };
+            if let Some(value) = value {
+                if let Err(e) = write_v2_power(&peripheral, &characteristic, value).await {
+                    error!(
+                        "[Core] Failed to set the power state of lighthouse device ({}) : {}",
+                        device.device_name, e
+                    );
+                    // Drop the stale session so the next attempt rediscovers the services
+                    let _ = peripheral.disconnect().await;
+                    return Err(LighthouseError::FailedToWriteCharacteristic(e));
+                }
+            }
         }
     };
     drop(guard);
@@ -543,17 +562,31 @@ async fn get_power_characteristic(
             (LIGHTHOUSE_V2_PWR_SERVICE, LIGHTHOUSE_V2_PWR_CHARACTERISTIC)
         }
     };
-    let service = device
+    // Service discovery skips services whose characteristics it could not enumerate, so an
+    // incomplete cache has to be dropped instead of being kept for every later operation
+    let service = match device
         .bt_device
         .services()
         .into_iter()
         .find(|service| service.uuid.eq(&service_uuid))
-        .ok_or(LighthouseError::ServiceNotFound)?;
-    let characteristic = service
+    {
+        Some(service) => service,
+        None => {
+            let _ = device.bt_device.disconnect().await;
+            return Err(LighthouseError::ServiceNotFound);
+        }
+    };
+    let characteristic = match service
         .characteristics
         .into_iter()
         .find(|characteristic| characteristic.uuid.eq(&characteristic_uuid))
-        .ok_or(LighthouseError::CharacteristicNotFound)?;
+    {
+        Some(characteristic) => characteristic,
+        None => {
+            let _ = device.bt_device.disconnect().await;
+            return Err(LighthouseError::CharacteristicNotFound);
+        }
+    };
     Ok((device.bt_device, characteristic))
 }
 

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -7,11 +7,18 @@ use std::{
     time::Duration,
 };
 
-use bluest::{Adapter, Characteristic, Device, DeviceId, Service, Uuid};
-use futures_util::StreamExt;
+use btleplug::{
+    api::{
+        Central, CentralEvent, CharPropFlags, Characteristic, Manager as _, Peripheral as _,
+        ScanFilter, WriteType,
+    },
+    platform::{Adapter, Manager, Peripheral, PeripheralId},
+};
+use futures_util::{future::join_all, StreamExt};
 use log::{debug, error, info, trace, warn};
 use models::LighthouseDevice;
 use tokio::{sync::Mutex, time::sleep};
+use uuid::Uuid;
 
 use crate::utils::send_event;
 
@@ -45,21 +52,44 @@ static SCANNING: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 static ADAPTER: LazyLock<Mutex<Option<Adapter>>> = LazyLock::new(Mutex::default);
 static STATUS: LazyLock<Mutex<LighthouseStatus>> =
     LazyLock::new(|| Mutex::new(LighthouseStatus::Uninitialized));
-static PROCESSING_DEVICES: LazyLock<Mutex<HashSet<DeviceId>>> =
+static PROCESSING_DEVICES: LazyLock<Mutex<HashSet<PeripheralId>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const CONNECT_RETRY_COOLDOWN: Duration = Duration::from_secs(10);
+const SCAN_START_RETRY_DELAY: Duration = Duration::from_secs(10);
 
 pub async fn init() {
     // Initialize adapter
-    {
-        let adapter = Adapter::default().await;
-        if adapter.is_none() {
-            set_lighthouse_status(LighthouseStatus::NoAdapter).await;
-            warn!("[Core] No bluetooth adapter was found. Disabling lighthouse module.");
-            return;
+    let adapter = {
+        let manager = match Manager::new().await {
+            Ok(manager) => manager,
+            Err(err) => {
+                error!("[Core] Failed to initialize the bluetooth manager: {err}");
+                set_lighthouse_status(LighthouseStatus::AdapterError).await;
+                return;
+            }
+        };
+        let adapter = match manager.adapters().await {
+            Ok(adapters) => adapters.into_iter().next(),
+            Err(err) => {
+                error!("[Core] Failed to list the bluetooth adapters: {err}");
+                set_lighthouse_status(LighthouseStatus::AdapterError).await;
+                return;
+            }
+        };
+        match adapter {
+            Some(adapter) => adapter,
+            None => {
+                set_lighthouse_status(LighthouseStatus::NoAdapter).await;
+                warn!("[Core] No bluetooth adapter was found. Disabling lighthouse module.");
+                return;
+            }
         }
-        *ADAPTER.lock().await = adapter;
-    }
+    };
+    *ADAPTER.lock().await = Some(adapter.clone());
     set_lighthouse_status(LighthouseStatus::Ready).await;
+    tokio::spawn(scan_for_devices(adapter));
     // Poll the status of connected lighthouses every few seconds in a separate task
     tokio::spawn(async move {
         loop {
@@ -67,62 +97,71 @@ pub async fn init() {
             let devices_guard = LIGHTHOUSE_DEVICES.lock().await;
             let devices = devices_guard.clone();
             drop(devices_guard);
-            for d in devices.iter() {
-                let _ = get_device_power_state(d.bt_device.id().to_string()).await;
-            }
+            // Polled together, so an unreachable device cannot hold up the others
+            join_all(
+                devices
+                    .iter()
+                    .map(|d| get_device_power_state(d.id.to_string())),
+            )
+            .await;
         }
     });
 }
 
-pub async fn start_scan(duration: Duration) {
-    // Get the adapter
-    let adapter_guard = ADAPTER.lock().await;
-    let adapter = match adapter_guard.as_ref() {
-        Some(adapter) => adapter,
-        None => {
-            // No bluetooth adapter was found, we stop here
+/// Runs for the lifetime of the process. The scan must be started only once: btleplug registers an
+/// advertisement handler per `start_scan` call and never removes it.
+async fn scan_for_devices(adapter: Adapter) {
+    // Subscribing after the scan starts would miss the first advertisements
+    let mut events = match adapter.events().await {
+        Ok(events) => events,
+        Err(err) => {
+            error!("[Core] Failed to listen for bluetooth adapter events: {err}");
             return;
         }
     };
-    // Wait until the adapter is available
-    if let Err(e) = adapter.wait_available().await {
-        warn!("[Core] Failed to wait for bluetooth adapter to become available: {e}");
-        set_scanning_status(false).await;
+    let mut reported = false;
+    while let Err(err) = adapter.start_scan(ScanFilter::default()).await {
+        if !reported {
+            warn!("[Core] Failed to scan for lighthouse devices: {err}");
+            reported = true;
+        }
+        sleep(SCAN_START_RETRY_DELAY).await;
+    }
+    while let Some(event) = events.next().await {
+        let device_id = match event {
+            CentralEvent::DeviceDiscovered(id) | CentralEvent::DeviceUpdated(id) => id,
+            _ => continue,
+        };
+        // Advertisements are only acted on while the UI has a scan window open
+        if !*SCANNING.lock().await {
+            continue;
+        }
+        if let Ok(peripheral) = adapter.peripheral(&device_id).await {
+            tokio::spawn(handle_discovered_device(peripheral));
+        }
+    }
+}
+
+pub async fn start_scan(duration: Duration) {
+    if ADAPTER.lock().await.is_none() {
+        // No bluetooth adapter was found, we stop here
         return;
     }
-    // Check if we are already scanning
+    // Claim the scanning state, so two commands cannot open a window at the same time
     {
-        if *SCANNING.lock().await {
+        let mut scanning_guard = SCANNING.lock().await;
+        if *scanning_guard {
             warn!("[Core] Already scanning for lighthouse devices");
             return;
         }
+        *scanning_guard = true;
     }
-    set_scanning_status(true).await;
-    // Start the scan
-    let mut scan = match adapter.scan(&[]).await {
-        Ok(scan) => scan,
-        Err(err) => {
-            warn!("[Core] Failed to scan for lighthouse devices: {err}");
-            set_scanning_status(false).await;
-            return;
-        }
-    };
-    // Listen for scan scan results
-    let mut timer = Box::pin(sleep(duration));
-    loop {
-        tokio::select! {
-            _ = timer.as_mut() => {
-                break;
-            }
-            result = scan.next() => {
-                if let Some(discovered_device) = result {
-                    tokio::spawn(handle_discovered_device(discovered_device.device));
-                } else {
-                    break;
-                }
-            }
-        }
-    }
+    send_event(
+        EVENT_SCANNING_STATUS_CHANGED,
+        LighthouseScanningStatusChangedEvent { scanning: true },
+    )
+    .await;
+    sleep(duration).await;
     set_scanning_status(false).await;
 }
 
@@ -143,25 +182,20 @@ pub async fn get_device_power_state(
     let device = get_device(device_id.clone())
         .await
         .ok_or(LighthouseError::DeviceNotFound)?;
-    let characteristic = match get_power_characteristic(device_id.clone()).await {
-        Ok(characteristic) => characteristic,
-        Err(err) => {
-            return Err(err);
+    let value = {
+        let op_lock = device.op_lock.clone();
+        let _guard = op_lock.lock().await;
+        let (peripheral, characteristic) = get_power_characteristic(device_id.clone()).await?;
+        if !characteristic.properties.contains(CharPropFlags::READ) {
+            return Err(LighthouseError::CharacteristicDoesNotSupportRead);
         }
-    };
-    let characteristic_props = match characteristic.properties().await {
-        Ok(props) => props,
-        Err(err) => {
-            return Err(LighthouseError::FailedToGetCharacteristicProperties(err));
-        }
-    };
-    if !characteristic_props.read {
-        return Err(LighthouseError::CharacteristicDoesNotSupportRead);
-    }
-    let value = match characteristic.read().await {
-        Ok(value) => value,
-        Err(err) => {
-            return Err(LighthouseError::FailedToReadCharacteristic(err));
+        match peripheral.read(&characteristic).await {
+            Ok(value) => value,
+            Err(err) => {
+                // Drop the stale session so the next attempt rediscovers the services
+                let _ = peripheral.disconnect().await;
+                return Err(LighthouseError::FailedToReadCharacteristic(err));
+            }
         }
     };
     let (state, v1_timeout) = match device.device_type {
@@ -250,10 +284,9 @@ pub async fn set_device_power_state(
     let device = get_device(device_id.clone())
         .await
         .ok_or(LighthouseError::DeviceNotFound)?;
-    let characteristic = match get_power_characteristic(device_id.clone()).await {
-        Ok(characteristic) => characteristic,
-        Err(err) => return Err(err),
-    };
+    let op_lock = device.op_lock.clone();
+    let guard = op_lock.lock().await;
+    let (peripheral, characteristic) = get_power_characteristic(device_id.clone()).await?;
     match device.device_type {
         LighthouseDeviceType::LighthouseV1 => {
             match state {
@@ -265,7 +298,9 @@ pub async fn set_device_power_state(
                         0x00, 0x00,
                     ];
                     // Write command
-                    let result = characteristic.write(&payload).await;
+                    let result = peripheral
+                        .write(&characteristic, &payload, WriteType::WithResponse)
+                        .await;
                     if let Err(e) = result {
                         error!(
                             "[Core] Failed to power on lighthouse device ({}) : {}",
@@ -293,7 +328,9 @@ pub async fn set_device_power_state(
                     // Set timeout
                     payload[2..4].copy_from_slice(&timeout.to_be_bytes());
                     // Write command
-                    let result = characteristic.write(&payload).await;
+                    let result = peripheral
+                        .write(&characteristic, &payload, WriteType::WithResponse)
+                        .await;
                     if let Err(e) = result {
                         error!(
                             "[Core] Failed to power off lighthouse device ({}) : {}",
@@ -313,13 +350,13 @@ pub async fn set_device_power_state(
         LighthouseDeviceType::LighthouseV2 => {
             match state {
                 LighthousePowerState::Sleep => {
-                    let _ = characteristic.write_without_response(&[0x00]).await;
+                    let _ = write_v2_power(&peripheral, &characteristic, 0x00).await;
                 }
                 LighthousePowerState::Standby => {
-                    let _ = characteristic.write_without_response(&[0x02]).await;
+                    let _ = write_v2_power(&peripheral, &characteristic, 0x02).await;
                 }
                 LighthousePowerState::On => {
-                    let _ = characteristic.write_without_response(&[0x01]).await;
+                    let _ = write_v2_power(&peripheral, &characteristic, 0x01).await;
                 }
                 LighthousePowerState::Booting | LighthousePowerState::Unknown => {
                     warn!("[Core] Attempted to set lighthouse device power to an invalid state");
@@ -327,98 +364,79 @@ pub async fn set_device_power_state(
             };
         }
     };
+    drop(guard);
     // Fetch the new state for confirmation
     let _ = get_device_power_state(device_id).await;
     Ok(())
 }
 
-async fn handle_discovered_device(device: Device) {
+async fn handle_discovered_device(device: Peripheral) {
     let device_id = device.id();
 
     // Check if this device is already being processed and add it atomically
     {
         let mut processing_devices_guard = PROCESSING_DEVICES.lock().await;
-        if processing_devices_guard.contains(&device_id) {
+        if !processing_devices_guard.insert(device_id.clone()) {
             return;
         }
-        processing_devices_guard.insert(device_id.clone());
     }
+    if !identify_discovered_device(&device, &device_id).await {
+        // Held in PROCESSING_DEVICES meanwhile, so further advertisements are ignored
+        sleep(CONNECT_RETRY_COOLDOWN).await;
+    }
+    PROCESSING_DEVICES.lock().await.remove(&device_id);
+}
 
-    // Helper closure to clean up processing device on early return
-    let cleanup = |device_id: DeviceId| {
-        tokio::spawn(async move {
-            let mut processing_devices_guard = PROCESSING_DEVICES.lock().await;
-            processing_devices_guard.remove(&device_id);
-        });
-    };
-
+async fn identify_discovered_device(device: &Peripheral, device_id: &PeripheralId) -> bool {
     // Check if the device is already known
     {
         let lighthouse_devices_guard = LIGHTHOUSE_DEVICES.lock().await;
-        if lighthouse_devices_guard.iter().any(|d| d.id.eq(&device_id)) {
-            cleanup(device_id.clone());
-            return;
+        if lighthouse_devices_guard.iter().any(|d| d.id.eq(device_id)) {
+            return true;
         }
     }
-    // Get the device name
-    let device_name = match device.name_async().await {
-        Ok(name) => name,
+    // Get the advertised device name
+    let device_name = match device.properties().await {
+        Ok(Some(properties)) => properties.local_name.unwrap_or_default(),
+        Ok(None) => return true,
         Err(err) => {
-            trace!("[Core] Failed to get name of discovered device: {err}");
-            cleanup(device_id.clone());
-            return;
+            trace!("[Core] Failed to get properties of discovered device: {err}");
+            return true;
         }
     };
     // Check if it starts with known prefixes
     if (!device_name.starts_with("LHB-") && !device_name.starts_with("HTC BS"))
         || device_name == "LHB-00000000"
     {
-        cleanup(device_id.clone());
-        return;
+        return true;
     }
-    // Get the device's services
-    debug!(
-        "[Core] Getting services of discovered device: {}",
-        device_name.clone()
-    );
-    let services = match tokio::time::timeout(Duration::from_secs(15), device.services()).await {
-        Ok(Ok(services)) => services,
-        Ok(Err(err)) => {
-            warn!(
-                "[Core] Failed to get services of discovered device ({}): {}",
-                device_name.clone(),
-                err
-            );
-            cleanup(device_id.clone());
-            return;
+    // Connect and enumerate the device's services
+    let services = {
+        if let Err(err) = ensure_connected(device, &device_name).await {
+            warn!("[Core] Failed to connect to discovered device ({device_name}): {err:?}");
+            let _ = device.disconnect().await;
+            return false;
         }
-        Err(_) => {
-            debug!(
-                "[Core] Timeout getting services of discovered device: {}",
-                device_name.clone()
-            );
-            cleanup(device_id.clone());
-            return;
-        }
+        device.services()
     };
     // Determine the device type based on the services present
     let device_type = {
         if services
             .iter()
-            .any(|service| service.uuid().eq(&LIGHTHOUSE_V1_PWR_SERVICE))
+            .any(|service| service.uuid.eq(&LIGHTHOUSE_V1_PWR_SERVICE))
         {
             LighthouseDeviceType::LighthouseV1
         } else if services
             .iter()
-            .any(|service| service.uuid().eq(&LIGHTHOUSE_V2_PWR_SERVICE))
+            .any(|service| service.uuid.eq(&LIGHTHOUSE_V2_PWR_SERVICE))
         {
             LighthouseDeviceType::LighthouseV2
         } else {
             warn!(
                 "[Core] Discovered device does not contain a lighthouse control service: {device_name}"
             );
-            cleanup(device_id);
-            return;
+            let _ = device.disconnect().await;
+            return false;
         }
     };
     // Add the device to the list of lighthouse devices
@@ -427,13 +445,13 @@ async fn handle_discovered_device(device: Device) {
         device_name: device_name.clone(),
         device_type: device_type.clone(),
         bt_device: device.clone(),
+        op_lock: Arc::new(Mutex::new(())),
     };
     {
         let mut lighthouse_devices_guard = LIGHTHOUSE_DEVICES.lock().await;
         // Double-check that device hasn't been added by another thread
-        if lighthouse_devices_guard.iter().any(|d| d.id.eq(&device_id)) {
-            cleanup(device_id.clone());
-            return;
+        if lighthouse_devices_guard.iter().any(|d| d.id.eq(device_id)) {
+            return true;
         }
         lighthouse_devices_guard.push(discovered_device.clone());
     }
@@ -450,9 +468,7 @@ async fn handle_discovered_device(device: Device) {
         device_type.clone(),
         device_name
     );
-
-    // Clean up processing device
-    cleanup(device_id.clone());
+    true
 }
 
 async fn set_lighthouse_status(status: LighthouseStatus) {
@@ -475,64 +491,77 @@ async fn set_scanning_status(scanning: bool) {
     .await;
 }
 
-async fn get_device(device_id: String) -> Option<Arc<LighthouseDevice>> {
+async fn get_device(device_id: String) -> Option<LighthouseDevice> {
     let devices = LIGHTHOUSE_DEVICES.lock().await;
-    for device in devices.iter() {
-        if device.id.to_string().eq(&device_id) {
-            return Some(Arc::new(device.clone()));
-        }
-    }
-    None
-}
-
-async fn get_lighthouse_service(device: LighthouseDevice) -> Result<Service, LighthouseError> {
-    let services = match device.bt_device.services().await {
-        Ok(services) => services,
-        Err(err) => return Err(LighthouseError::FailedToGetServices(err)),
-    };
-    let service_uuid = match device.device_type {
-        LighthouseDeviceType::LighthouseV1 => LIGHTHOUSE_V1_PWR_SERVICE,
-        LighthouseDeviceType::LighthouseV2 => LIGHTHOUSE_V2_PWR_SERVICE,
-    };
-    let service = services
+    devices
         .iter()
-        .find(|service| service.uuid().eq(&service_uuid));
-    match service {
-        Some(service) => Ok(service.clone()),
-        None => Err(LighthouseError::ServiceNotFound),
-    }
+        .find(|device| device.id.to_string().eq(&device_id))
+        .cloned()
 }
 
-async fn get_power_characteristic(device_id: String) -> Result<Characteristic, LighthouseError> {
+async fn write_v2_power(
+    peripheral: &Peripheral,
+    characteristic: &Characteristic,
+    value: u8,
+) -> Result<(), btleplug::Error> {
+    peripheral
+        .write(characteristic, &[value], WriteType::WithoutResponse)
+        .await
+}
+
+async fn ensure_connected(device: &Peripheral, device_name: &str) -> Result<(), LighthouseError> {
+    if device.is_connected().await.unwrap_or(false) {
+        return Ok(());
+    }
+    debug!("[Core] Connecting to lighthouse device: {device_name}");
+    // The cached service handles are invalid after a reconnect, so drop them first
+    let _ = device.disconnect().await;
+    device
+        .connect_with_timeout(CONNECT_TIMEOUT)
+        .await
+        .map_err(LighthouseError::FailedToConnect)?;
+    if let Err(err) = device.discover_services_with_timeout(CONNECT_TIMEOUT).await {
+        // Leaving it connected without services would make every later operation fail
+        let _ = device.disconnect().await;
+        return Err(LighthouseError::FailedToGetServices(err));
+    }
+    Ok(())
+}
+
+async fn get_power_characteristic(
+    device_id: String,
+) -> Result<(Peripheral, Characteristic), LighthouseError> {
     let device = get_device(device_id)
         .await
         .ok_or(LighthouseError::DeviceNotFound)?;
-    let service = match get_lighthouse_service(Arc::unwrap_or_clone(device.clone())).await {
-        Ok(service) => service,
-        Err(err) => return Err(err),
+    ensure_connected(&device.bt_device, &device.device_name).await?;
+    let (service_uuid, characteristic_uuid) = match device.device_type {
+        LighthouseDeviceType::LighthouseV1 => {
+            (LIGHTHOUSE_V1_PWR_SERVICE, LIGHTHOUSE_V1_PWR_CHARACTERISTIC)
+        }
+        LighthouseDeviceType::LighthouseV2 => {
+            (LIGHTHOUSE_V2_PWR_SERVICE, LIGHTHOUSE_V2_PWR_CHARACTERISTIC)
+        }
     };
-    let characteristics = match service.characteristics().await {
-        Ok(characteristics) => characteristics,
-        Err(err) => return Err(LighthouseError::FailedToGetCharacteristics(err)),
-    };
-    let characteristic_uuid = match device.device_type {
-        LighthouseDeviceType::LighthouseV1 => LIGHTHOUSE_V1_PWR_CHARACTERISTIC,
-        LighthouseDeviceType::LighthouseV2 => LIGHTHOUSE_V2_PWR_CHARACTERISTIC,
-    };
-    let characteristic = characteristics
-        .iter()
-        .find(|characteristic| characteristic.uuid().eq(&characteristic_uuid));
-    match characteristic {
-        Some(characteristic) => Ok(characteristic.clone()),
-        None => Err(LighthouseError::CharacteristicNotFound),
-    }
+    let service = device
+        .bt_device
+        .services()
+        .into_iter()
+        .find(|service| service.uuid.eq(&service_uuid))
+        .ok_or(LighthouseError::ServiceNotFound)?;
+    let characteristic = service
+        .characteristics
+        .into_iter()
+        .find(|characteristic| characteristic.uuid.eq(&characteristic_uuid))
+        .ok_or(LighthouseError::CharacteristicNotFound)?;
+    Ok((device.bt_device, characteristic))
 }
 
 async fn map_discovered_device_to_lighthouse_device(d: LighthouseDevice) -> LighthouseDeviceModel {
     let power_state = match LIGHTHOUSE_DEVICE_POWER_STATES
         .lock()
         .await
-        .get(&d.bt_device.id().to_string())
+        .get(&d.id.to_string())
     {
         Some(state) => state.clone(),
         None => LighthousePowerState::Unknown,
@@ -540,7 +569,7 @@ async fn map_discovered_device_to_lighthouse_device(d: LighthouseDevice) -> Ligh
     let v1_timeout = LIGHTHOUSE_DEVICE_V1_TIMEOUTS
         .lock()
         .await
-        .get(&d.bt_device.id().to_string())
+        .get(&d.id.to_string())
         .copied();
     let ld = LighthouseDeviceModel {
         id: d.id.to_string(),
@@ -567,12 +596,9 @@ async fn reset() {
     }
     // Disconnect all devices
     {
-        let adapter_guard = ADAPTER.lock().await;
-        if let Some(adapter) = adapter_guard.as_ref() {
-            let devices_guard = LIGHTHOUSE_DEVICES.lock().await;
-            for device in devices_guard.iter() {
-                let _ = adapter.disconnect_device(&device.bt_device).await;
-            }
+        let devices_guard = LIGHTHOUSE_DEVICES.lock().await;
+        for device in devices_guard.iter() {
+            let _ = device.bt_device.disconnect().await;
         }
     }
     // Clear all known devices

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -103,7 +103,7 @@ pub async fn init() {
 }
 
 /// Every scan needs its own adapter: btleplug registers an advertisement handler per `start_scan`
-/// call and never removes it, while a fresh adapter carries a fresh watcher.
+/// call and never removes it.
 async fn scan_adapter() -> Option<Adapter> {
     let manager_guard = MANAGER.lock().await;
     let manager = manager_guard.as_ref()?;
@@ -562,8 +562,7 @@ async fn get_power_characteristic(
             (LIGHTHOUSE_V2_PWR_SERVICE, LIGHTHOUSE_V2_PWR_CHARACTERISTIC)
         }
     };
-    // Service discovery skips services whose characteristics it could not enumerate, so an
-    // incomplete cache has to be dropped instead of being kept for every later operation
+    // Discovery leaves out services it could not enumerate, so an incomplete cache is dropped
     let service = match device
         .bt_device
         .services()

--- a/src-core/src/lighthouse/models.rs
+++ b/src-core/src/lighthouse/models.rs
@@ -1,5 +1,8 @@
-use bluest::{Device, DeviceId};
+use std::sync::Arc;
+
+use btleplug::platform::{Peripheral, PeripheralId};
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use tokio::sync::Mutex;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -30,15 +33,14 @@ pub enum LighthouseDeviceType {
 #[derive(Debug)]
 pub enum LighthouseError {
     DeviceNotFound,
-    FailedToGetServices(bluest::Error),
+    FailedToConnect(btleplug::Error),
+    FailedToGetServices(btleplug::Error),
     ServiceNotFound,
-    FailedToGetCharacteristics(bluest::Error),
     CharacteristicNotFound,
-    FailedToReadCharacteristic(bluest::Error),
-    FailedToWriteCharacteristic(bluest::Error),
+    FailedToReadCharacteristic(btleplug::Error),
+    FailedToWriteCharacteristic(btleplug::Error),
     InvalidCharacteristicValue,
     CharacteristicDoesNotSupportRead,
-    FailedToGetCharacteristicProperties(bluest::Error),
 }
 
 impl Serialize for LighthouseError {
@@ -52,6 +54,10 @@ impl Serialize for LighthouseError {
                 error.serialize_field("error", "DeviceNotFound")?;
                 error.serialize_field("message", &None::<String>)?;
             }
+            LighthouseError::FailedToConnect(e) => {
+                error.serialize_field("error", "FailedToConnect")?;
+                error.serialize_field("message", &Some(e.to_string()))?;
+            }
             LighthouseError::FailedToGetServices(e) => {
                 error.serialize_field("error", "FailedToGetServices")?;
                 error.serialize_field("message", &Some(e.to_string()))?;
@@ -59,10 +65,6 @@ impl Serialize for LighthouseError {
             LighthouseError::ServiceNotFound => {
                 error.serialize_field("error", "ServiceNotFound")?;
                 error.serialize_field("message", &None::<String>)?;
-            }
-            LighthouseError::FailedToGetCharacteristics(e) => {
-                error.serialize_field("error", "FailedToGetCharacteristics")?;
-                error.serialize_field("message", &Some(e.to_string()))?;
             }
             LighthouseError::CharacteristicNotFound => {
                 error.serialize_field("error", "CharacteristicNotFound")?;
@@ -84,10 +86,6 @@ impl Serialize for LighthouseError {
                 error.serialize_field("error", "CharacteristicCoesNotSupportRead")?;
                 error.serialize_field("message", &None::<String>)?;
             }
-            LighthouseError::FailedToGetCharacteristicProperties(e) => {
-                error.serialize_field("error", "FailedToReadCharacteristicProperties")?;
-                error.serialize_field("message", &Some(e.to_string()))?;
-            }
         };
         error.end()
     }
@@ -105,10 +103,12 @@ pub struct LighthouseDeviceModel {
 
 #[derive(Debug, Clone)]
 pub struct LighthouseDevice {
-    pub id: DeviceId,
-    pub bt_device: Device,
+    pub id: PeripheralId,
+    pub bt_device: Peripheral,
     pub device_name: String,
     pub device_type: LighthouseDeviceType,
+    /// Reconnecting closes the GATT handles, so operations on one device must not overlap
+    pub op_lock: Arc<Mutex<()>>,
 }
 
 //

--- a/src-ui/app/migrations/app-settings.migrations.ts
+++ b/src-ui/app/migrations/app-settings.migrations.ts
@@ -3,6 +3,7 @@ import { APP_SETTINGS_DEFAULT, AppSettings } from '../models/settings';
 import { error, info } from '@tauri-apps/plugin-log';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { message } from '@tauri-apps/plugin-dialog';
+import { migrateLighthouseDeviceId } from './lighthouse-device-id';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
@@ -15,6 +16,7 @@ const migrations: { [v: number]: (data: any) => any } = {
   8: from7to8,
   9: from8to9,
   10: from9to10,
+  11: from10to11,
 };
 
 export function migrateAppSettings(data: any): AppSettings {
@@ -72,6 +74,19 @@ async function saveBackup(oldData: any) {
 function resetToLatest(data: any): any {
   // Reset to latest
   data = structuredClone(APP_SETTINGS_DEFAULT);
+  return data;
+}
+
+function from10to11(data: any): any {
+  data.version = 11;
+  if (data.v1LighthouseIdentifiers) {
+    data.v1LighthouseIdentifiers = Object.fromEntries(
+      Object.entries(data.v1LighthouseIdentifiers).map(([id, identifier]) => [
+        migrateLighthouseDeviceId(id) ?? id,
+        identifier,
+      ])
+    );
+  }
   return data;
 }
 

--- a/src-ui/app/migrations/automation-configs.migrations.ts
+++ b/src-ui/app/migrations/automation-configs.migrations.ts
@@ -4,6 +4,7 @@ import { error, info } from '@tauri-apps/plugin-log';
 import { message } from '@tauri-apps/plugin-dialog';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { migrateOscScript } from './osc-script.migrations';
+import { migrateKnownLighthouseDeviceId } from './lighthouse-device-id';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
@@ -24,7 +25,31 @@ const migrations: { [v: number]: (data: any) => any } = {
   16: from15to16,
   17: from16to17,
   18: from17to18,
+  19: from18to19,
 };
+
+function from18to19(data: any): any {
+  data.version = 19;
+  migrateSelectedDeviceIds(data);
+  return data;
+}
+
+// Rewrites the base station ids in every device selection, wherever it sits in the config tree
+function migrateSelectedDeviceIds(value: any) {
+  if (Array.isArray(value)) {
+    value.forEach(migrateSelectedDeviceIds);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value.devices)) {
+    value.devices = [
+      ...new Set(
+        value.devices.map((id: string) => migrateKnownLighthouseDeviceId(id) ?? id) as string[]
+      ),
+    ];
+  }
+  Object.values(value).forEach(migrateSelectedDeviceIds);
+}
 
 export function migrateAutomationConfigs(data: any): AutomationConfigs {
   let currentVersion = data.version || 0;

--- a/src-ui/app/migrations/device-manager.migrations.ts
+++ b/src-ui/app/migrations/device-manager.migrations.ts
@@ -22,7 +22,7 @@ function from1to2(data: any): any {
       continue;
     }
     existing.nickname = existing.nickname ?? device.nickname;
-    existing.tagIds = existing.tagIds?.length ? existing.tagIds : (device.tagIds ?? []);
+    existing.tagIds = [...new Set([...(existing.tagIds ?? []), ...(device.tagIds ?? [])])];
     existing.disabled = existing.disabled || device.disabled;
     existing.lastSeen = Math.max(existing.lastSeen ?? 0, device.lastSeen ?? 0);
   }

--- a/src-ui/app/migrations/device-manager.migrations.ts
+++ b/src-ui/app/migrations/device-manager.migrations.ts
@@ -3,10 +3,32 @@ import { error, info } from '@tauri-apps/plugin-log';
 import { DEVICE_MANAGER_DATA_DEFAULT, DeviceManagerData } from '../models/device-manager';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { message } from '@tauri-apps/plugin-dialog';
+import { migrateKnownLighthouseDeviceId } from './lighthouse-device-id';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
+  2: from1to2,
 };
+
+function from1to2(data: any): any {
+  data.version = 2;
+  const knownDevices: any[] = [];
+  for (const device of data.knownDevices ?? []) {
+    device.id = migrateKnownLighthouseDeviceId(device.id) ?? device.id;
+    // Both id formats can be present for one device, each with its own entry
+    const existing = knownDevices.find((d) => d.id === device.id);
+    if (!existing) {
+      knownDevices.push(device);
+      continue;
+    }
+    existing.nickname = existing.nickname ?? device.nickname;
+    existing.tagIds = existing.tagIds?.length ? existing.tagIds : (device.tagIds ?? []);
+    existing.disabled = existing.disabled || device.disabled;
+    existing.lastSeen = Math.max(existing.lastSeen ?? 0, device.lastSeen ?? 0);
+  }
+  data.knownDevices = knownDevices;
+  return data;
+}
 
 export function migrateDeviceManagerData(data: any): DeviceManagerData {
   let currentVersion = data.version || 0;

--- a/src-ui/app/migrations/lighthouse-device-id.ts
+++ b/src-ui/app/migrations/lighthouse-device-id.ts
@@ -1,5 +1,3 @@
-// Superseded ids are the Windows device path, `BluetoothLE#BluetoothLE<adapter mac>-<device mac>`.
-// Current ids are the base station's own MAC address.
 const LIGHTHOUSE_ID_PATTERN =
   /^BluetoothLE#BluetoothLE[0-9a-f]{2}(?::[0-9a-f]{2}){5}-([0-9a-f]{2}(?::[0-9a-f]{2}){5})$/i;
 const KNOWN_DEVICE_ID_PATTERN = /^(LH_[A-Za-z0-9]+_)(.+)$/;
@@ -12,10 +10,7 @@ export function migrateLighthouseDeviceId(id: string): string | null {
   return match ? match[1].toUpperCase() : null;
 }
 
-/**
- * Same as {@link migrateLighthouseDeviceId}, for the `LH_<type>_<device id>` ids the device manager
- * keeps for known devices.
- */
+/** Same as {@link migrateLighthouseDeviceId}, for the device manager's `LH_<type>_<device id>` ids. */
 export function migrateKnownLighthouseDeviceId(id: string): string | null {
   const match = KNOWN_DEVICE_ID_PATTERN.exec(id);
   if (!match) return null;

--- a/src-ui/app/migrations/lighthouse-device-id.ts
+++ b/src-ui/app/migrations/lighthouse-device-id.ts
@@ -1,0 +1,24 @@
+// Superseded ids are the Windows device path, `BluetoothLE#BluetoothLE<adapter mac>-<device mac>`.
+// Current ids are the base station's own MAC address.
+const LIGHTHOUSE_ID_PATTERN =
+  /^BluetoothLE#BluetoothLE[0-9a-f]{2}(?::[0-9a-f]{2}){5}-([0-9a-f]{2}(?::[0-9a-f]{2}){5})$/i;
+const KNOWN_DEVICE_ID_PATTERN = /^(LH_[A-Za-z0-9]+_)(.+)$/;
+
+/**
+ * Returns null when the id is already in the current format, or is not a Windows base station id.
+ */
+export function migrateLighthouseDeviceId(id: string): string | null {
+  const match = LIGHTHOUSE_ID_PATTERN.exec(id);
+  return match ? match[1].toUpperCase() : null;
+}
+
+/**
+ * Same as {@link migrateLighthouseDeviceId}, for the `LH_<type>_<device id>` ids the device manager
+ * keeps for known devices.
+ */
+export function migrateKnownLighthouseDeviceId(id: string): string | null {
+  const match = KNOWN_DEVICE_ID_PATTERN.exec(id);
+  if (!match) return null;
+  const deviceId = migrateLighthouseDeviceId(match[2]);
+  return deviceId ? match[1] + deviceId : null;
+}

--- a/src-ui/app/models/automations.ts
+++ b/src-ui/app/models/automations.ts
@@ -49,7 +49,7 @@ export type AutomationType =
   | 'RUN_AUTOMATIONS';
 
 export interface AutomationConfigs {
-  version: 18;
+  version: 19;
   // CORE SLEEP FUNCTIONALITY
   SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR: SleepModeEnableForSleepDetectorAutomationConfig;
   SLEEP_MODE_ENABLE_AT_TIME: SleepModeEnableAtTimeAutomationConfig;
@@ -517,7 +517,7 @@ export interface RunAutomationsConfig extends AutomationConfig {
 //
 
 export const AUTOMATION_CONFIGS_DEFAULT: AutomationConfigs = {
-  version: 18,
+  version: 19,
   // CORE SLEEP FUNCTIONALITY
   SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR: {
     enabled: false,

--- a/src-ui/app/models/device-manager.ts
+++ b/src-ui/app/models/device-manager.ts
@@ -5,7 +5,7 @@ export interface DeviceSelection {
 }
 
 export interface DeviceManagerData {
-  version: 1;
+  version: 2;
   knownDevices: DMKnownDevice[];
   tags: DMDeviceTag[];
 }
@@ -31,7 +31,7 @@ export interface DMDeviceTag {
 }
 
 export const DEVICE_MANAGER_DATA_DEFAULT: DeviceManagerData = {
-  version: 1,
+  version: 2,
   knownDevices: [],
   tags: [],
 };

--- a/src-ui/app/models/settings.ts
+++ b/src-ui/app/models/settings.ts
@@ -4,7 +4,7 @@ import { OneTimeFlag } from './one-time-flags';
 import { EventLogType } from './event-log-entry';
 
 export interface AppSettings {
-  version: 10;
+  version: 11;
   // General Settings
   userLanguage: string;
   userLanguagePicked: boolean;
@@ -94,7 +94,7 @@ export const NotificationTypes = [
 export type NotificationType = (typeof NotificationTypes)[number];
 
 export const APP_SETTINGS_DEFAULT: AppSettings = {
-  version: 10,
+  version: 11,
   // General Settings
   userLanguage: 'en',
   userLanguagePicked: false,

--- a/src-ui/app/services/openvr.service.ts
+++ b/src-ui/app/services/openvr.service.ts
@@ -41,6 +41,7 @@ export class OpenVRService {
   ) {}
 
   async init() {
+    let statusReceived = false;
     this._status.next(await invoke<OpenVRStatus>('openvr_status'));
     this.appSettings.settings
       .pipe(
@@ -58,7 +59,10 @@ export class OpenVRService {
       listen<DeviceUpdateEvent>('OVR_DEVICE_UPDATE', (event) =>
         this.onDeviceUpdate(event.payload.device)
       ),
-      listen<OpenVRStatus>('OVR_STATUS_UPDATE', (event) => this.onStatusUpdate(event.payload)),
+      listen<OpenVRStatus>('OVR_STATUS_UPDATE', (event) => {
+        statusReceived = true;
+        this.onStatusUpdate(event.payload);
+      }),
       listen<any>('OVR_POSE_UPDATE', (event) => {
         const poses = structuredClone(this._devicePoses.value);
         const {
@@ -75,6 +79,9 @@ export class OpenVRService {
         this.appRef.tick();
       }),
     ]);
+    // A status update sent while the listener above was still being registered is never delivered
+    const status = await invoke<OpenVRStatus>('openvr_status');
+    if (!statusReceived) this._status.next(status);
 
     this.handleTelemetry();
   }

--- a/src-ui/app/services/openvr.service.ts
+++ b/src-ui/app/services/openvr.service.ts
@@ -81,7 +81,7 @@ export class OpenVRService {
     ]);
     // A status update sent while the listener above was still being registered is never delivered
     const status = await invoke<OpenVRStatus>('openvr_status');
-    if (!statusReceived) this._status.next(status);
+    if (!statusReceived) this.onStatusUpdate(status);
 
     this.handleTelemetry();
   }

--- a/src-ui/app/services/power-automations/oyasumivr-steamvr-device-power-automations.service.ts
+++ b/src-ui/app/services/power-automations/oyasumivr-steamvr-device-power-automations.service.ts
@@ -167,7 +167,6 @@ export class OyasumiVRSteamVRDevicePowerAutomationsService {
         await this.lighthouse.setPowerState(device, 'on');
       }
     } else if (!turnOnAtStart) {
-      // Turning devices on at startup takes precedence over turning them off for a stopped SteamVR
       const applicableDevices = this.deviceManager.getDevicesForSelection(
         this.config.turnOffDevicesOnSteamVRStop
       );

--- a/src-ui/app/services/power-automations/oyasumivr-steamvr-device-power-automations.service.ts
+++ b/src-ui/app/services/power-automations/oyasumivr-steamvr-device-power-automations.service.ts
@@ -139,6 +139,11 @@ export class OyasumiVRSteamVRDevicePowerAutomationsService {
     this.seenLighthouseIds.add(device.id);
     let lighthouseStateChanged = false;
 
+    const turnOnAtStartDevices = await this.deviceManager.getDevicesForSelection(
+      this.config.turnOnDevicesOnOyasumiStart
+    );
+    const turnOnAtStart = turnOnAtStartDevices.lighthouseDevices.some((d) => d.id === device.id);
+
     // Handle SteamVR status based changesz
     const steamVRActive = (await firstValueFrom(this.openvr.status)) === 'INITIALIZED';
     if (steamVRActive) {
@@ -161,7 +166,8 @@ export class OyasumiVRSteamVRDevicePowerAutomationsService {
         } as EventLogLighthouseSetPowerState);
         await this.lighthouse.setPowerState(device, 'on');
       }
-    } else {
+    } else if (!turnOnAtStart) {
+      // Turning devices on at startup takes precedence over turning them off for a stopped SteamVR
       const applicableDevices = this.deviceManager.getDevicesForSelection(
         this.config.turnOffDevicesOnSteamVRStop
       );
@@ -188,16 +194,9 @@ export class OyasumiVRSteamVRDevicePowerAutomationsService {
     // If the lighthouse state was already changed, we don't need to do anything else.
     if (lighthouseStateChanged) return;
 
-    const applicableDevices = await this.deviceManager.getDevicesForSelection(
-      this.config.turnOnDevicesOnOyasumiStart
-    );
-    const isLighthouseApplicable = applicableDevices.lighthouseDevices.some(
-      (d) => d.id === device.id
-    );
     const shouldPowerOn =
-      isLighthouseApplicable && (device.powerState === 'sleep' || device.powerState === 'standby');
+      turnOnAtStart && (device.powerState === 'sleep' || device.powerState === 'standby');
     if (shouldPowerOn) {
-      lighthouseStateChanged = true;
       this.eventLog.logEvent({
         type: 'lighthouseSetPowerState',
         reason: 'OYASUMI_START',


### PR DESCRIPTION
Moves the lighthouse base station integration from `bluest` to `btleplug`.

`btleplug` closes the WinRT device and its services in `impl Drop for BLEDevice`, and creates a
device object only in `connect()` rather than per advertisement. It also builds on `windows 0.62`,
which Tauri already pulls in, so the duplicate `windows 0.48` codegen goes away.

## What changed

Most of it is `src-core/src/lighthouse/mod.rs`. The Tauri commands, the event names, the payloads,
and the V1 and V2 power state encoding are unchanged.

`btleplug` requires explicit `connect()` and `disconnect()` where Windows used to manage the
connection implicitly. That is where the substance of this port is:

- Base stations are filtered by advertised `local_name` before connecting, so other Bluetooth
  devices are never connected at all.
- A per device lock serialises operations. A reconnect closes the GATT handles another task may be
  reading through, which surfaces as `HRESULT(0x80000013) "The object has been closed"`.
- A reconnect disconnects first. `discover_services()` skips services already in btleplug's cache,
  and only `disconnect()` clears it, so without this the reconnect reuses closed handles.
- A failed read or write, a service discovery that fails after connecting, and a missing service or
  characteristic all drop the connection. btleplug otherwise keeps reporting the peripheral as
  connected with an empty or incomplete service cache, which wedges the device until a reset.
- Each scan window lists the adapter again and scans on that. btleplug registers an advertisement
  handler per `start_scan` call and never removes it, so reusing one adapter accumulates handlers
  and floods a 16 slot broadcast channel whose overflow is dropped silently.
- A device that advertises but refuses connections is retried at most once every 10 seconds instead
  of on every advertisement.

## Startup precedence

Second commit. When a base station is covered by both "turn on when OyasumiVR starts" and "turn off
when SteamVR stops", starting OyasumiVR while SteamVR is not running turned it off, because the
handler for newly discovered devices applied the SteamVR status first. The user enabled the start
automation, so the device is now left on. The SteamVR status still decides for devices the start
automation does not cover, and on an actual SteamVR start or stop while OyasumiVR is running.

## Migration

Device ids change from the Windows device path
(`BluetoothLE#BluetoothLE<adapter mac>-<device mac>`) to the base station's own MAC address. Three
stores key off that id, so three migrations run: app settings 10 to 11 rekeys
`v1LighthouseIdentifiers`, device manager 1 to 2 rewrites `knownDevices[].id` and merges any
duplicate entries, and automation configs 18 to 19 rewrites the ids in every `DeviceSelection`.
Without these, V1 power control silently stops working and every base station reappears as a new
device with no nickname, tags or automations.

## What a reviewer should check

- The scan lifecycle in `start_scan` and `scan_for_devices`, in particular that listing the adapter
  per window is an acceptable cost for avoiding the handler leak.
- The duplicate merge rule in the device manager migration, which unions tags and keeps the newest
  `lastSeen`.
- The startup precedence, which only changes the case where both automations cover one device.

## Testing

Tested against three V2 base stations on Windows 11.

- Discovery of all three per run, across many app restarts.
- Power off and on confirmed by reading the state back, including two stations driven at once so the
  per device locks were exercised.
- A station that dropped out reconnected on its own and then accepted a write and a read.
- Every SteamVR automation path: stop, start, and starting OyasumiVR while SteamVR was already
  running or already stopped. A control run with OyasumiVR closed confirmed SteamVR was not driving
  the base stations itself, so the results are attributable to OyasumiVR.
- The startup precedence in all three states: covered and already on, covered and asleep, and not
  covered.
- The migrations against a real settings store with six base stations. Nine known device entries
  collapsed to the correct six, the other 35 known devices were untouched, no old format id
  remained, and rediscovery afterwards matched the migrated entries instead of creating new ones.

Not covered: V1 base stations, and the `DeviceSelection` migration, because the store used for
testing selects by device type rather than by individual device. Both go through the same id
transform, which is covered by the real and edge case ids.

## Not included

Both bluest and btleplug scan with a `BluetoothLEAdvertisementWatcher`, which can miss base stations
that the user has paired in Windows Bluetooth settings. Handling those is separate work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Lighthouse Bluetooth discovery, connections, power control, and recovery.
  - Added automatic migration for legacy Lighthouse identifiers across settings, automations, and device data.

- **Bug Fixes**
  - Fixed Windows Bluetooth memory leakage.
  - Improved base-station recovery after temporary Bluetooth disconnection.
  - Ensured OyasumiVR startup power-on automation takes precedence over SteamVR stop actions.
  - Improved SteamVR status initialization reliability.

- **Compatibility**
  - Existing Lighthouse configurations and known devices are updated automatically while preserving supported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->