### PR TITLE
Report VRChat pipeline failures to Sentry

### DIFF
--- a/src-ui/app/services/error-reporting.service.ts
+++ b/src-ui/app/services/error-reporting.service.ts
@@ -28,6 +28,10 @@ export class ErrorReportingService {
     return this.update;
   }
 
+  captureException(error: Error): void {
+    if (this.active) Sentry.captureException(error);
+  }
+
   private async setEnabled(consented: boolean) {
     const enabled = consented && environment.production && FLAVOUR !== 'DEV';
     if (enabled === this.active) return;

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -876,6 +876,6 @@ export class VRChatAPI {
 
 function requestFailure(message: string, cause: unknown): Error {
   if (cause instanceof Response) return new Error(`${message}: HTTP ${cause.status}`);
-  if (cause instanceof Error) return new Error(`${message}: ${cause.name}: ${cause.message}`);
+  if (cause instanceof Error) return new Error(message);
   return new Error(`${message}: unknown error`);
 }

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -876,6 +876,6 @@ export class VRChatAPI {
 
 function requestFailure(message: string, cause: unknown): Error {
   if (cause instanceof Response) return new Error(`${message}: HTTP ${cause.status}`);
-  if (cause instanceof Error) return new Error(`${message}: ${cause.name}`);
+  if (cause instanceof Error) return new Error(`${message}: ${cause.name}: ${cause.message}`);
   return new Error(`${message}: unknown error`);
 }

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -172,7 +172,8 @@ export class VRChatAPI {
 
   constructor(
     private readonly settings: Observable<VRChatApiSettings>,
-    private readonly updateSettings: (settings: Partial<VRChatApiSettings>) => Promise<void>
+    private readonly updateSettings: (settings: Partial<VRChatApiSettings>) => Promise<void>,
+    private readonly reportError: (cause: Error) => void
   ) {}
 
   public async init(
@@ -438,7 +439,9 @@ export class VRChatAPI {
       });
       this.requireSuccessfulResponse(result);
     } catch (e) {
-      error(`[VRChat] Failed to invite user: ${JSON.stringify(e)}`);
+      const failure = requestFailure('VRChat invite request failed', e);
+      error(`[VRChat] ${failure.message}`);
+      this.reportError(failure);
       throw e;
     }
   }
@@ -869,4 +872,10 @@ export class VRChatAPI {
     await this.trackWrite(this.updateSettings(settings));
     this.ensureCacheGeneration(cacheGeneration);
   }
+}
+
+function requestFailure(message: string, cause: unknown): Error {
+  if (cause instanceof Response) return new Error(`${message}: HTTP ${cause.status}`);
+  if (cause instanceof Error) return new Error(`${message}: ${cause.name}`);
+  return new Error(`${message}: unknown error`);
 }

--- a/src-ui/app/services/vrchat-api/vrchat-socket.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-socket.ts
@@ -40,7 +40,6 @@ export class VRChatSocket {
   private readonly handlers: VRChatEventHandler[];
   private socket?: WebSocket;
   private openedAt?: number;
-  private receivedMessage = false;
   private socketError = false;
   private consecutiveFailures = 0;
   /** Changes whenever pending socket work must be discarded. */
@@ -112,7 +111,6 @@ export class VRChatSocket {
     }
     this.socket = socket;
     this.openedAt = undefined;
-    this.receivedMessage = false;
     this.socketError = false;
     socket.onopen = () => this.handleOpen(socket);
     socket.onerror = () => this.handleError(socket);
@@ -143,8 +141,7 @@ export class VRChatSocket {
   private handleClose(socket: WebSocket, event: CloseEvent): void {
     if (this.socket !== socket) return;
     const lifetime = this.openedAt === undefined ? undefined : Date.now() - this.openedAt;
-    const failedBeforeHealthy =
-      !this.receivedMessage && (lifetime === undefined || lifetime < HEALTHY_CONNECTION_DURATION);
+    const failedBeforeHealthy = lifetime === undefined || lifetime < HEALTHY_CONNECTION_DURATION;
     this.consecutiveFailures = failedBeforeHealthy ? this.consecutiveFailures + 1 : 0;
     this.socket = undefined;
     this.statusSubject.next('CLOSED');
@@ -170,8 +167,6 @@ export class VRChatSocket {
 
   private handleMessage(socket: WebSocket, message: MessageEvent): void {
     if (this.socket !== socket) return;
-    this.receivedMessage = true;
-    this.consecutiveFailures = 0;
 
     let data: VRChatPipelineMessage;
     try {

--- a/src-ui/app/services/vrchat-api/vrchat-socket.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-socket.ts
@@ -170,7 +170,18 @@ export class VRChatSocket {
 
     let data: VRChatPipelineMessage;
     try {
-      data = JSON.parse(String(message.data)) as VRChatPipelineMessage;
+      const parsed: unknown = JSON.parse(String(message.data));
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        !('type' in parsed) ||
+        typeof parsed.type !== 'string' ||
+        !('content' in parsed) ||
+        typeof parsed.content !== 'string'
+      ) {
+        throw new Error('Invalid VRChat pipeline message');
+      }
+      data = { type: parsed.type, content: parsed.content };
     } catch (cause) {
       error(`[VRChat] Failed to parse websocket message: ${cause}`);
       this.reportError(new Error('VRChat pipeline message parsing failed'));

--- a/src-ui/app/services/vrchat-api/vrchat-socket.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-socket.ts
@@ -19,6 +19,8 @@ import { VRChatAPI } from './vrchat-api';
 import { VRChatAuth } from './vrchat-auth';
 
 const RECONNECT_INTERVAL = 10_000;
+const HEALTHY_CONNECTION_DURATION = 30_000;
+const FAILURE_REPORT_THRESHOLD = 3;
 
 export type VRChatSocketStatus = 'CLOSED' | 'OPEN' | 'OPENING';
 
@@ -37,6 +39,10 @@ export class VRChatSocket {
   private readonly notificationSubject = new Subject<Notification>();
   private readonly handlers: VRChatEventHandler[];
   private socket?: WebSocket;
+  private openedAt?: number;
+  private receivedMessage = false;
+  private socketError = false;
+  private consecutiveFailures = 0;
   /** Changes whenever pending socket work must be discarded. */
   private connectionGeneration = 0;
 
@@ -46,7 +52,8 @@ export class VRChatSocket {
   constructor(
     private readonly auth: VRChatAuth,
     private readonly api: VRChatAPI,
-    private readonly settings: Observable<VRChatApiSettings>
+    private readonly settings: Observable<VRChatApiSettings>,
+    private readonly reportError: (cause: Error) => void
   ) {
     this.handlers = [
       new UserUpdateHandler(this.auth),
@@ -60,6 +67,7 @@ export class VRChatSocket {
       if (status === 'LOGGED_IN') {
         void this.openSocket();
       } else if (status === 'LOGGED_OUT') {
+        this.consecutiveFailures = 0;
         this.closeSocket();
       }
     });
@@ -103,9 +111,12 @@ export class VRChatSocket {
       return;
     }
     this.socket = socket;
+    this.openedAt = undefined;
+    this.receivedMessage = false;
+    this.socketError = false;
     socket.onopen = () => this.handleOpen(socket);
     socket.onerror = () => this.handleError(socket);
-    socket.onclose = () => this.handleClose(socket);
+    socket.onclose = (event) => this.handleClose(socket, event);
     socket.onmessage = (message) => this.handleMessage(socket, message);
   }
 
@@ -124,31 +135,50 @@ export class VRChatSocket {
 
   private handleOpen(socket: WebSocket): void {
     if (this.socket !== socket) return;
+    this.openedAt = Date.now();
     this.statusSubject.next('OPEN');
     info('[VRChat] Websocket connection opened');
   }
 
-  private handleClose(socket: WebSocket): void {
+  private handleClose(socket: WebSocket, event: CloseEvent): void {
     if (this.socket !== socket) return;
+    const lifetime = this.openedAt === undefined ? undefined : Date.now() - this.openedAt;
+    const failedBeforeHealthy =
+      !this.receivedMessage && (lifetime === undefined || lifetime < HEALTHY_CONNECTION_DURATION);
+    this.consecutiveFailures = failedBeforeHealthy ? this.consecutiveFailures + 1 : 0;
     this.socket = undefined;
     this.statusSubject.next('CLOSED');
-    info('[VRChat] Websocket connection closed');
+    const reason = event.reason.trim().replace(/\s+/g, ' ').slice(0, 120) || 'none';
+    const lifetimeBucket = socketLifetimeBucket(lifetime);
+    info(
+      `[VRChat] Websocket connection closed: code=${event.code} clean=${event.wasClean} lifetime=${lifetimeBucket} error=${this.socketError} reason=${reason}`
+    );
+    if (this.consecutiveFailures === FAILURE_REPORT_THRESHOLD) {
+      this.reportError(
+        new Error(
+          `VRChat pipeline repeatedly closed: code=${event.code} clean=${event.wasClean} lifetime=${lifetimeBucket} error=${this.socketError} reason=${reason}`
+        )
+      );
+    }
   }
 
   private handleError(socket: WebSocket): void {
     if (this.socket !== socket) return;
+    this.socketError = true;
     error('[VRChat] Websocket connection error');
-    this.closeSocket();
   }
 
   private handleMessage(socket: WebSocket, message: MessageEvent): void {
     if (this.socket !== socket) return;
+    this.receivedMessage = true;
+    this.consecutiveFailures = 0;
 
     let data: VRChatPipelineMessage;
     try {
       data = JSON.parse(String(message.data)) as VRChatPipelineMessage;
     } catch (cause) {
       error(`[VRChat] Failed to parse websocket message: ${cause}`);
+      this.reportError(new Error('VRChat pipeline message parsing failed'));
       return;
     }
 
@@ -156,15 +186,28 @@ export class VRChatSocket {
     if (!handler) return;
     try {
       void Promise.resolve(handler.handle(data.content)).catch((cause) =>
-        error(`[VRChat] Failed to handle websocket event '${data.type}': ${cause}`)
+        this.reportHandlerError(data.type, cause)
       );
     } catch (cause) {
-      error(`[VRChat] Failed to handle websocket event '${data.type}': ${cause}`);
+      this.reportHandlerError(data.type, cause);
     }
+  }
+
+  private reportHandlerError(type: string, cause: unknown): void {
+    error(`[VRChat] Failed to handle websocket event '${type}': ${cause}`);
+    this.reportError(new Error(`VRChat pipeline event handling failed: ${type}`));
   }
 
   private async receiveNotification(notification: Notification): Promise<void> {
     info(`[VRChat] Received notification: ${JSON.stringify(notification)}`);
     this.notificationSubject.next(notification);
   }
+}
+
+function socketLifetimeBucket(lifetime: number | undefined): string {
+  if (lifetime === undefined) return 'not-opened';
+  if (lifetime < 1_000) return 'under-1s';
+  if (lifetime < 10_000) return 'under-10s';
+  if (lifetime < HEALTHY_CONNECTION_DURATION) return 'under-30s';
+  return 'healthy';
 }

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -20,6 +20,7 @@ import type {
   VRChatOnPlayerLeftEvent,
 } from '../../models/vrchat-log-event';
 import type { VRChatSocketStatus } from './vrchat-socket';
+import { ErrorReportingService } from '../error-reporting.service';
 
 @Injectable({
   providedIn: 'root',
@@ -27,6 +28,7 @@ import type { VRChatSocketStatus } from './vrchat-socket';
 export class VRChatService {
   private readonly modalService = inject(ModalService);
   private readonly logService = inject(VRChatLogService);
+  private readonly errorReporting = inject(ErrorReportingService);
 
   private readonly settingsSubject = new BehaviorSubject<VRChatApiSettings>({
     ...VRCHAT_API_SETTINGS_DEFAULT,
@@ -54,14 +56,15 @@ export class VRChatService {
   public readonly websocketStatus: Observable<VRChatSocketStatus>;
 
   constructor() {
-    this.api = new VRChatAPI(this.settings, this.updateSettings.bind(this));
+    const reportError = (cause: Error) => this.errorReporting.captureException(cause);
+    this.api = new VRChatAPI(this.settings, this.updateSettings.bind(this), reportError);
     this.auth = new VRChatAuth(
       this.api,
       this.modalService,
       this.updateSettings.bind(this),
       this.settings
     );
-    this.socket = new VRChatSocket(this.auth, this.api, this.settings);
+    this.socket = new VRChatSocket(this.auth, this.api, this.settings, reportError);
     this.user = this.auth.user;
     this.status = this.auth.status;
     this.notifications = this.socket.notifications;


### PR DESCRIPTION
VRChat pipeline failures currently disappear into local logs, which leaves #195 with little evidence to work from. This sends the useful failure details to Sentry without sending account or message data.

- Report the close code, clean flag, lifetime bucket, error state, and server reason after three short-lived connections.
- Keep the browser's close event after `onerror` so those details survive.
- Report message parsing failures, handler failures, and failed invite HTTP status codes.

No auth tokens, account IDs, notification contents, or WebSocket payloads are sent.

Checked with ESLint, Prettier, an Angular development build, and `npm audit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invitation requests and real-time connections.
  * Added clearer reporting for connection failures, message-processing errors, and unexpected request failures.
  * Improved validation of incoming real-time messages.
  * Reduced premature reporting of transient connection issues while tracking repeated early failures.

* **Reliability**
  * Error reporting is consistently routed through the application’s reporting system when enabled.
  * Connection state and failure tracking now reset appropriately during initialization and logout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->