### PR TITLE
Limit developer tools and make console output opt in

### DIFF
--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -126,7 +126,7 @@ rev = "47c00b5fab8d7a45ba3254873ca7886f84483560"
 
 [dependencies.tauri]
 version = "2.11.5"
-features = ["devtools", "tray-icon"]
+features = ["tray-icon"]
 
 [build-dependencies]
 reqwest = { version = "0.13.4", features = ["blocking"] }

--- a/src-core/src/commands/debug.rs
+++ b/src-core/src/commands/debug.rs
@@ -1,8 +1,15 @@
+#[cfg(debug_assertions)]
 use tauri::Manager;
 
 #[tauri::command]
-pub async fn open_dev_tools(app_handle: tauri::AppHandle) {
-    app_handle
+pub fn dev_tools_available() -> bool {
+    cfg!(debug_assertions)
+}
+
+#[tauri::command]
+pub async fn open_dev_tools(_app_handle: tauri::AppHandle) {
+    #[cfg(debug_assertions)]
+    _app_handle
         .get_webview_window("main")
         .unwrap()
         .open_devtools();

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -211,11 +211,6 @@ async fn app_setup(app_handle: tauri::AppHandle) {
     // Set up app reference
     *TAURI_APP_HANDLE.lock().await = Some(app_handle.clone());
     let window = app_handle.get_webview_window("main").unwrap();
-    // Open devtools if we're in debug mode
-    #[cfg(debug_assertions)]
-    {
-        window.open_devtools();
-    }
     // Disable swipe navigation in main window
     window
         .with_webview(|webview| unsafe {
@@ -385,6 +380,7 @@ fn configure_command_handlers() -> impl Fn(tauri::ipc::Invoke) -> bool {
         commands::nvml::nvml_status,
         commands::nvml::nvml_get_devices,
         commands::nvml::nvml_set_power_management_limit,
+        commands::debug::dev_tools_available,
         commands::debug::open_dev_tools,
         cn_compliance::cn_compliance_mode,
         commands::time::get_sunrise_sunset_time,

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -42,13 +42,6 @@ use crate::globals::APTABASE_HOST;
 
 #[tokio::main]
 async fn main() {
-    #[cfg(windows)]
-    if std::env::args_os().any(|arg| arg == "--console") {
-        use windows::Win32::System::Console::{AllocConsole, AttachConsole, ATTACH_PARENT_PROCESS};
-        if unsafe { AttachConsole(ATTACH_PARENT_PROCESS) }.is_err() {
-            let _ = unsafe { AllocConsole() };
-        }
-    }
     // Construct OyasumiVR Tauri application
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -69,6 +62,10 @@ async fn main() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(configure_tauri_plugin_aptabase())
         .setup(|app| {
+            #[cfg(windows)]
+            if std::env::args_os().any(|arg| arg == "--console") {
+                open_console();
+            }
             let matches = match app.cli().matches() {
                 Ok(matches) => Some(matches),
                 Err(e) => {
@@ -97,8 +94,20 @@ async fn main() {
         .expect("An error occurred while running the application")
 }
 
+#[cfg(windows)]
+fn open_console() {
+    use windows::Win32::System::Console::{AllocConsole, AttachConsole, ATTACH_PARENT_PROCESS};
+    if unsafe { AttachConsole(ATTACH_PARENT_PROCESS) }.is_err() {
+        let _ = unsafe { AllocConsole() };
+    }
+}
+
 fn configure_tauri_plugin_single_instance() -> TauriPlugin<Wry> {
     tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        #[cfg(windows)]
+        if _argv.iter().any(|arg| arg == "--console") {
+            open_console();
+        }
         // Focus main window when user attempts to launch a second instance.
         let window = app.get_webview_window("main").unwrap();
         if let Ok(is_visible) = window.is_visible() {

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![windows_subsystem = "windows"]
 
 mod cn_compliance;
 mod commands;
@@ -42,11 +42,12 @@ use crate::globals::APTABASE_HOST;
 
 #[tokio::main]
 async fn main() {
-    // Attach to parent console if we're running from a command line
     #[cfg(windows)]
-    {
-        use windows::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
-        let _ = unsafe { AttachConsole(ATTACH_PARENT_PROCESS) };
+    if std::env::args_os().any(|arg| arg == "--console") {
+        use windows::Win32::System::Console::{AllocConsole, AttachConsole, ATTACH_PARENT_PROCESS};
+        if unsafe { AttachConsole(ATTACH_PARENT_PROCESS) }.is_err() {
+            let _ = unsafe { AllocConsole() };
+        }
     }
     // Construct OyasumiVR Tauri application
     tauri::Builder::default()

--- a/src-core/tauri.conf.json
+++ b/src-core/tauri.conf.json
@@ -73,6 +73,10 @@
       "description": "OyasumiVR - VR Sleep Utilities",
       "args": [
         {
+          "name": "console",
+          "description": "Opens a console window for log output"
+        },
+        {
           "name": "dont-need-security-where-im-going-uwu",
           "description": "Permanently enables the main process to run with administrative privileges",
           "longDescription": "WARNING: Enabling this has significant security risks!\n\nLaunching OyasumiVR with this flag will allow OyasumiVR to be ran as administrator from then on. Requires OyasumiVR.exe to be run with administrative privileges. This action can be undone by running the application again with the --reset-elevation-security flag.\n\nMore information can be found at https://raphii.co/oyasumivr/hidden/troubleshooting/launch-as-admin"

--- a/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.html
@@ -203,17 +203,19 @@
               </button>
             </div>
           </div>
-          <div class="setting-row">
-            <div class="setting-row-label">
-              <span transloco="settings.advanced.troubleshooting.devTools.title"></span>
-              <span transloco="settings.advanced.troubleshooting.devTools.description"></span>
+          @if (devToolsAvailable | async) {
+            <div class="setting-row">
+              <div class="setting-row-label">
+                <span transloco="settings.advanced.troubleshooting.devTools.title"></span>
+                <span transloco="settings.advanced.troubleshooting.devTools.description"></span>
+              </div>
+              <div class="setting-row-action">
+                <button class="btn btn-primary" (click)="openDevTools()">
+                  <span transloco="settings.advanced.troubleshooting.devTools.action"></span>
+                </button>
+              </div>
             </div>
-            <div class="setting-row-action">
-              <button class="btn btn-primary" (click)="openDevTools()">
-                <span transloco="settings.advanced.troubleshooting.devTools.action"></span>
-              </button>
-            </div>
-          </div>
+          }
         </div>
       </div>
     </div>

--- a/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-advanced-view/settings-advanced-view.component.ts
@@ -57,6 +57,7 @@ export class SettingsAdvancedViewComponent {
   ];
   checkedPersistentStorageItems: string[] = [];
   memoryWatcherActive = FLAVOUR === 'DEV';
+  devToolsAvailable = invoke<boolean>('dev_tools_available');
   overlayGpuAcceleration = true;
   openVrInitDelayFix = false;
   lighthousePowerOffDelay = false;


### PR DESCRIPTION
## Summary

- Stop opening developer tools automatically at startup.
- Compile developer tools only in debug builds.
- Hide the troubleshooting option in release builds.
- Prevent debug builds from opening a console unless `--console` is passed.

## Why

The startup call was limited to debug builds, but the Tauri `devtools` feature also enabled developer tools in release builds. Steam beta builds use the debug profile, so they retain the settings button and WebView2 shortcuts.

Rust used the default console subsystem for debug builds, which caused Windows to open a console on every beta launch. The app now uses the Windows GUI subsystem in every profile and attaches or allocates a console only when `--console` is present.

## User impact

Release builds no longer expose developer tools or show the troubleshooting option. Steam beta keeps developer tools but no longer opens a console by default. Developers can launch `OyasumiVR.exe --console` when they need console output.

## Checks

- `cargo check --quiet`
- `cargo check --release --quiet`
- `cargo build --quiet`
- Verified the debug executable uses PE subsystem 2, Windows GUI
- `npm run ng -- build oyasumivr --configuration development --output-path .t3-tmp/devtools-ui`
- Prettier check for the changed Angular files
- Targeted Rustfmt check for the changed Rust files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `--console` launch option to open a console window for log output.
  - Developer tools now appear in troubleshooting settings only when available.

- **Bug Fixes**
  - Developer tools no longer open automatically when the app starts.
  - Production builds no longer expose unavailable developer-tools functionality.
  - Windows builds now attach to or allocate a console only when explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->