### PR TITLE
Guard the OpenVR settings interface like the overlay interface

### DIFF
--- a/src-core/src/openvr/brightness_analog.rs
+++ b/src-core/src/openvr/brightness_analog.rs
@@ -2,7 +2,7 @@ use std::ffi::CStr;
 
 use super::devices::get_devices;
 use super::models::TrackedDeviceClass;
-use super::OVR_CONTEXT;
+use super::{settings_interface_available, OVR_CONTEXT};
 use ovr_overlay as ovr;
 
 pub async fn get_analog_gain() -> Result<f32, String> {
@@ -16,6 +16,9 @@ pub async fn get_analog_gain() -> Result<f32, String> {
             Some(context) => context,
             None => return Err("OPENVR_NOT_INITIALISED".to_string()),
         };
+        if !settings_interface_available() {
+            return Err("OPENVR_NOT_INITIALISED".to_string());
+        }
         let mut settings = context.settings_mngr();
         let analog_gain = settings.get_float(
             CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
@@ -41,6 +44,9 @@ pub async fn set_analog_gain(analog_gain: f32) -> Result<(), String> {
             Some(context) => context,
             None => return Err("OPENVR_NOT_INITIALISED".to_string()),
         };
+        if !settings_interface_available() {
+            return Err("OPENVR_NOT_INITIALISED".to_string());
+        }
         let settings = &mut context.settings_mngr();
         let _ = settings.set_float(
             CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),

--- a/src-core/src/openvr/chaperone.rs
+++ b/src-core/src/openvr/chaperone.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use super::OVR_CONTEXT;
+use super::{settings_interface_available, OVR_CONTEXT};
 use ovr_overlay as ovr;
 
 pub async fn get_fade_distance() -> Result<f32, String> {
@@ -9,6 +9,9 @@ pub async fn get_fade_distance() -> Result<f32, String> {
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     let settings = &mut context.settings_mngr();
     let fade_distance = settings.get_float(
         CStr::from_bytes_with_nul(ovr::sys::k_pch_CollisionBounds_Section).unwrap(),
@@ -26,6 +29,9 @@ pub async fn set_fade_distance(fade_distance: f32) -> Result<(), String> {
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     let settings = &mut context.settings_mngr();
     let _ = settings.set_float(
         CStr::from_bytes_with_nul(ovr::sys::k_pch_CollisionBounds_Section).unwrap(),

--- a/src-core/src/openvr/colortemp_analog.rs
+++ b/src-core/src/openvr/colortemp_analog.rs
@@ -1,7 +1,9 @@
 use ovr_overlay as ovr;
 use std::ffi::CStr;
 
-use crate::openvr::{devices::get_devices, models::TrackedDeviceClass, OVR_CONTEXT};
+use crate::openvr::{
+    devices::get_devices, models::TrackedDeviceClass, settings_interface_available, OVR_CONTEXT,
+};
 
 pub async fn set_color_temp(mut temperature: Option<u32>) -> Result<(f64, f64, f64), String> {
     let devices = get_devices().await;
@@ -16,6 +18,9 @@ pub async fn set_color_temp(mut temperature: Option<u32>) -> Result<(f64, f64, f
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     if temperature.is_none() {
         temperature = Some(6600);
     }

--- a/src-core/src/openvr/framelimiter.rs
+++ b/src-core/src/openvr/framelimiter.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use super::{models::OVRFrameLimits, OVR_CONTEXT};
+use super::{models::OVRFrameLimits, settings_interface_available, OVR_CONTEXT};
 
 pub async fn set_app_framelimits(
     app_id: u32,
@@ -11,6 +11,9 @@ pub async fn set_app_framelimits(
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     let settings = &mut context.settings_mngr();
 
     let section_string = format!("steam.app.{app_id}\0");
@@ -44,6 +47,9 @@ pub async fn get_app_framelimits(app_id: u32) -> Result<Option<OVRFrameLimits>, 
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     let settings = &mut context.settings_mngr();
 
     let section_string = format!("steam.app.{app_id}\0");

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -22,7 +22,13 @@ use models::OpenVRStatus;
 use ovr::input::ActiveActionSet;
 use ovr_overlay as ovr;
 use sleep_detector::SleepDetector;
-use std::{sync::LazyLock, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        LazyLock,
+    },
+    time::Duration,
+};
 use substring::Substring;
 use tokio::sync::Mutex;
 
@@ -311,17 +317,18 @@ async fn shutdown_ovr() {
     *context = None;
 }
 
-/// Constructing an overlay manager while this is false panics. Callers must hold `OVR_CONTEXT`,
-/// or `VR_Shutdown` can invalidate the pointer between this check and the manager's construction.
+/// Constructing an overlay manager while this is false panics. Callers must hold `OVR_CONTEXT`.
 pub fn overlay_interface_available() -> bool {
     !unsafe { ovr::sys::VROverlay() }.is_null()
 }
 
-/// Constructing a settings manager while this is false panics. Callers must hold `OVR_CONTEXT`,
-/// or `VR_Shutdown` can invalidate the pointer between this check and the manager's construction.
+/// Constructing a settings manager while this is false panics. Callers must hold `OVR_CONTEXT`.
 pub fn settings_interface_available() -> bool {
+    static WARNED: AtomicBool = AtomicBool::new(false);
     let available = !unsafe { ovr::sys::VRSettings() }.is_null();
-    if !available {
+    if available {
+        WARNED.store(false, Ordering::Relaxed);
+    } else if !WARNED.swap(true, Ordering::Relaxed) {
         warn!("[Core] The OpenVR settings interface is unavailable");
     }
     available

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -316,6 +316,11 @@ pub fn overlay_interface_available() -> bool {
     !unsafe { ovr::sys::VROverlay() }.is_null()
 }
 
+/// Constructing a settings manager while this is false panics.
+pub fn settings_interface_available() -> bool {
+    !unsafe { ovr::sys::VRSettings() }.is_null()
+}
+
 async fn update_status(new_status: OpenVRStatus) {
     let mut status = OVR_STATUS.lock().await;
     *status = new_status.clone();

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use gesture_detector::GestureDetector;
-use log::{error, info};
+use log::{error, info, warn};
 use models::OpenVRStatus;
 use ovr::input::ActiveActionSet;
 use ovr_overlay as ovr;
@@ -311,14 +311,20 @@ async fn shutdown_ovr() {
     *context = None;
 }
 
-/// Constructing an overlay manager while this is false panics.
+/// Constructing an overlay manager while this is false panics. Callers must hold `OVR_CONTEXT`,
+/// or `VR_Shutdown` can invalidate the pointer between this check and the manager's construction.
 pub fn overlay_interface_available() -> bool {
     !unsafe { ovr::sys::VROverlay() }.is_null()
 }
 
-/// Constructing a settings manager while this is false panics.
+/// Constructing a settings manager while this is false panics. Callers must hold `OVR_CONTEXT`,
+/// or `VR_Shutdown` can invalidate the pointer between this check and the manager's construction.
 pub fn settings_interface_available() -> bool {
-    !unsafe { ovr::sys::VRSettings() }.is_null()
+    let available = !unsafe { ovr::sys::VRSettings() }.is_null();
+    if !available {
+        warn!("[Core] The OpenVR settings interface is unavailable");
+    }
+    available
 }
 
 async fn update_status(new_status: OpenVRStatus) {

--- a/src-core/src/openvr/supersampling.rs
+++ b/src-core/src/openvr/supersampling.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use super::OVR_CONTEXT;
+use super::{settings_interface_available, OVR_CONTEXT};
 use ovr_overlay as ovr;
 
 pub async fn get_supersample_scale() -> Result<Option<f32>, String> {
@@ -9,6 +9,9 @@ pub async fn get_supersample_scale() -> Result<Option<f32>, String> {
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     let settings = &mut context.settings_mngr();
     let supersample_manual_override = settings.get_bool(
         CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
@@ -39,6 +42,9 @@ pub async fn set_supersample_scale(supersample_scale: Option<f32>) -> Result<(),
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
+    if !settings_interface_available() {
+        return Err("OPENVR_NOT_INITIALISED".to_string());
+    }
     let settings = &mut context.settings_mngr();
     let _ = settings.set_bool(
         CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),


### PR DESCRIPTION
## What changed

`SettingsManager::new` in `ovr_overlay` unwraps the `IVRSettings` pointer (`settings.rs:14:74`), so constructing the manager while the interface is unavailable aborts the process (`panic = abort`). Crash telemetry on 25.6.12 caught this panic once in the last 30 days.

The overlay interface got `overlay_interface_available()` guards for the same hazard in #218. This PR gives the settings interface the same treatment:

- `settings_interface_available()` next to the existing overlay check in `src-core/src/openvr/mod.rs`.
- All nine `settings_mngr()` call sites now return `OPENVR_NOT_INITIALISED` when the interface is gone: brightness analog, chaperone, colour temperature analog, framelimiter, supersampling.

The main race that produced the crash on 25.6.12 (calling `VR_Shutdown` without holding `OVR_CONTEXT`) is already fixed on develop by #218. This guard covers the remaining window where the context is live but the interface lookup fails, mirroring the decision #218 made for overlays.

## What to check

- The error string `OPENVR_NOT_INITIALISED` is reused for the unavailable-interface case so the UI keeps its existing handling. Confirm that is the desired behaviour.
- The system, input and applications interfaces are deliberately left unguarded: the system interface is polled at 30Hz and never produced a crash, so there is no evidence those interfaces can go null while the context is live.

## Left out

No changes to `ovr_overlay` itself. Returning `Result` from the manager constructors would be the deeper fix, but that needs a fork revision bump and touches every manager, while this guard matches the pattern already merged for overlays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when SteamVR settings are unavailable.
  * Brightness, fade distance, color temperature, frame limiting, and supersampling operations now report that OpenVR is not initialized instead of attempting unavailable settings access.
  * Added clearer warning behavior when the settings interface is unavailable, while avoiding repeated warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->