### PR TITLE
Skip the surface paint when softbuffer rejects the window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed the app crashing during a window transition that reported an invalid window size
 - Fixed base stations being turned off when OyasumiVR was started while SteamVR was already running
 - Fixed base station control leaking memory in the Windows Bluetooth service, which could use up all
   of the system's memory

--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1662,7 +1662,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1976,7 +1976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3782,7 +3782,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3947,7 +3947,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5333,7 +5333,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5856,7 +5856,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5869,7 +5869,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5936,7 +5936,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6528,7 +6528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7538,8 +7538,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime"
 version = "2.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
+source = "git+https://github.com/Raphiiko/tauri?rev=e75f81ecb74752ee65d15c7ad7356f9e9b9738e0#e75f81ecb74752ee65d15c7ad7356f9e9b9738e0"
 dependencies = [
  "cookie",
  "dpi",
@@ -7563,8 +7562,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime-wry"
 version = "2.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
+source = "git+https://github.com/Raphiiko/tauri?rev=e75f81ecb74752ee65d15c7ad7356f9e9b9738e0#e75f81ecb74752ee65d15c7ad7356f9e9b9738e0"
 dependencies = [
  "gtk",
  "http 1.3.1",
@@ -7589,8 +7587,7 @@ dependencies = [
 [[package]]
 name = "tauri-utils"
 version = "2.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
+source = "git+https://github.com/Raphiiko/tauri?rev=e75f81ecb74752ee65d15c7ad7356f9e9b9738e0#e75f81ecb74752ee65d15c7ad7356f9e9b9738e0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -7619,7 +7616,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 0.9.8",
  "url",
  "urlpattern",
  "uuid",
@@ -7659,7 +7656,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8223,7 +8220,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8903,7 +8900,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9496,7 +9493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3782,7 +3782,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3947,7 +3947,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6528,7 +6528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7538,7 +7538,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime"
 version = "2.11.3"
-source = "git+https://github.com/Raphiiko/tauri?rev=e75f81ecb74752ee65d15c7ad7356f9e9b9738e0#e75f81ecb74752ee65d15c7ad7356f9e9b9738e0"
+source = "git+https://github.com/Raphiiko/tauri?rev=03a8ec9776ee456cdc36fd9084a3835248cf85f2#03a8ec9776ee456cdc36fd9084a3835248cf85f2"
 dependencies = [
  "cookie",
  "dpi",
@@ -7562,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime-wry"
 version = "2.11.4"
-source = "git+https://github.com/Raphiiko/tauri?rev=e75f81ecb74752ee65d15c7ad7356f9e9b9738e0#e75f81ecb74752ee65d15c7ad7356f9e9b9738e0"
+source = "git+https://github.com/Raphiiko/tauri?rev=03a8ec9776ee456cdc36fd9084a3835248cf85f2#03a8ec9776ee456cdc36fd9084a3835248cf85f2"
 dependencies = [
  "gtk",
  "http 1.3.1",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "tauri-utils"
 version = "2.9.3"
-source = "git+https://github.com/Raphiiko/tauri?rev=e75f81ecb74752ee65d15c7ad7356f9e9b9738e0#e75f81ecb74752ee65d15c7ad7356f9e9b9738e0"
+source = "git+https://github.com/Raphiiko/tauri?rev=03a8ec9776ee456cdc36fd9084a3835248cf85f2#03a8ec9776ee456cdc36fd9084a3835248cf85f2"
 dependencies = [
  "anyhow",
  "brotli",
@@ -7616,7 +7616,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 0.9.8",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -8220,7 +8220,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8900,7 +8900,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9493,7 +9493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -136,9 +136,9 @@ toml = "1.1.4"
 tonic-prost-build = { version = "0.14.6", features = [] }
 
 [patch.crates-io]
-tauri-runtime = { git = "https://github.com/Raphiiko/tauri", rev = "e75f81ecb74752ee65d15c7ad7356f9e9b9738e0" }
-tauri-runtime-wry = { git = "https://github.com/Raphiiko/tauri", rev = "e75f81ecb74752ee65d15c7ad7356f9e9b9738e0" }
-tauri-utils = { git = "https://github.com/Raphiiko/tauri", rev = "e75f81ecb74752ee65d15c7ad7356f9e9b9738e0" }
+tauri-runtime = { git = "https://github.com/Raphiiko/tauri", rev = "03a8ec9776ee456cdc36fd9084a3835248cf85f2" }
+tauri-runtime-wry = { git = "https://github.com/Raphiiko/tauri", rev = "03a8ec9776ee456cdc36fd9084a3835248cf85f2" }
+tauri-utils = { git = "https://github.com/Raphiiko/tauri", rev = "03a8ec9776ee456cdc36fd9084a3835248cf85f2" }
 
 [profile.release]
 panic = "abort"   # Strip expensive panic clean-up logic

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -135,6 +135,11 @@ tauri-build = { version = "2.6.3", features = [] }
 toml = "1.1.4"
 tonic-prost-build = { version = "0.14.6", features = [] }
 
+[patch.crates-io]
+tauri-runtime = { git = "https://github.com/Raphiiko/tauri", rev = "e75f81ecb74752ee65d15c7ad7356f9e9b9738e0" }
+tauri-runtime-wry = { git = "https://github.com/Raphiiko/tauri", rev = "e75f81ecb74752ee65d15c7ad7356f9e9b9738e0" }
+tauri-utils = { git = "https://github.com/Raphiiko/tauri", rev = "e75f81ecb74752ee65d15c7ad7356f9e9b9738e0" }
+
 [profile.release]
 panic = "abort"   # Strip expensive panic clean-up logic
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better


### PR DESCRIPTION
## What changed

Crash telemetry on 25.6.12 caught this panic once in 30 days:

```
called `Result::unwrap()` on an `Err` value: SizeOutOfRange { width: 4294967286, height: 159 }
```

`draw_surface` in tauri-runtime-wry paints the background of transparent windows through softbuffer, and it unwraps `surface.resize(width, height)`. The width 4294967286 is a wrapped negative value from `tao`'s `inner_size()`: a window mid-transition can report a transient client rect that softbuffer rejects. The height of 159 sits far below the 662 pixel minimum of the main window, so no user resize can produce it. With `panic = "abort"` this kills the process. Both app windows are `transparent: true`, so both take this path on every resize.

The unwrap is unchanged in tauri-runtime-wry 2.11.4 (the latest release) and on the `dev` branch, so there is nothing released to upgrade to.

This PR pins the tauri workspace crates to a fork revision that skips the paint when `resize` or `buffer_mut` fails and logs a warning, following the approach of the tao pin in #232:

- Fork: `Raphiiko/tauri`, branch `fix/draw-surface-size-out-of-range`, two commits on top of the `tauri-runtime-wry-v2.11.4` tag (rev `03a8ec9`). The change makes the two unwraps in `draw_surface` non-fatal.
- `tauri-runtime`, `tauri-runtime-wry` and `tauri-utils` are patched together, because the git source of one would otherwise coexist with the crates.io copies of its two workspace siblings and produce duplicate types.

## Verifying by hand

No automated test can exercise this: the bad size only appears during interactive window transitions. To verify manually, build with the pin, then minimize/restore, snap, and drag the main window between monitors with mixed DPI scaling. The window must keep painting normally, and a skipped paint (if it ever happens) appears as a `skipping surface draw` warning in the log.

## The Cargo.lock churn

Adding the three git sources let cargo re-resolve the ranges around them, so 14 dependency edges moved to other versions already present in the graph (for example `arboard` to `windows-sys 0.52.0`, `tauri-utils` to `toml 0.9.8`). The published crates and the fork carry the same requirements; the set of resolved versions before and after is unchanged, and `cargo clippy -- -D warnings` is clean.

## Merge notes

- This PR and #232 both add a `[patch.crates-io]` section at the same spot in `src-core/Cargo.toml`. Whichever merges second needs a rebase that combines the two tables into one section.
- The pin silently stops applying if a future tauri bump moves the requirements past these versions; cargo only warns. A CI check on `cargo tree --locked -p tauri-runtime-wry` naming the fork would catch that, left as a follow-up because #232 does not guard its pin either.

## Left out

No upstream pull request was opened against `tauri-apps/tauri`; the fork commit applies cleanly to `dev` if you want to send it upstream.