### PR TITLE
Prevent Tao panic after WM_ENDSESSION

### DIFF
--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -7032,8 +7032,7 @@ dependencies = [
 [[package]]
 name = "tao"
 version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
+source = "git+https://github.com/Raphiiko/tao?rev=4f87271e9fa5f1435cc1da8a92fea6955ec71682#4f87271e9fa5f1435cc1da8a92fea6955ec71682"
 dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.1",

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -135,6 +135,9 @@ tauri-build = { version = "2.6.3", features = [] }
 toml = "1.1.4"
 tonic-prost-build = { version = "0.14.6", features = [] }
 
+[patch.crates-io]
+tao = { git = "https://github.com/Raphiiko/tao", rev = "4f87271e9fa5f1435cc1da8a92fea6955ec71682" }
+
 [profile.release]
 panic = "abort"   # Strip expensive panic clean-up logic
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better


### PR DESCRIPTION
Pins a Tao 0.35.3 backport of the merged upstream WM_ENDSESSION fix. Windows could mark the event loop destroyed, return to the message loop, then panic on the next paint.\n\nThe reproduction sends WM_ENDSESSION and WM_PAINT to Tao's hidden event window. It exits with the reported panic on the released crate and exits cleanly with this backport.\n\nChecked with \cargo check --locked\ in \src-core\.