### PR TITLE
Trigger player-count status automation on sleep mode changes

### DIFF
--- a/src-ui/app/services/status-automations/status-change-for-player-count-automation.service.ts
+++ b/src-ui/app/services/status-automations/status-change-for-player-count-automation.service.ts
@@ -31,7 +31,6 @@ export class StatusChangeForPlayerCountAutomationService {
   private config: ChangeStatusBasedOnPlayerCountAutomationConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.CHANGE_STATUS_BASED_ON_PLAYER_COUNT
   );
-  private sleepMode = false;
 
   constructor(
     private vrchat: VRChatService,
@@ -47,7 +46,6 @@ export class StatusChangeForPlayerCountAutomationService {
     this.automationConfig.configs.subscribe((configs) => {
       this.config = structuredClone(configs.CHANGE_STATUS_BASED_ON_PLAYER_COUNT);
     });
-    this.sleep.mode.subscribe((mode) => (this.sleepMode = mode));
 
     combineLatest([
       // React to player count changes
@@ -65,12 +63,13 @@ export class StatusChangeForPlayerCountAutomationService {
         distinctUntilChanged((a, b) => isEqual(a, b)),
         delay(100)
       ),
+      this.sleep.mode.pipe(distinctUntilChanged()),
     ])
       .pipe(
         // Automation must be enabled
         filter(() => this.config.enabled),
         // Sleep mode condition must be met or disabled
-        filter(() => this.sleepMode || !this.config.onlyIfSleepModeEnabled),
+        filter(([, , , sleepMode]) => sleepMode || !this.config.onlyIfSleepModeEnabled),
         // User must be currently online
         filter(([, user]) => !!user && user.status !== UserStatus.Offline),
         // Determine the new status


### PR DESCRIPTION
## Summary

- Re-evaluate the player-count status automation when sleep mode changes.
- Remove the redundant cached sleep-mode field and subscription.

## Root cause

Sleep mode was only read as a filter condition. Toggling it did not emit through the automation pipeline, so an existing player count was not checked until another source changed.

The player-count automation now includes sleep mode in its trigger sources. Enabling sleep mode immediately checks the current player count.

## Validation

- `npx eslint src-ui/app/services/status-automations/status-change-for-player-count-automation.service.ts`
- `npx ng build oyasumivr`

Fixes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status automation handling when sleep mode changes.
  * Prevented duplicate sleep-mode updates from triggering unnecessary automation processing.
  * Ensured player-count automations consistently use the current sleep-mode state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->