### PR TITLE
Add VRChat account profiles

### DIFF
--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -4546,6 +4546,7 @@ name = "oyasumivr"
 version = "26.8.0-beta.3"
 dependencies = [
  "async-recursion",
+ "base64 0.22.1",
  "btleplug",
  "byteorder",
  "bytes",

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-updater = "2.10.1"
 
 [dependencies]
 async-recursion = "1.1.1"
+base64 = "0.22.1"
 btleplug = "0.12.0"
 byteorder = "1.5.0"
 bytes = "1.12.1"
@@ -92,6 +93,7 @@ widestring = "1.2.1"
 windows-core = { version = "0.62.2", default-features = false }
 windows = { version = "0.62.2", features = [
   "Win32_Foundation",
+  "Win32_Security_Cryptography",
   "Win32_Devices_FunctionDiscovery", 
   "Win32_Media_Audio_Endpoints",
   "Win32_System_Com_StructuredStorage",

--- a/src-core/src/commands/mod.rs
+++ b/src-core/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod notifications;
 pub mod nvml;
 pub mod splash;
 pub mod time;
+pub mod vrchat_secrets;

--- a/src-core/src/commands/vrchat_secrets.rs
+++ b/src-core/src/commands/vrchat_secrets.rs
@@ -1,0 +1,98 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use windows::Win32::{
+    Foundation::HLOCAL,
+    Security::Cryptography::{
+        CryptProtectData, CryptUnprotectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
+    },
+};
+use windows_core::{Owned, PCWSTR};
+
+fn blob(bytes: &[u8]) -> Result<CRYPT_INTEGER_BLOB, String> {
+    Ok(CRYPT_INTEGER_BLOB {
+        cbData: u32::try_from(bytes.len()).map_err(|_| "VRChat secret is too large")?,
+        pbData: bytes.as_ptr().cast_mut(),
+    })
+}
+
+fn copy_output(output: CRYPT_INTEGER_BLOB) -> Vec<u8> {
+    let allocation = unsafe { Owned::new(HLOCAL(output.pbData.cast())) };
+    if output.cbData == 0 {
+        drop(allocation);
+        return Vec::new();
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize) };
+    let result = bytes.to_vec();
+    drop(allocation);
+    result
+}
+
+fn protect(secret: &[u8]) -> Result<Vec<u8>, String> {
+    let input = blob(secret)?;
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptProtectData(
+            &input,
+            PCWSTR::null(),
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    }
+    .map_err(|error| error.to_string())?;
+    Ok(copy_output(output))
+}
+
+fn unprotect(secret: &[u8]) -> Result<Vec<u8>, String> {
+    let input = blob(secret)?;
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptUnprotectData(
+            &input,
+            None,
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    }
+    .map_err(|error| error.to_string())?;
+    Ok(copy_output(output))
+}
+
+#[tauri::command]
+pub fn protect_vrchat_secret(secret: String) -> Result<String, String> {
+    Ok(STANDARD.encode(protect(secret.as_bytes())?))
+}
+
+#[tauri::command]
+pub fn unprotect_vrchat_secret(secret: String) -> Result<String, String> {
+    let protected = STANDARD.decode(secret).map_err(|error| error.to_string())?;
+    String::from_utf8(unprotect(&protected)?).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_unicode_text() {
+        let secret = "user@example.com:pässword:日本語".to_string();
+        let protected = protect_vrchat_secret(secret.clone()).unwrap();
+
+        assert_ne!(protected, secret);
+        assert_eq!(unprotect_vrchat_secret(protected).unwrap(), secret);
+        assert_eq!(
+            unprotect_vrchat_secret(protect_vrchat_secret(String::new()).unwrap()).unwrap(),
+            ""
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_input() {
+        assert!(unprotect_vrchat_secret("not base64".to_string()).is_err());
+        assert!(unprotect_vrchat_secret(STANDARD.encode("not dpapi")).is_err());
+    }
+}

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -410,6 +410,8 @@ fn configure_command_handlers() -> impl Fn(tauri::ipc::Invoke) -> bool {
         commands::debug::open_dev_tools,
         cn_compliance::cn_compliance_mode,
         commands::time::get_sunrise_sunset_time,
+        commands::vrchat_secrets::protect_vrchat_secret,
+        commands::vrchat_secrets::unprotect_vrchat_secret,
         grpc::commands::get_core_grpc_port,
         grpc::commands::get_core_grpc_web_port,
         telemetry::commands::set_telemetry_enabled,

--- a/src-ui/app/app.module.ts
+++ b/src-ui/app/app.module.ts
@@ -54,6 +54,7 @@ import { firstValueFrom } from 'rxjs';
 import { VRChatService } from './services/vrchat-api/vrchat.service';
 import { VRChatLoginModalComponent } from './components/vrchat-login-modal/vrchat-login-modal.component';
 import { VRChatLoginTFAModalComponent } from './components/vrchat-login-tfa-modal/vrchat-login-tfa-modal.component';
+import { VRChatAccountsModalComponent } from './components/vrchat-accounts-modal/vrchat-accounts-modal.component';
 import { StatusAutomationsViewComponent } from './views/dashboard-view/views/status-automations-view/status-automations-view.component';
 import { SleepingAnimationPresetModalComponent } from './components/sleeping-animation-preset-modal/sleeping-animation-preset-modal.component';
 import { VRChatLogService } from './services/vrchat-log.service';
@@ -331,6 +332,7 @@ import { StoreSnapshotService } from './services/store-snapshot.service';
     SettingsAdvancedViewComponent,
     VRChatLoginModalComponent,
     VRChatLoginTFAModalComponent,
+    VRChatAccountsModalComponent,
     StatusAutomationsViewComponent,
     SleepingAnimationPresetModalComponent,
     MainStatusBarComponent,

--- a/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.html
+++ b/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.html
@@ -1,0 +1,78 @@
+<div class="pane modal" @fadeUp>
+  <div class="pane-title" transloco="comp.vrchat-accounts-modal.title"></div>
+  <div class="pane-content">
+    <p transloco="comp.vrchat-accounts-modal.description"></p>
+    <div class="accounts">
+      @for (profile of sortedProfiles | async; track profile.id) {
+        @let active = (vrchat.activeProfile | async)?.id === profile.id && !!(vrchat.user | async);
+        @let selectable = !active && !profile.secretLocked && !busyProfileId;
+        <div
+          class="account"
+          [class.active]="active"
+          [class.selectable]="selectable"
+          [attr.role]="active ? null : 'button'"
+          [attr.tabindex]="selectable ? 0 : null"
+          [attr.aria-disabled]="!active && !selectable ? true : null"
+          (click)="activate(profile)"
+          (keydown.enter)="activate(profile)"
+          (keydown.space)="$event.preventDefault(); activate(profile)"
+        >
+          <i class="material-icons-round account-icon">account_circle</i>
+          <div class="account-label">
+            <span class="account-name">{{ accountName(profile) }}</span>
+            @if (!active && profile.secretLocked) {
+              <span class="account-status locked">
+                <i class="material-icons-round">lock</i>
+                <span transloco="comp.vrchat-accounts-modal.locked"></span>
+              </span>
+            }
+          </div>
+          <div
+            class="account-actions"
+            (click)="$event.stopPropagation()"
+            (keydown.enter)="$event.stopPropagation()"
+            (keydown.space)="$event.stopPropagation()"
+          >
+            @if (active) {
+              <button
+                class="btn btn-secondary account-action"
+                [disabled]="!!busyProfileId"
+                (click)="disconnect(profile)"
+              >
+                @if (busyProfileId === profile.id) {
+                  <div class="small-spinner" @hshrink></div>
+                } @else {
+                  <span transloco="settings.integrations.disconnect"></span>
+                }
+              </button>
+            } @else if (busyProfileId === profile.id) {
+              <div class="small-spinner" @hshrink></div>
+            }
+            <button
+              class="btn btn-secondary btn-icon"
+              [disabled]="!!busyProfileId"
+              (click)="forget(profile)"
+              [attr.aria-label]="'comp.vrchat-accounts-modal.forget.tooltip' | transloco"
+              [tooltip]="'comp.vrchat-accounts-modal.forget.tooltip'"
+              tooltipMode="top"
+            >
+              <i class="material-icons">delete</i>
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+  <div class="pane-actions spread">
+    <button
+      class="btn btn-secondary"
+      [disabled]="!!busyProfileId"
+      (click)="close()"
+      transloco="shared.modals.close"
+    ></button>
+    <button class="btn btn-primary" [disabled]="!!busyProfileId" (click)="addAccount()">
+      <i class="material-icons">add</i>
+      <span transloco="comp.vrchat-accounts-modal.add"></span>
+    </button>
+  </div>
+</div>

--- a/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.html
+++ b/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.html
@@ -6,33 +6,25 @@
       @for (profile of sortedProfiles | async; track profile.id) {
         @let active = (vrchat.activeProfile | async)?.id === profile.id && !!(vrchat.user | async);
         @let selectable = !active && !profile.secretLocked && !busyProfileId;
-        <div
-          class="account"
-          [class.active]="active"
-          [class.selectable]="selectable"
-          [attr.role]="active ? null : 'button'"
-          [attr.tabindex]="selectable ? 0 : null"
-          [attr.aria-disabled]="!active && !selectable ? true : null"
-          (click)="activate(profile)"
-          (keydown.enter)="activate(profile)"
-          (keydown.space)="$event.preventDefault(); activate(profile)"
-        >
-          <i class="material-icons-round account-icon">account_circle</i>
-          <div class="account-label">
-            <span class="account-name">{{ accountName(profile) }}</span>
-            @if (!active && profile.secretLocked) {
-              <span class="account-status locked">
-                <i class="material-icons-round">lock</i>
-                <span transloco="comp.vrchat-accounts-modal.locked"></span>
-              </span>
-            }
-          </div>
-          <div
-            class="account-actions"
-            (click)="$event.stopPropagation()"
-            (keydown.enter)="$event.stopPropagation()"
-            (keydown.space)="$event.stopPropagation()"
+        <div class="account" [class.active]="active" [class.selectable]="selectable">
+          <button
+            type="button"
+            class="account-select"
+            [disabled]="!selectable"
+            (click)="activate(profile)"
           >
+            <i class="material-icons-round account-icon">account_circle</i>
+            <span class="account-label">
+              <span class="account-name">{{ accountName(profile) }}</span>
+              @if (!active && profile.secretLocked) {
+                <span class="account-status locked">
+                  <i class="material-icons-round">lock</i>
+                  <span transloco="comp.vrchat-accounts-modal.locked"></span>
+                </span>
+              }
+            </span>
+          </button>
+          <div class="account-actions">
             @if (active) {
               <button
                 class="btn btn-secondary account-action"

--- a/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.scss
+++ b/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.scss
@@ -16,8 +16,6 @@
 .account {
   display: flex;
   align-items: center;
-  gap: 0.875em;
-  padding: 0.75em 1em;
   border: 1px solid var(--color-surface-3);
   border-radius: var(--surface-border-radius);
   background: var(--color-surface-1);
@@ -47,6 +45,25 @@
     &:active {
       transform: translateY(1px);
     }
+  }
+}
+
+.account-select {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  align-self: stretch;
+  gap: 0.875em;
+  min-width: 0;
+  padding: 0.75em 0 0.75em 1em;
+  border: 0;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  cursor: inherit;
+
+  &:disabled {
+    opacity: 1;
   }
 
   &:focus-visible {
@@ -105,6 +122,7 @@
   flex-shrink: 0;
   align-items: center;
   gap: 0.5em;
+  padding-right: 1em;
 }
 
 .account-actions .btn {

--- a/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.scss
+++ b/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.scss
@@ -1,0 +1,121 @@
+.pane {
+  width: min(42em, calc(100vw - 4em));
+}
+
+.pane-content > p {
+  margin-bottom: 1.25em;
+  color: var(--color-text-2);
+}
+
+.accounts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.account {
+  display: flex;
+  align-items: center;
+  gap: 0.875em;
+  padding: 0.75em 1em;
+  border: 1px solid var(--color-surface-3);
+  border-radius: var(--surface-border-radius);
+  background: var(--color-surface-1);
+  transition: all 0.15s ease;
+
+  &.active {
+    border-color: var(--color-primary);
+    background: var(--color-surface-3);
+
+    .account-icon {
+      color: var(--color-text-1);
+    }
+  }
+
+  &.selectable {
+    cursor: pointer;
+
+    &:hover {
+      border-color: var(--color-surface-4);
+      background: var(--color-surface-2);
+
+      .account-icon {
+        color: var(--color-text-1);
+      }
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+}
+
+.account-icon {
+  flex-shrink: 0;
+  color: var(--color-text-2);
+  font-size: 2.25em;
+}
+
+.account-label {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.15em;
+}
+
+.account-name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-status {
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+  min-width: 0;
+  font-size: 0.85em;
+  color: var(--color-text-3);
+
+  i {
+    flex-shrink: 0;
+    font-size: 1.15em;
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &.locked {
+    color: var(--color-alert-warning);
+  }
+}
+
+.account-actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.account-actions .btn {
+  height: 2.3em;
+
+  &.btn-icon {
+    width: 2.3em;
+    padding: 0;
+  }
+}
+
+.account-action {
+  min-width: 8em;
+}

--- a/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.ts
+++ b/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.ts
@@ -89,7 +89,7 @@ export class VRChatAccountsModalComponent extends BaseModalComponent<void, void>
           title: 'comp.vrchat-accounts-modal.forget.title',
           message: {
             string: 'comp.vrchat-accounts-modal.forget.message',
-            values: { account: profile.displayName ?? profile.username ?? '' },
+            values: { account: this.accountName(profile) },
           },
           confirmButtonText: 'comp.vrchat-accounts-modal.forget.confirm',
         }

--- a/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.ts
+++ b/src-ui/app/components/vrchat-accounts-modal/vrchat-accounts-modal.component.ts
@@ -1,0 +1,108 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { combineLatest, firstValueFrom, map, Observable } from 'rxjs';
+import { TranslocoService } from '@jsverse/transloco';
+import { BaseModalComponent } from '../base-modal/base-modal.component';
+import {
+  ConfirmModalComponent,
+  ConfirmModalInputModel,
+  ConfirmModalOutputModel,
+} from '../confirm-modal/confirm-modal.component';
+import { ModalService } from '../../services/modal.service';
+import { VRChatService } from '../../services/vrchat-api/vrchat.service';
+import { VRChatAccountProfile } from '../../models/vrchat-api-settings';
+import { fadeUp, hshrink } from '../../utils/animations';
+
+@Component({
+  selector: 'app-vrchat-accounts-modal',
+  templateUrl: './vrchat-accounts-modal.component.html',
+  styleUrls: ['./vrchat-accounts-modal.component.scss'],
+  animations: [fadeUp(), hshrink()],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class VRChatAccountsModalComponent extends BaseModalComponent<void, void> {
+  busyProfileId: string | null = null;
+  protected readonly sortedProfiles: Observable<VRChatAccountProfile[]>;
+
+  constructor(
+    protected vrchat: VRChatService,
+    private modalService: ModalService,
+    private translate: TranslocoService,
+    private cdr: ChangeDetectorRef
+  ) {
+    super();
+    this.sortedProfiles = combineLatest([this.vrchat.profiles, this.translate.langChanges$]).pipe(
+      map(([profiles]) =>
+        [...profiles].sort(
+          (a, b) =>
+            this.accountName(a).localeCompare(this.accountName(b), undefined, {
+              sensitivity: 'base',
+            }) || a.id.localeCompare(b.id)
+        )
+      )
+    );
+  }
+
+  protected accountName(profile: VRChatAccountProfile): string {
+    return (
+      profile.displayName ||
+      profile.username ||
+      this.translate.translate('comp.vrchat-accounts-modal.unknownAccount')
+    );
+  }
+
+  async activate(profile: VRChatAccountProfile): Promise<void> {
+    if (this.busyProfileId || profile.secretLocked) return;
+    const [activeProfile, user] = await Promise.all([
+      firstValueFrom(this.vrchat.activeProfile),
+      firstValueFrom(this.vrchat.user),
+    ]);
+    if (activeProfile?.id === profile.id && user) return;
+    await this.close();
+    await this.vrchat.activateProfile(profile.id).catch(() => this.vrchat.showLoginModal());
+  }
+
+  async disconnect(profile: VRChatAccountProfile): Promise<void> {
+    if (this.busyProfileId) return;
+    this.busyProfileId = profile.id;
+    this.cdr.markForCheck();
+    try {
+      await this.vrchat.logout();
+    } finally {
+      this.busyProfileId = null;
+      this.cdr.markForCheck();
+    }
+  }
+
+  async addAccount(): Promise<void> {
+    if (this.busyProfileId) return;
+    await this.close();
+    await this.vrchat.prepareNewLogin();
+  }
+
+  async forget(profile: VRChatAccountProfile): Promise<void> {
+    if (this.busyProfileId) return;
+    const result = await firstValueFrom(
+      this.modalService.addModal<ConfirmModalInputModel, ConfirmModalOutputModel>(
+        ConfirmModalComponent,
+        {
+          title: 'comp.vrchat-accounts-modal.forget.title',
+          message: {
+            string: 'comp.vrchat-accounts-modal.forget.message',
+            values: { account: profile.displayName ?? profile.username ?? '' },
+          },
+          confirmButtonText: 'comp.vrchat-accounts-modal.forget.confirm',
+        }
+      )
+    );
+    if (!result?.confirmed) return;
+    this.busyProfileId = profile.id;
+    this.cdr.markForCheck();
+    try {
+      await this.vrchat.removeProfile(profile.id);
+    } finally {
+      this.busyProfileId = null;
+      this.cdr.markForCheck();
+    }
+  }
+}

--- a/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
+++ b/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
@@ -167,7 +167,6 @@ export class VRChatLoginModalComponent
     switch (error) {
       case 'CHECK_EMAIL':
       case 'INVALID_CREDENTIALS':
-      case 'PROFILE_MISMATCH':
       case 'UNEXPECTED_RESPONSE':
       case 'UNSUPPORTED_2FA_METHOD':
         this.error = `comp.vrchat-login-modal.errors.${error}`;

--- a/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
+++ b/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
@@ -155,10 +155,10 @@ export class VRChatLoginModalComponent
   }
 
   private async finishLogin() {
-    if (!this.rememberCredentials) {
-      await this.vrchat.forgetCredentials();
-    } else if (this.username && this.password) {
+    if (this.rememberCredentials && this.username && this.password) {
       await this.vrchat.rememberCredentials(this.username, this.password);
+    } else if (!this.newAccount) {
+      await this.vrchat.forgetCredentials();
     }
     await this.close();
   }

--- a/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
+++ b/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
@@ -19,6 +19,8 @@ import {
 
 interface VRChatLoginModalInputModel {
   autoLogin?: boolean;
+  newAccount?: boolean;
+  keepActiveProfile?: boolean;
   twoFactorMethod?: VRChatTwoFactorMethod;
   initialError?: string;
   username?: string;
@@ -44,6 +46,8 @@ export class VRChatLoginModalComponent
   error = '';
   rememberCredentials = false;
   autoLogin = false;
+  newAccount = false;
+  keepActiveProfile = false;
   twoFactorMethod?: VRChatTwoFactorMethod;
   initialError?: string;
 
@@ -58,24 +62,24 @@ export class VRChatLoginModalComponent
 
   async ngOnInit(): Promise<void> {
     if (this.initialError) this.setLoginError(this.initialError);
-    this.vrchat.settings
+    this.vrchat.activeProfile
       .pipe(
-        map((settings) => settings.rememberCredentials),
+        map((profile) => profile?.rememberCredentials ?? false),
         takeUntilDestroyed(this.destroyRef),
         take(1)
       )
       .subscribe(async (rememberCredentials) => {
         try {
-          this.rememberCredentials = rememberCredentials;
+          this.rememberCredentials = this.newAccount ? false : rememberCredentials;
+          const credentials = this.newAccount ? null : await this.vrchat.loadCredentials();
+          if (credentials) {
+            this.username = credentials.username;
+            this.password = credentials.password;
+          }
           if (this.twoFactorMethod) {
             this.loggingIn = true;
             await this.loginWithTwoFactor(this.twoFactorMethod);
           } else {
-            const credentials = await this.vrchat.loadCredentials();
-            if (credentials) {
-              this.username = credentials.username;
-              this.password = credentials.password;
-            }
             if (this.autoLogin && credentials) await this.login();
           }
         } catch (e) {
@@ -109,7 +113,8 @@ export class VRChatLoginModalComponent
     this.loggingIn = true;
     this.error = '';
     try {
-      await this.vrchat.login(this.username, this.password);
+      if (this.newAccount) await this.vrchat.loginNewAccount(this.username, this.password);
+      else await this.vrchat.login(this.username, this.password, this.keepActiveProfile);
       await this.finishLogin();
     } catch (e) {
       const method = twoFactorMethodFromError(e);
@@ -150,7 +155,9 @@ export class VRChatLoginModalComponent
   }
 
   private async finishLogin() {
-    if (this.rememberCredentials && this.username && this.password) {
+    if (!this.rememberCredentials) {
+      await this.vrchat.forgetCredentials();
+    } else if (this.username && this.password) {
       await this.vrchat.rememberCredentials(this.username, this.password);
     }
     await this.close();
@@ -160,6 +167,7 @@ export class VRChatLoginModalComponent
     switch (error) {
       case 'CHECK_EMAIL':
       case 'INVALID_CREDENTIALS':
+      case 'PROFILE_MISMATCH':
       case 'UNEXPECTED_RESPONSE':
       case 'UNSUPPORTED_2FA_METHOD':
         this.error = `comp.vrchat-login-modal.errors.${error}`;
@@ -172,8 +180,6 @@ export class VRChatLoginModalComponent
 
   async toggleRememberCredentials() {
     this.rememberCredentials = !this.rememberCredentials;
-    if (!this.rememberCredentials) {
-      await this.vrchat.forgetCredentials();
-    }
+    if (!this.rememberCredentials && !this.newAccount) await this.vrchat.forgetCredentials();
   }
 }

--- a/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
+++ b/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
@@ -157,7 +157,7 @@ export class VRChatLoginModalComponent
   private async finishLogin() {
     if (this.rememberCredentials && this.username && this.password) {
       await this.vrchat.rememberCredentials(this.username, this.password);
-    } else if (!this.newAccount) {
+    } else {
       await this.vrchat.forgetCredentials();
     }
     await this.close();

--- a/src-ui/app/migrations/vrchat-api-settings.migrations.ts
+++ b/src-ui/app/migrations/vrchat-api-settings.migrations.ts
@@ -92,16 +92,18 @@ function from3To4(data: any): any {
 
 function from4To5(data: any): any {
   const hasProfile = !!(
-    data.authCookie ||
-    data.twoFactorCookie ||
-    data.encryptedPendingTwoFactorLoginIdentifier ||
-    data.rememberedCredentials
+    data.authCookie != null ||
+    data.twoFactorCookie != null ||
+    data.encryptedPendingTwoFactorLoginIdentifier != null ||
+    data.rememberedCredentials != null
   );
   const profileId = crypto.randomUUID();
   data.profiles = hasProfile
     ? [
         {
           id: profileId,
+          sourceProfileId: null,
+          restoreProfileId: null,
           userId: null,
           username: null,
           displayName: null,

--- a/src-ui/app/migrations/vrchat-api-settings.migrations.ts
+++ b/src-ui/app/migrations/vrchat-api-settings.migrations.ts
@@ -9,6 +9,8 @@ const migrations: { [v: number]: (data: any) => any } = {
   2: from1To2,
   3: from2To3,
   4: from3To4,
+  5: from4To5,
+  6: from5To6,
 };
 
 export function migrateVRChatApiSettings(data: any): VRChatApiSettings {
@@ -85,6 +87,54 @@ function from3To4(data: any): any {
   delete data['twoFactorCookieExpiry'];
   data.encryptedPendingTwoFactorLoginIdentifier = null;
   data.version = 4;
+  return data;
+}
+
+function from4To5(data: any): any {
+  const hasProfile = !!(
+    data.authCookie ||
+    data.twoFactorCookie ||
+    data.encryptedPendingTwoFactorLoginIdentifier ||
+    data.rememberedCredentials
+  );
+  const profileId = crypto.randomUUID();
+  data.profiles = hasProfile
+    ? [
+        {
+          id: profileId,
+          userId: null,
+          username: null,
+          displayName: null,
+          draft: false,
+          authCookie: data.authCookie ?? null,
+          twoFactorCookie: data.twoFactorCookie ?? null,
+          twoFactorCookieLoginIdentifierHash: data.twoFactorCookieLoginIdentifierHash ?? null,
+          encryptedPendingTwoFactorLoginIdentifier:
+            data.encryptedPendingTwoFactorLoginIdentifier ?? null,
+          rememberCredentials: !!data.rememberCredentials,
+          rememberedCredentials: data.rememberedCredentials ?? null,
+        },
+      ]
+    : [];
+  data.activeProfileId = hasProfile ? profileId : null;
+  delete data.authCookie;
+  delete data.twoFactorCookie;
+  delete data.twoFactorCookieLoginIdentifierHash;
+  delete data.encryptedPendingTwoFactorLoginIdentifier;
+  delete data.rememberCredentials;
+  delete data.rememberedCredentials;
+  data.version = 5;
+  return data;
+}
+
+function from5To6(data: any): any {
+  data.profiles = (data.profiles ?? []).map((profile: any) => ({
+    ...profile,
+    protectedSecret: null,
+  }));
+  data.legacyCredentialCryptoKey = data.credentialCryptoKey ?? null;
+  delete data.credentialCryptoKey;
+  data.version = 6;
   return data;
 }
 

--- a/src-ui/app/models/vrchat-api-settings.ts
+++ b/src-ui/app/models/vrchat-api-settings.ts
@@ -1,21 +1,115 @@
-export interface VRChatApiSettings {
-  version: 4;
+export interface VRChatCredentials {
+  username: string;
+  password: string;
+}
+
+export interface VRChatAccountSecret {
   authCookie: string | null;
   twoFactorCookie: string | null;
   twoFactorCookieLoginIdentifierHash: string | null;
-  encryptedPendingTwoFactorLoginIdentifier: string | null;
+  pendingTwoFactorLoginIdentifier: string | null;
   rememberCredentials: boolean;
-  rememberedCredentials: string | null;
-  credentialCryptoKey: string | null;
+  rememberedCredentials: VRChatCredentials | null;
+}
+
+export interface VRChatAccountProfile {
+  id: string;
+  userId: string | null;
+  username: string | null;
+  displayName: string | null;
+  draft: boolean;
+  protectedSecret: string | null;
+  secretLocked: boolean;
+  authCookie: string | null;
+  twoFactorCookie: string | null;
+  twoFactorCookieLoginIdentifierHash: string | null;
+  pendingTwoFactorLoginIdentifier: string | null;
+  rememberCredentials: boolean;
+  rememberedCredentials: VRChatCredentials | null;
+}
+
+export interface VRChatApiSettings {
+  version: 6;
+  profiles: VRChatAccountProfile[];
+  activeProfileId: string | null;
+  legacyCredentialCryptoKey: string | null;
 }
 
 export const VRCHAT_API_SETTINGS_DEFAULT: VRChatApiSettings = {
-  version: 4,
+  version: 6,
+  profiles: [],
+  activeProfileId: null,
+  legacyCredentialCryptoKey: null,
+};
+
+export const VRCHAT_ACCOUNT_SECRET_EMPTY: VRChatAccountSecret = {
   authCookie: null,
   twoFactorCookie: null,
   twoFactorCookieLoginIdentifierHash: null,
-  encryptedPendingTwoFactorLoginIdentifier: null,
+  pendingTwoFactorLoginIdentifier: null,
   rememberCredentials: false,
   rememberedCredentials: null,
-  credentialCryptoKey: null,
 };
+
+export function getActiveVRChatProfile(settings: VRChatApiSettings): VRChatAccountProfile | null {
+  return settings.profiles.find((profile) => profile.id === settings.activeProfileId) ?? null;
+}
+
+export function normalizeVRChatAccountProfile(
+  profile: Partial<VRChatAccountProfile>
+): VRChatAccountProfile {
+  return {
+    id: profile.id ?? crypto.randomUUID(),
+    userId: profile.userId ?? null,
+    username: profile.username ?? null,
+    displayName: profile.displayName ?? null,
+    draft: profile.draft ?? false,
+    protectedSecret: profile.protectedSecret ?? null,
+    secretLocked: profile.secretLocked ?? false,
+    authCookie: profile.authCookie ?? null,
+    twoFactorCookie: profile.twoFactorCookie ?? null,
+    twoFactorCookieLoginIdentifierHash: profile.twoFactorCookieLoginIdentifierHash ?? null,
+    pendingTwoFactorLoginIdentifier: profile.pendingTwoFactorLoginIdentifier ?? null,
+    rememberCredentials: profile.rememberCredentials ?? false,
+    rememberedCredentials: profile.rememberedCredentials ?? null,
+  };
+}
+
+export function getVRChatAccountSecret(profile: VRChatAccountProfile): VRChatAccountSecret {
+  return {
+    authCookie: profile.authCookie,
+    twoFactorCookie: profile.twoFactorCookie,
+    twoFactorCookieLoginIdentifierHash: profile.twoFactorCookieLoginIdentifierHash,
+    pendingTwoFactorLoginIdentifier: profile.pendingTwoFactorLoginIdentifier,
+    rememberCredentials: profile.rememberCredentials,
+    rememberedCredentials: profile.rememberedCredentials,
+  };
+}
+
+export function parseVRChatAccountSecret(value: unknown): VRChatAccountSecret {
+  if (!value || typeof value !== 'object') throw new Error('Invalid VRChat account secret');
+  const secret = value as Record<string, unknown>;
+  const credentials = secret['rememberedCredentials'];
+  if (
+    credentials !== null &&
+    (typeof credentials !== 'object' ||
+      typeof (credentials as Record<string, unknown>)['username'] !== 'string' ||
+      typeof (credentials as Record<string, unknown>)['password'] !== 'string')
+  ) {
+    throw new Error('Invalid VRChat credentials');
+  }
+  for (const key of [
+    'authCookie',
+    'twoFactorCookie',
+    'twoFactorCookieLoginIdentifierHash',
+    'pendingTwoFactorLoginIdentifier',
+  ]) {
+    if (secret[key] !== null && typeof secret[key] !== 'string') {
+      throw new Error(`Invalid VRChat account secret field: ${key}`);
+    }
+  }
+  if (typeof secret['rememberCredentials'] !== 'boolean') {
+    throw new Error('Invalid VRChat credential preference');
+  }
+  return secret as unknown as VRChatAccountSecret;
+}

--- a/src-ui/app/models/vrchat-api-settings.ts
+++ b/src-ui/app/models/vrchat-api-settings.ts
@@ -14,6 +14,8 @@ export interface VRChatAccountSecret {
 
 export interface VRChatAccountProfile {
   id: string;
+  sourceProfileId: string | null;
+  restoreProfileId: string | null;
   userId: string | null;
   username: string | null;
   displayName: string | null;
@@ -60,6 +62,8 @@ export function normalizeVRChatAccountProfile(
 ): VRChatAccountProfile {
   return {
     id: profile.id ?? crypto.randomUUID(),
+    sourceProfileId: profile.sourceProfileId ?? null,
+    restoreProfileId: profile.restoreProfileId ?? null,
     userId: profile.userId ?? null,
     username: profile.username ?? null,
     displayName: profile.displayName ?? null,

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -394,7 +394,10 @@ export class VRChatAPI {
       throw 'UNEXPECTED_RESPONSE';
     }
     const user = responseData as CurrentUser;
-    if (expectedUserId && user.id !== expectedUserId) throw 'PROFILE_MISMATCH';
+    if (expectedUserId && user.id !== expectedUserId) {
+      warn(`[VRChat] /auth/user returned ${user.id} while ${expectedUserId} was expected`);
+      throw 'PROFILE_MISMATCH';
+    }
     this.ensureCacheGeneration(cacheGeneration);
     await this.parseResponseCookies(response, cacheGeneration, profileId);
     return user;

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -53,6 +53,8 @@ interface CurrentUserRequestOptions {
   credentials?: VRChatCredentials;
   signal?: AbortSignal;
   includeTwoFactorCookie?: boolean;
+  expectedUserId?: string;
+  captureChallengeCookies?: boolean;
 }
 
 interface CurrentUserChallenge {
@@ -171,6 +173,7 @@ export class VRChatAPI {
 
   private user!: Observable<CurrentUser | null>;
   private patchCurrentUser!: (user: Partial<CurrentUser>) => void;
+  private authenticationFailureHandler: () => void = () => undefined;
 
   constructor(
     private readonly settings: Observable<VRChatApiSettings>,
@@ -188,6 +191,10 @@ export class VRChatAPI {
     this.userAgent = `OyasumiVR/${await getVersion()} (https://github.com/Raphiiko/OyasumiVR)`;
     this.user = user;
     this.patchCurrentUser = patchCurrentUser;
+  }
+
+  public setAuthenticationFailureHandler(handler: () => void): void {
+    this.authenticationFailureHandler = handler;
   }
 
   public async clearCaches(): Promise<void> {
@@ -270,7 +277,11 @@ export class VRChatAPI {
   public async verify2FA(code: string, method: VRChatTwoFactorMethod): Promise<void> {
     const cacheGeneration = this.cacheGeneration;
     const profileId = await this.requireActiveProfileId();
-    const headers = await this.getDefaultHeaders({}, cacheGeneration, profileId);
+    const headers = await this.getDefaultHeaders(
+      { includeTwoFactorCookie: false },
+      cacheGeneration,
+      profileId
+    );
     const response = await requestVRChat(`${BASE_URL}/auth/twofactorauth/${method}/verify`, {
       method: 'POST',
       body: JSON.stringify({ code }),
@@ -296,7 +307,7 @@ export class VRChatAPI {
   }
 
   public async getCurrentUser(options: CurrentUserRequestOptions = {}): Promise<CurrentUser> {
-    const { credentials, signal } = options;
+    const { captureChallengeCookies = true, credentials, expectedUserId, signal } = options;
     const includeTwoFactorCookie = options.includeTwoFactorCookie ?? !credentials;
     const cacheGeneration = this.cacheGeneration;
     const profileId = await this.requireActiveProfileId();
@@ -344,8 +355,6 @@ export class VRChatAPI {
       error(`[VRChat] Received invalid response body from /auth/user`);
       throw 'UNEXPECTED_RESPONSE';
     }
-    this.ensureCacheGeneration(cacheGeneration);
-    await this.parseResponseCookies(response, cacheGeneration, profileId);
     if ('requiresTwoFactorAuth' in responseData) {
       if (!Array.isArray(responseData.requiresTwoFactorAuth)) {
         error(`[VRChat] Received invalid 2FA challenge from /auth/user`);
@@ -357,6 +366,10 @@ export class VRChatAPI {
       info(
         `[VRChat] 2FA Required for login. (methods=${JSON.stringify(responseData.requiresTwoFactorAuth)})`
       );
+      if (captureChallengeCookies) {
+        this.ensureCacheGeneration(cacheGeneration);
+        await this.parseResponseCookies(response, cacheGeneration, profileId);
+      }
       if (methods.includes('totp')) throw '2FA_TOTP_REQUIRED';
       if (methods.includes('emailotp')) throw '2FA_EMAILOTP_REQUIRED';
       error(
@@ -365,12 +378,21 @@ export class VRChatAPI {
       );
       throw 'UNSUPPORTED_2FA_METHOD';
     }
-    if (!('id' in responseData) || typeof responseData.id !== 'string') {
+    if (
+      !('id' in responseData) ||
+      typeof responseData.id !== 'string' ||
+      !('username' in responseData) ||
+      typeof responseData.username !== 'string' ||
+      !('displayName' in responseData) ||
+      typeof responseData.displayName !== 'string'
+    ) {
       error(`[VRChat] Received invalid user from /auth/user`);
       throw 'UNEXPECTED_RESPONSE';
     }
     const user = responseData as CurrentUser;
+    if (expectedUserId && user.id !== expectedUserId) throw 'PROFILE_MISMATCH';
     this.ensureCacheGeneration(cacheGeneration);
+    await this.parseResponseCookies(response, cacheGeneration, profileId);
     return user;
   }
 
@@ -701,11 +723,14 @@ export class VRChatAPI {
 
   // live cache updates
 
-  public pollCurrentUser(): Promise<CompletionResult<CurrentUser>> {
-    return this.apiCallQueue.queueTask<CurrentUser>({
-      typeId: 'POLL_USER',
-      runnable: () => this.getCurrentUser(),
-    });
+  public pollCurrentUser(expectedUserId?: string): Promise<CompletionResult<CurrentUser>> {
+    return this.apiCallQueue.queueTask<CurrentUser>(
+      {
+        typeId: 'POLL_USER',
+        runnable: () => this.getCurrentUser({ captureChallengeCookies: false, expectedUserId }),
+      },
+      true
+    );
   }
 
   public updateCachedGroup(groupId: string, group: Partial<LimitedUserGroups>): void {
@@ -736,7 +761,10 @@ export class VRChatAPI {
 
   private requireSuccessfulResponse(result: CompletionResult<Response>): Response {
     if (result.error) throw result.error;
-    if (!result.result?.ok) throw result.result;
+    if (!result.result?.ok) {
+      if (result.result?.status === 401) this.authenticationFailureHandler();
+      throw result.result;
+    }
     return result.result;
   }
 

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -409,7 +409,9 @@ export class VRChatAPI {
       signal: abortController.signal,
     }).finally(() => clearTimeout(timeout));
     this.ensureCacheGeneration(cacheGeneration);
-    if (!response.ok) throw response;
+    if (!response.ok) {
+      throw new Error(`VRChat profile logout failed: HTTP ${response.status}`);
+    }
   }
 
   // notifications and invites
@@ -501,6 +503,7 @@ export class VRChatAPI {
       this.ensureCacheGeneration(cacheGeneration);
       this.requireSuccessfulResponse(result);
     } catch (e) {
+      if (e === VRCHAT_API_STALE_REQUEST) throw e;
       const failure = requestFailure('VRChat invite request failed', e);
       error(`[VRChat] ${failure.message}`);
       this.reportError(failure);

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -9,7 +9,11 @@ import { CachedValue } from 'src-ui/app/utils/cached-value';
 import { AvatarEx, InviteMessageEx, InviteMessageType, UserStatus } from 'src-ui/app/models/vrchat';
 import { uniqBy } from 'lodash';
 import { BehaviorSubject, distinctUntilChanged, firstValueFrom, Observable } from 'rxjs';
-import { getActiveVRChatProfile, VRChatApiSettings } from 'src-ui/app/models/vrchat-api-settings';
+import {
+  getActiveVRChatProfile,
+  VRChatAccountProfile,
+  VRChatApiSettings,
+} from 'src-ui/app/models/vrchat-api-settings';
 import { VRChatProfileSessionPatch } from './vrchat-profiles';
 import { CompletionResult } from 'src-ui/app/utils/completer';
 
@@ -396,19 +400,15 @@ export class VRChatAPI {
     return user;
   }
 
-  public async logoutProfile(profileId: string): Promise<void> {
-    const cacheGeneration = this.cacheGeneration;
-    const settings = await firstValueFrom(this.settings);
-    const profile = settings.profiles.find((candidate) => candidate.id === profileId);
+  public async logoutProfile(profile?: VRChatAccountProfile): Promise<void> {
     if (!profile?.authCookie) return;
     const abortController = new AbortController();
     const timeout = setTimeout(() => abortController.abort(), PROFILE_LOGOUT_TIMEOUT);
     const response = await requestVRChat(`${BASE_URL}/logout`, {
       method: 'PUT',
-      headers: await this.getDefaultHeaders({}, cacheGeneration, profileId),
+      headers: this.getProfileHeaders(profile),
       signal: abortController.signal,
     }).finally(() => clearTimeout(timeout));
-    this.ensureCacheGeneration(cacheGeneration);
     if (!response.ok) {
       throw new Error(`VRChat profile logout failed: HTTP ${response.status}`);
     }
@@ -892,17 +892,24 @@ export class VRChatAPI {
     cacheGeneration: number,
     profileId?: string
   ): Promise<Record<string, string>> {
-    const {
-      contentType = 'application/json',
-      includeAuthCookie = true,
-      includeTwoFactorCookie = true,
-    } = options;
     const settings = await firstValueFrom(this.settings);
     this.ensureCacheGeneration(cacheGeneration);
     const profile = profileId
       ? settings.profiles.find((candidate) => candidate.id === profileId)
       : getActiveVRChatProfile(settings);
     if (!profile) throw new Error('Cannot make a VRChat API request without an active profile');
+    return this.getProfileHeaders(profile, options);
+  }
+
+  private getProfileHeaders(
+    profile: VRChatAccountProfile,
+    options: RequestHeaderOptions = {}
+  ): Record<string, string> {
+    const {
+      contentType = 'application/json',
+      includeAuthCookie = true,
+      includeTwoFactorCookie = true,
+    } = options;
     const cookies: string[] = [];
     if (includeAuthCookie && profile.authCookie)
       cookies.push(serializeCookie({ name: 'auth', value: profile.authCookie }));

--- a/src-ui/app/services/vrchat-api/vrchat-api.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-api.ts
@@ -9,7 +9,8 @@ import { CachedValue } from 'src-ui/app/utils/cached-value';
 import { AvatarEx, InviteMessageEx, InviteMessageType, UserStatus } from 'src-ui/app/models/vrchat';
 import { uniqBy } from 'lodash';
 import { BehaviorSubject, distinctUntilChanged, firstValueFrom, Observable } from 'rxjs';
-import { VRChatApiSettings } from 'src-ui/app/models/vrchat-api-settings';
+import { getActiveVRChatProfile, VRChatApiSettings } from 'src-ui/app/models/vrchat-api-settings';
+import { VRChatProfileSessionPatch } from './vrchat-profiles';
 import { CompletionResult } from 'src-ui/app/utils/completer';
 
 async function requestVRChat(
@@ -37,6 +38,7 @@ const PAGE_SIZE = 100;
 const DEFAULT_PAGE_LIMIT = 500;
 const DEFAULT_RATE_LIMIT_RETRIES = 5;
 const DEFAULT_RATE_LIMIT_DELAY = 5_000;
+const PROFILE_LOGOUT_TIMEOUT = 10_000;
 
 export const VRCHAT_API_STALE_REQUEST = 'STALE_REQUEST';
 
@@ -172,7 +174,10 @@ export class VRChatAPI {
 
   constructor(
     private readonly settings: Observable<VRChatApiSettings>,
-    private readonly updateSettings: (settings: Partial<VRChatApiSettings>) => Promise<void>,
+    private readonly updateProfile: (
+      profileId: string,
+      patch: VRChatProfileSessionPatch
+    ) => Promise<void>,
     private readonly reportError: (cause: Error) => void
   ) {}
 
@@ -187,6 +192,7 @@ export class VRChatAPI {
 
   public async clearCaches(): Promise<void> {
     this.cacheGeneration++;
+    this.apiCallQueue.cancelPending(VRCHAT_API_STALE_REQUEST);
     this.activeCacheClears++;
     this.friendFetch = undefined;
     this.avatarFetch = undefined;
@@ -217,6 +223,7 @@ export class VRChatAPI {
     status: UserStatus | null,
     statusMessage: string | null
   ): Promise<boolean> {
+    const cacheGeneration = this.cacheGeneration;
     const currentUser = await this.requireCurrentUser('setting status');
     statusMessage =
       statusMessage === null ? null : statusMessage.replace(/\s+/g, ' ').trim().slice(0, 32);
@@ -240,15 +247,17 @@ export class VRChatAPI {
         {
           typeId: 'STATUS_CHANGE',
           runnable: async () => {
+            this.ensureCacheGeneration(cacheGeneration);
             return requestVRChat(`${BASE_URL}/users/${currentUser.id}`, {
               method: 'PUT',
               body: JSON.stringify(body),
-              headers: await this.getDefaultHeaders(),
+              headers: await this.getDefaultHeaders({}, cacheGeneration),
             });
           },
         },
         true
       );
+      this.ensureCacheGeneration(cacheGeneration);
       this.requireSuccessfulResponse(result);
       this.patchCurrentUser(body);
     } catch (e) {
@@ -260,7 +269,8 @@ export class VRChatAPI {
 
   public async verify2FA(code: string, method: VRChatTwoFactorMethod): Promise<void> {
     const cacheGeneration = this.cacheGeneration;
-    const headers = await this.getDefaultHeaders();
+    const profileId = await this.requireActiveProfileId();
+    const headers = await this.getDefaultHeaders({}, cacheGeneration, profileId);
     const response = await requestVRChat(`${BASE_URL}/auth/twofactorauth/${method}/verify`, {
       method: 'POST',
       body: JSON.stringify({ code }),
@@ -282,17 +292,22 @@ export class VRChatAPI {
       throw 'UNEXPECTED_RESPONSE';
     }
     this.ensureCacheGeneration(cacheGeneration);
-    await this.parseResponseCookies(response, cacheGeneration);
+    await this.parseResponseCookies(response, cacheGeneration, profileId);
   }
 
   public async getCurrentUser(options: CurrentUserRequestOptions = {}): Promise<CurrentUser> {
     const { credentials, signal } = options;
     const includeTwoFactorCookie = options.includeTwoFactorCookie ?? !credentials;
     const cacheGeneration = this.cacheGeneration;
-    const headers = await this.getDefaultHeaders({
-      includeAuthCookie: !credentials,
-      includeTwoFactorCookie,
-    });
+    const profileId = await this.requireActiveProfileId();
+    const headers = await this.getDefaultHeaders(
+      {
+        includeAuthCookie: !credentials,
+        includeTwoFactorCookie,
+      },
+      cacheGeneration,
+      profileId
+    );
     if (credentials) {
       headers['Authorization'] = `Basic ${btoa(
         encodeURIComponent(credentials.username) + ':' + encodeURIComponent(credentials.password)
@@ -330,7 +345,7 @@ export class VRChatAPI {
       throw 'UNEXPECTED_RESPONSE';
     }
     this.ensureCacheGeneration(cacheGeneration);
-    await this.parseResponseCookies(response, cacheGeneration);
+    await this.parseResponseCookies(response, cacheGeneration, profileId);
     if ('requiresTwoFactorAuth' in responseData) {
       if (!Array.isArray(responseData.requiresTwoFactorAuth)) {
         error(`[VRChat] Received invalid 2FA challenge from /auth/user`);
@@ -359,21 +374,40 @@ export class VRChatAPI {
     return user;
   }
 
+  public async logoutProfile(profileId: string): Promise<void> {
+    const cacheGeneration = this.cacheGeneration;
+    const settings = await firstValueFrom(this.settings);
+    const profile = settings.profiles.find((candidate) => candidate.id === profileId);
+    if (!profile?.authCookie) return;
+    const abortController = new AbortController();
+    const timeout = setTimeout(() => abortController.abort(), PROFILE_LOGOUT_TIMEOUT);
+    const response = await requestVRChat(`${BASE_URL}/logout`, {
+      method: 'PUT',
+      headers: await this.getDefaultHeaders({}, cacheGeneration, profileId),
+      signal: abortController.signal,
+    }).finally(() => clearTimeout(timeout));
+    this.ensureCacheGeneration(cacheGeneration);
+    if (!response.ok) throw response;
+  }
+
   // notifications and invites
 
   public async deleteNotification(notificationId: string): Promise<void> {
+    const cacheGeneration = this.cacheGeneration;
     await this.requireCurrentUser('deleting a notification');
     info(`[VRChat] Deleting notification '${notificationId}'`);
     try {
       const result = await this.apiCallQueue.queueTask<Response>({
         typeId: 'DELETE_NOTIFICATION',
         runnable: async () => {
+          this.ensureCacheGeneration(cacheGeneration);
           return requestVRChat(`${BASE_URL}/auth/user/notifications/${notificationId}/hide`, {
             method: 'PUT',
-            headers: await this.getDefaultHeaders(),
+            headers: await this.getDefaultHeaders({}, cacheGeneration),
           });
         },
       });
+      this.ensureCacheGeneration(cacheGeneration);
       this.requireSuccessfulResponse(result);
     } catch (e) {
       error(`[VRChat] Failed to delete notification: ${JSON.stringify(e)}`);
@@ -385,6 +419,7 @@ export class VRChatAPI {
     notificationType: 'invite' | 'requestInvite',
     message: string
   ): Promise<void> {
+    const cacheGeneration = this.cacheGeneration;
     await this.requireCurrentUser('declining an invite or invite request');
     let messageSlot: number | undefined;
     if (message) {
@@ -402,13 +437,15 @@ export class VRChatAPI {
       const result = await this.apiCallQueue.queueTask<Response>({
         typeId: 'DECLINE_INVITE_OR_INVITE_REQUEST',
         runnable: async () => {
+          this.ensureCacheGeneration(cacheGeneration);
           return requestVRChat(`${BASE_URL}/invite/${notificationId}/response`, {
             method: 'POST',
-            headers: await this.getDefaultHeaders(),
+            headers: await this.getDefaultHeaders({}, cacheGeneration),
             body: JSON.stringify({ responseSlot: messageSlot }),
           });
         },
       });
+      this.ensureCacheGeneration(cacheGeneration);
       this.requireSuccessfulResponse(result);
     } catch (e) {
       error(`[VRChat] Failed to decline invite or invite request: ${JSON.stringify(e)}`);
@@ -416,6 +453,7 @@ export class VRChatAPI {
   }
 
   public async inviteUser(inviteeId: string, instanceId: string, message?: string): Promise<void> {
+    const cacheGeneration = this.cacheGeneration;
     await this.requireCurrentUser('inviting a user');
     let messageSlot: number | undefined;
     if (message) {
@@ -430,13 +468,15 @@ export class VRChatAPI {
       const result = await this.apiCallQueue.queueTask<Response>({
         typeId: 'INVITE',
         runnable: async () => {
+          this.ensureCacheGeneration(cacheGeneration);
           return requestVRChat(`${BASE_URL}/invite/${inviteeId}`, {
             body: JSON.stringify({ instanceId, messageSlot }),
             method: 'POST',
-            headers: await this.getDefaultHeaders(),
+            headers: await this.getDefaultHeaders({}, cacheGeneration),
           });
         },
       });
+      this.ensureCacheGeneration(cacheGeneration);
       this.requireSuccessfulResponse(result);
     } catch (e) {
       const failure = requestFailure('VRChat invite request failed', e);
@@ -527,20 +567,23 @@ export class VRChatAPI {
   }
 
   public async representGroup(groupId: string, representing: boolean): Promise<void> {
+    const cacheGeneration = this.cacheGeneration;
     await this.requireCurrentUser('representing a group');
 
     const result = await this.apiCallQueue.queueTask<Response>({
       typeId: 'REPRESENT_GROUP',
       runnable: async () => {
+        this.ensureCacheGeneration(cacheGeneration);
         return requestVRChat(`${BASE_URL}/groups/${groupId}/representation`, {
           method: 'PUT',
-          headers: await this.getDefaultHeaders(),
+          headers: await this.getDefaultHeaders({}, cacheGeneration),
           body: JSON.stringify({
             isRepresenting: representing,
           }),
         });
       },
     });
+    this.ensureCacheGeneration(cacheGeneration);
     this.requireSuccessfulResponse(result);
   }
 
@@ -558,7 +601,7 @@ export class VRChatAPI {
         runnable: async () => {
           this.ensureCacheGeneration(cacheGeneration);
           return requestVRChat(`${BASE_URL}/users/${userId}/groups`, {
-            headers: await this.getDefaultHeaders(),
+            headers: await this.getDefaultHeaders({}, cacheGeneration),
           });
         },
       });
@@ -575,17 +618,20 @@ export class VRChatAPI {
   }
 
   public async selectAvatar(avatarId: string): Promise<void> {
+    const cacheGeneration = this.cacheGeneration;
     await this.requireCurrentUser('selecting an avatar');
     const result = await this.apiCallQueue.queueTask<Response>({
       typeId: 'SELECT_AVATAR',
       runnable: async () => {
+        this.ensureCacheGeneration(cacheGeneration);
         return requestVRChat(`${BASE_URL}/avatars/${avatarId}/select`, {
           method: 'PUT',
           body: JSON.stringify({}),
-          headers: await this.getDefaultHeaders(),
+          headers: await this.getDefaultHeaders({}, cacheGeneration),
         });
       },
     });
+    this.ensureCacheGeneration(cacheGeneration);
     this.requireSuccessfulResponse(result);
   }
 
@@ -704,7 +750,7 @@ export class VRChatAPI {
       runnable: async () => {
         this.ensureCacheGeneration(cacheGeneration);
         return requestVRChat(`${BASE_URL}/message/${userId}/${type}`, {
-          headers: await this.getDefaultHeaders(),
+          headers: await this.getDefaultHeaders({}, cacheGeneration),
         });
       },
     });
@@ -725,7 +771,7 @@ export class VRChatAPI {
         this.ensureCacheGeneration(cacheGeneration);
         return requestVRChat(`${BASE_URL}/message/${userId}/${type}/${slot}`, {
           method: 'PUT',
-          headers: await this.getDefaultHeaders(),
+          headers: await this.getDefaultHeaders({}, cacheGeneration),
           body: JSON.stringify({ message }),
         });
       },
@@ -755,6 +801,7 @@ export class VRChatAPI {
     options: PaginatedRequestOptions,
     cacheGeneration?: number
   ): Promise<T[]> {
+    const requestGeneration = cacheGeneration ?? this.cacheGeneration;
     const { url, apiCallTypeId, query = {}, maxEntries = DEFAULT_PAGE_LIMIT } = options;
     const maxRetries = options.rateLimit?.maxRetries ?? DEFAULT_RATE_LIMIT_RETRIES;
     const retryDelay = options.rateLimit?.delay ?? DEFAULT_RATE_LIMIT_DELAY;
@@ -772,7 +819,7 @@ export class VRChatAPI {
             ...query,
           }).toString();
           return requestVRChat(`${url}?${queryParams}`, {
-            headers: await this.getDefaultHeaders(),
+            headers: await this.getDefaultHeaders({}, requestGeneration),
           });
         },
       });
@@ -810,7 +857,9 @@ export class VRChatAPI {
 
   /** Adds persisted auth cookies because the HTTP client has no cookie store. */
   private async getDefaultHeaders(
-    options: RequestHeaderOptions = {}
+    options: RequestHeaderOptions,
+    cacheGeneration: number,
+    profileId?: string
   ): Promise<Record<string, string>> {
     const {
       contentType = 'application/json',
@@ -818,11 +867,16 @@ export class VRChatAPI {
       includeTwoFactorCookie = true,
     } = options;
     const settings = await firstValueFrom(this.settings);
+    this.ensureCacheGeneration(cacheGeneration);
+    const profile = profileId
+      ? settings.profiles.find((candidate) => candidate.id === profileId)
+      : getActiveVRChatProfile(settings);
+    if (!profile) throw new Error('Cannot make a VRChat API request without an active profile');
     const cookies: string[] = [];
-    if (includeAuthCookie && settings.authCookie)
-      cookies.push(serializeCookie({ name: 'auth', value: settings.authCookie }));
-    if (includeTwoFactorCookie && settings.twoFactorCookie)
-      cookies.push(serializeCookie({ name: 'twoFactorAuth', value: settings.twoFactorCookie }));
+    if (includeAuthCookie && profile.authCookie)
+      cookies.push(serializeCookie({ name: 'auth', value: profile.authCookie }));
+    if (includeTwoFactorCookie && profile.twoFactorCookie)
+      cookies.push(serializeCookie({ name: 'twoFactorAuth', value: profile.twoFactorCookie }));
     return {
       Cookie: cookies.join('; '),
       'User-Agent': this.userAgent,
@@ -851,25 +905,35 @@ export class VRChatAPI {
     if (generation !== this.cacheGeneration) throw VRCHAT_API_STALE_REQUEST;
   }
 
-  private async parseResponseCookies(response: Response, cacheGeneration: number): Promise<void> {
-    const settings: Partial<VRChatApiSettings> = {};
+  private async requireActiveProfileId(): Promise<string> {
+    const profile = getActiveVRChatProfile(await firstValueFrom(this.settings));
+    if (!profile) throw new Error('Cannot make a VRChat API request without an active profile');
+    return profile.id;
+  }
+
+  private async parseResponseCookies(
+    response: Response,
+    cacheGeneration: number,
+    profileId: string
+  ): Promise<void> {
+    const patch: VRChatProfileSessionPatch = {};
     const cookieHeaders = response.headers.getSetCookie();
     for (const cookieHeader of cookieHeaders) {
       const cookies = parseSetCookieHeader(cookieHeader);
       for (const cookie of cookies) {
         switch (cookie.name) {
           case 'auth':
-            settings.authCookie = cookie.value;
+            patch.authCookie = cookie.value;
             break;
           case 'twoFactorAuth':
-            settings.twoFactorCookie = cookie.value;
+            patch.twoFactorCookie = cookie.value;
             break;
         }
       }
     }
-    if (!Object.keys(settings).length) return;
+    if (!Object.keys(patch).length) return;
     this.ensureCacheGeneration(cacheGeneration);
-    await this.trackWrite(this.updateSettings(settings));
+    await this.trackWrite(this.updateProfile(profileId, patch));
     this.ensureCacheGeneration(cacheGeneration);
   }
 }

--- a/src-ui/app/services/vrchat-api/vrchat-auth.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-auth.ts
@@ -639,6 +639,7 @@ export class VRChatAuth {
   private async completeLogin(user: CurrentUser): Promise<void> {
     const active = await this.requireActiveProfile();
     if (active.userId && active.userId !== user.id) {
+      warn(`[VRChat] Logged in as ${user.id} while profile ${active.userId} was expected`);
       await this.patchActiveProfile({ authCookie: null });
       throw 'PROFILE_MISMATCH';
     }

--- a/src-ui/app/services/vrchat-api/vrchat-auth.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-auth.ts
@@ -53,30 +53,33 @@ const STATUS_POLL_INTERVAL = 60_000;
 const SOCKET_UPDATE_HEALTH_WINDOW = 60 * 60_000;
 const STATUS_FRESHNESS_WINDOW = 10 * 60_000;
 
-function shouldRetryCurrentUserRequest(cause: unknown): boolean {
-  return ![
-    'INVALID_CREDENTIALS',
-    'MISSING_CREDENTIALS',
-    'CHECK_EMAIL',
-    'UNSUPPORTED_2FA_METHOD',
-    '2FA_TOTP_REQUIRED',
-    '2FA_EMAILOTP_REQUIRED',
-    'PROFILE_MISMATCH',
-    'AUTHENTICATION_REJECTED',
-  ].includes(String(cause));
+interface VRChatLoginModalOptions {
+  autoLogin?: boolean;
+  twoFactorMethod?: VRChatTwoFactorMethod;
+  initialError?: string;
+  username?: string;
+  newAccount?: boolean;
+  restoreProfileIdOnCancel?: string;
+  keepActiveProfile?: boolean;
 }
 
+const REAUTHENTICATION_ERRORS: readonly string[] = [
+  'INVALID_CREDENTIALS',
+  'MISSING_CREDENTIALS',
+  'CHECK_EMAIL',
+  'UNSUPPORTED_2FA_METHOD',
+  '2FA_TOTP_REQUIRED',
+  '2FA_EMAILOTP_REQUIRED',
+  'PROFILE_MISMATCH',
+  'AUTHENTICATION_REJECTED',
+];
+
 function requiresSessionReauthentication(cause: unknown): boolean {
-  return [
-    'INVALID_CREDENTIALS',
-    'MISSING_CREDENTIALS',
-    'CHECK_EMAIL',
-    'UNSUPPORTED_2FA_METHOD',
-    '2FA_TOTP_REQUIRED',
-    '2FA_EMAILOTP_REQUIRED',
-    'PROFILE_MISMATCH',
-    'AUTHENTICATION_REJECTED',
-  ].includes(String(cause));
+  return REAUTHENTICATION_ERRORS.includes(String(cause));
+}
+
+function shouldRetryCurrentUserRequest(cause: unknown): boolean {
+  return !requiresSessionReauthentication(cause);
 }
 
 async function hashLoginIdentifier(identifier: string): Promise<string> {
@@ -168,17 +171,19 @@ export class VRChatAuth {
         signal,
         expectedUserId: savedProfile.userId ?? undefined,
       });
+      if ((await this.getActiveProfile())?.id !== savedProfile.id) return { status: 'RETRY' };
       if (savedProfile.userId && savedProfile.userId !== user.id) {
-        await this.patchActiveProfile({ authCookie: null });
+        await this.patchProfile(savedProfile.id, { authCookie: null });
         return { status: 'LOGIN_REQUIRED', error: 'PROFILE_MISMATCH' };
       }
       if (savedProfile.pendingTwoFactorLoginIdentifier) {
-        await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
+        await this.patchProfile(savedProfile.id, { pendingTwoFactorLoginIdentifier: null });
       }
       info(`[VRChat] Restored existing session`);
       return { status: 'RESTORED', user };
     } catch (e) {
       if (signal?.aborted) return { status: 'RETRY' };
+      if ((await this.getActiveProfile())?.id !== savedProfile.id) return { status: 'RETRY' };
       const method = twoFactorMethodFromError(e);
       if (method)
         return {
@@ -216,31 +221,28 @@ export class VRChatAuth {
   private handleSessionRestoreResult(result: SessionRestoreResult): void {
     switch (result.status) {
       case 'TWO_FACTOR_REQUIRED':
-        this.showLoginModal(
-          false,
-          result.method,
-          undefined,
-          result.loginIdentifier,
-          false,
-          undefined,
-          true
-        );
+        this.showLoginModal({
+          twoFactorMethod: result.method,
+          username: result.loginIdentifier,
+          keepActiveProfile: true,
+        });
         break;
       case 'LOGIN_REQUIRED':
         info(`[VRChat] Login expired.`);
-        this.showLoginModal(true, undefined, result.error, undefined, false, undefined, true);
+        this.showLoginModal({
+          autoLogin: true,
+          initialError: result.error,
+          keepActiveProfile: true,
+        });
         this.scheduleSessionRestore();
         break;
       case 'TEMPORARILY_REJECTED':
-        this.showLoginModal(
-          false,
-          undefined,
-          result.error,
-          result.loginIdentifier,
-          false,
-          result.sourceProfileId,
-          true
-        );
+        this.showLoginModal({
+          initialError: result.error,
+          username: result.loginIdentifier,
+          restoreProfileIdOnCancel: result.sourceProfileId,
+          keepActiveProfile: true,
+        });
         this.scheduleSessionRestore();
         break;
       case 'RETRY':
@@ -302,16 +304,17 @@ export class VRChatAuth {
 
   // authentication
 
-  public showLoginModal(
-    autoLogin = false,
-    twoFactorMethod?: VRChatTwoFactorMethod,
-    initialError?: string,
-    username?: string,
-    newAccount = false,
-    restoreProfileIdOnCancel?: string,
-    keepActiveProfile = false
-  ): void {
+  public showLoginModal(options: VRChatLoginModalOptions = {}): void {
     if (this.modalService.isModalOpen(LOGIN_MODAL_ID)) return;
+    const {
+      autoLogin = false,
+      twoFactorMethod,
+      initialError,
+      username,
+      newAccount = false,
+      restoreProfileIdOnCancel,
+      keepActiveProfile = false,
+    } = options;
     this.modalService
       .addModal(
         VRChatLoginModalComponent,
@@ -355,7 +358,15 @@ export class VRChatAuth {
     }
   }
 
-  public async login(username: string, password: string, keepActiveProfile = false): Promise<void> {
+  public login(username: string, password: string, keepActiveProfile = false): Promise<void> {
+    return this.queueTransition(() => this.loginNow(username, password, keepActiveProfile));
+  }
+
+  private async loginNow(
+    username: string,
+    password: string,
+    keepActiveProfile = false
+  ): Promise<void> {
     if (this.statusSubject.value !== 'LOGGED_OUT')
       throw new Error('Tried calling login() while already logged in');
     this.cancelSessionRestore();
@@ -412,7 +423,7 @@ export class VRChatAuth {
     return this.queueTransition(async () => {
       const previousProfile = await this.getActiveProfile();
       if (previousProfile?.draft && !previousProfile.sourceProfileId) {
-        await this.login(username, password, true);
+        await this.loginNow(username, password, true);
         return;
       }
       const previousUser = this.userSubject.value;
@@ -435,7 +446,7 @@ export class VRChatAuth {
           user: previousUser,
         });
       }
-      await this.login(username, password, true);
+      await this.loginNow(username, password, true);
     });
   }
 
@@ -512,15 +523,12 @@ export class VRChatAuth {
     const restoreProfileIdOnCancel =
       this.suspendedSessions.get(attempt.id)?.profileId ?? attempt.sourceProfileId ?? undefined;
     if (result.status === 'TWO_FACTOR_REQUIRED') {
-      this.showLoginModal(
-        false,
-        result.method,
-        undefined,
-        result.loginIdentifier,
-        false,
+      this.showLoginModal({
+        twoFactorMethod: result.method,
+        username: result.loginIdentifier,
         restoreProfileIdOnCancel,
-        true
-      );
+        keepActiveProfile: true,
+      });
       return;
     }
     if (result.status === 'RETRY') {
@@ -538,7 +546,7 @@ export class VRChatAuth {
     const credentials = await this.loadCredentials();
     if (credentials) {
       try {
-        await this.login(credentials.username, credentials.password, true);
+        await this.loginNow(credentials.username, credentials.password, true);
         return;
       } catch (cause) {
         const method = twoFactorMethodFromError(cause);
@@ -548,29 +556,24 @@ export class VRChatAuth {
           await this.restoreProfileAttempt(attempt, restoreProfileIdOnCancel);
           return;
         }
-        this.showLoginModal(
-          false,
-          method,
-          method ? undefined : String(cause),
-          credentials.username,
-          false,
+        this.showLoginModal({
+          twoFactorMethod: method,
+          initialError: method ? undefined : String(cause),
+          username: credentials.username,
           restoreProfileIdOnCancel,
-          true
-        );
+          keepActiveProfile: true,
+        });
         if (temporaryFailure) this.scheduleSessionRestore();
         return;
       }
     }
     const profile = await this.requireActiveProfile();
-    this.showLoginModal(
-      false,
-      undefined,
-      result.status === 'LOGIN_REQUIRED' ? result.error : undefined,
-      profile.username ?? undefined,
-      false,
+    this.showLoginModal({
+      initialError: result.status === 'LOGIN_REQUIRED' ? result.error : undefined,
+      username: profile.username ?? undefined,
       restoreProfileIdOnCancel,
-      true
-    );
+      keepActiveProfile: true,
+    });
     this.scheduleSessionRestore();
   }
 
@@ -584,7 +587,7 @@ export class VRChatAuth {
     const restoreProfileIdOnCancel = active?.draft
       ? (getVRChatProfileAttemptSource(settings, active)?.id ?? undefined)
       : active?.id;
-    this.showLoginModal(false, undefined, undefined, undefined, true, restoreProfileIdOnCancel);
+    this.showLoginModal({ newAccount: true, restoreProfileIdOnCancel });
   }
 
   public removeProfile(profileId: string): Promise<void> {
@@ -669,7 +672,11 @@ export class VRChatAuth {
 
   private async patchActiveProfile(patch: VRChatProfileSessionPatch): Promise<void> {
     const profile = await this.requireActiveProfile();
-    await this.mutateSettings((settings) => patchVRChatProfile(settings, profile.id, patch));
+    await this.patchProfile(profile.id, patch);
+  }
+
+  private async patchProfile(profileId: string, patch: VRChatProfileSessionPatch): Promise<void> {
+    await this.mutateSettings((settings) => patchVRChatProfile(settings, profileId, patch));
   }
 
   private async selectLoginProfile(loginIdentifierHash: string): Promise<void> {

--- a/src-ui/app/services/vrchat-api/vrchat-auth.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-auth.ts
@@ -19,6 +19,8 @@ import {
 import {
   adoptVRChatProfileIdentity,
   createVRChatDraftProfile,
+  createVRChatProfileAttempt,
+  getVRChatProfileAttemptSource,
   patchVRChatProfile,
   pruneVRChatDraftProfiles,
   removeVRChatProfile,
@@ -32,6 +34,12 @@ type SessionRestoreResult =
   | { status: 'NONE' | 'RETRY' }
   | { status: 'RESTORED'; user: CurrentUser }
   | { status: 'LOGIN_REQUIRED'; error?: string }
+  | {
+      status: 'TEMPORARILY_REJECTED';
+      error: string;
+      loginIdentifier?: string;
+      sourceProfileId?: string;
+    }
   | {
       status: 'TWO_FACTOR_REQUIRED';
       method: VRChatTwoFactorMethod;
@@ -53,6 +61,21 @@ function shouldRetryCurrentUserRequest(cause: unknown): boolean {
     'UNSUPPORTED_2FA_METHOD',
     '2FA_TOTP_REQUIRED',
     '2FA_EMAILOTP_REQUIRED',
+    'PROFILE_MISMATCH',
+    'AUTHENTICATION_REJECTED',
+  ].includes(String(cause));
+}
+
+function requiresSessionReauthentication(cause: unknown): boolean {
+  return [
+    'INVALID_CREDENTIALS',
+    'MISSING_CREDENTIALS',
+    'CHECK_EMAIL',
+    'UNSUPPORTED_2FA_METHOD',
+    '2FA_TOTP_REQUIRED',
+    '2FA_EMAILOTP_REQUIRED',
+    'PROFILE_MISMATCH',
+    'AUTHENTICATION_REJECTED',
   ].includes(String(cause));
 }
 
@@ -76,6 +99,7 @@ export class VRChatAuth {
   private lastUserUpdateAt = 0;
   private lastStatusUpdateAt = 0;
   private transition: Promise<void> = Promise.resolve();
+  private readonly suspendedSessions = new Map<string, { profileId: string; user: CurrentUser }>();
 
   public readonly status = this.statusSubject.asObservable();
   public readonly user = this.userSubject.asObservable();
@@ -92,7 +116,23 @@ export class VRChatAuth {
   // session restoration
 
   public async init(): Promise<void> {
+    const active = await this.getActiveProfile();
+    const resumedAttempt = active?.draft ? active : null;
+    if (active && !active.draft) {
+      await this.mutateSettings((settings) => createVRChatProfileAttempt(settings, active.id));
+    }
     let restoreResult = await this.loadSession();
+    if (
+      (restoreResult.status === 'NONE' || restoreResult.status === 'RETRY') &&
+      resumedAttempt?.restoreProfileId
+    ) {
+      await this.restoreProfileAttempt(resumedAttempt);
+      const restored = await this.getActiveProfile();
+      if (restored?.authCookie && !restored.draft) {
+        await this.mutateSettings((settings) => createVRChatProfileAttempt(settings, restored.id));
+        restoreResult = await this.loadSession();
+      }
+    }
     if (restoreResult.status === 'RESTORED') {
       try {
         await this.completeLogin(restoreResult.user);
@@ -121,13 +161,13 @@ export class VRChatAuth {
   private async loadSession(signal?: AbortSignal): Promise<SessionRestoreResult> {
     const savedProfile = await this.getActiveProfile();
     if (!savedProfile?.authCookie) {
-      if (savedProfile?.pendingTwoFactorLoginIdentifier) {
-        await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
-      }
       return { status: 'NONE' };
     }
     try {
-      const user = await this.api.getCurrentUser({ signal });
+      const user = await this.api.getCurrentUser({
+        signal,
+        expectedUserId: savedProfile.userId ?? undefined,
+      });
       if (savedProfile.userId && savedProfile.userId !== user.id) {
         await this.patchActiveProfile({ authCookie: null });
         return { status: 'LOGIN_REQUIRED', error: 'PROFILE_MISMATCH' };
@@ -151,21 +191,21 @@ export class VRChatAuth {
         case 'MISSING_CREDENTIALS':
           await this.api.clearCaches();
           if (signal?.aborted) return { status: 'RETRY' };
-          await this.patchActiveProfile({
-            authCookie: null,
-            pendingTwoFactorLoginIdentifier: null,
-          });
           info(`[VRChat] Failed to restore session: ${e}`);
           return { status: 'LOGIN_REQUIRED' };
-        case 'CHECK_EMAIL':
         case 'UNSUPPORTED_2FA_METHOD':
-          await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
+        case 'PROFILE_MISMATCH':
           info(`[VRChat] Failed to restore session: ${e}`);
           return { status: 'LOGIN_REQUIRED', error: String(e) };
+        case 'CHECK_EMAIL':
         case 'AUTHENTICATION_REJECTED':
-          await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
           info(`[VRChat] Failed to restore session: ${e}`);
-          return { status: 'LOGIN_REQUIRED', error: 'UNEXPECTED_RESPONSE' };
+          return {
+            status: 'TEMPORARILY_REJECTED',
+            error: String(e === 'CHECK_EMAIL' ? e : 'UNEXPECTED_RESPONSE'),
+            loginIdentifier: await this.loadPendingTwoFactorLoginIdentifier(),
+            sourceProfileId: savedProfile.sourceProfileId ?? undefined,
+          };
         default:
           error(`[VRChat] Error trying to restore session: ${e}`);
           return { status: 'RETRY' };
@@ -176,11 +216,32 @@ export class VRChatAuth {
   private handleSessionRestoreResult(result: SessionRestoreResult): void {
     switch (result.status) {
       case 'TWO_FACTOR_REQUIRED':
-        this.showLoginModal(false, result.method, undefined, result.loginIdentifier);
+        this.showLoginModal(
+          false,
+          result.method,
+          undefined,
+          result.loginIdentifier,
+          false,
+          undefined,
+          true
+        );
         break;
       case 'LOGIN_REQUIRED':
         info(`[VRChat] Login expired.`);
         this.showLoginModal(true, undefined, result.error, undefined, false, undefined, true);
+        this.scheduleSessionRestore();
+        break;
+      case 'TEMPORARILY_REJECTED':
+        this.showLoginModal(
+          false,
+          undefined,
+          result.error,
+          result.loginIdentifier,
+          false,
+          result.sourceProfileId,
+          true
+        );
+        this.scheduleSessionRestore();
         break;
       case 'RETRY':
         this.scheduleSessionRestore();
@@ -198,7 +259,7 @@ export class VRChatAuth {
       this.sessionRestoreAbortController = abortController;
       const restore = this.loadSession(abortController.signal);
       this.sessionRestoreInFlight = restore;
-      const result = await restore.catch((e) => {
+      let result = await restore.catch((e) => {
         error(`[VRChat] Error trying to restore session: ${e}`);
         return { status: 'RETRY' } as SessionRestoreResult;
       });
@@ -208,9 +269,19 @@ export class VRChatAuth {
       }
       if (generation !== this.sessionRestoreGeneration) return;
       if (result.status === 'RESTORED') {
-        await this.completeLogin(result.user);
-        this.modalService.closeModal(LOGIN_MODAL_ID);
+        const user = result.user;
+        try {
+          await this.queueTransition(async () => {
+            if (generation !== this.sessionRestoreGeneration) return;
+            await this.completeLogin(user);
+            this.modalService.closeModal(LOGIN_MODAL_ID);
+          });
+        } catch (cause) {
+          error(`[VRChat] Failed to complete restored login: ${cause}`);
+          result = { status: 'LOGIN_REQUIRED', error: 'UNEXPECTED_RESPONSE' };
+        }
       }
+      if (generation !== this.sessionRestoreGeneration) return;
       this.handleSessionRestoreResult(result);
     }, SESSION_RESTORE_RETRY_DELAY);
   }
@@ -219,6 +290,7 @@ export class VRChatAuth {
     this.sessionRestoreGeneration++;
     clearTimeout(this.sessionRestoreRetry);
     this.sessionRestoreRetry = undefined;
+    this.sessionRestoreInFlight = undefined;
     this.sessionRestoreAbortController?.abort();
     this.sessionRestoreAbortController = undefined;
   }
@@ -257,28 +329,28 @@ export class VRChatAuth {
         }
       )
       .subscribe(() => {
-        void this.finishLoginModal(newAccount, restoreProfileIdOnCancel);
+        void this.queueTransition(() => this.finishLoginModal(restoreProfileIdOnCancel));
       });
   }
 
-  private async finishLoginModal(
-    newAccount: boolean,
-    restoreProfileIdOnCancel?: string
-  ): Promise<void> {
+  private async finishLoginModal(restoreProfileIdOnCancel?: string): Promise<void> {
+    this.cancelSessionRestore();
     const incompleteProfile = !this.userSubject.value
       ? await this.getActiveProfile().then((profile) => (profile?.draft ? profile : null))
       : null;
     if (incompleteProfile) {
-      await this.api
-        .logoutProfile(incompleteProfile.id)
-        .catch((cause) => warn(`[VRChat] Failed to invalidate cancelled login: ${cause}`));
-    }
-    await this.mutateSettings(pruneVRChatDraftProfiles).catch((cause) =>
-      error(`[VRChat] Failed to clean up login profiles: ${cause}`)
-    );
-    if (newAccount && restoreProfileIdOnCancel && !this.userSubject.value) {
-      await this.activateProfile(restoreProfileIdOnCancel).catch((cause) =>
+      const settings = await firstValueFrom(this.settings);
+      if (!getVRChatProfileAttemptSource(settings, incompleteProfile)) {
+        await this.api
+          .logoutProfile(incompleteProfile.id)
+          .catch((cause) => warn(`[VRChat] Failed to invalidate cancelled login: ${cause}`));
+      }
+      await this.restoreProfileAttempt(incompleteProfile, restoreProfileIdOnCancel).catch((cause) =>
         error(`[VRChat] Failed to restore the previous profile: ${cause}`)
+      );
+    } else {
+      await this.mutateSettings(pruneVRChatDraftProfiles).catch((cause) =>
+        error(`[VRChat] Failed to clean up login profiles: ${cause}`)
       );
     }
   }
@@ -309,12 +381,12 @@ export class VRChatAuth {
       user = await this.api.getCurrentUser({
         credentials: { username, password },
         includeTwoFactorCookie: reuseTwoFactorCookie,
+        expectedUserId: savedProfile.userId ?? undefined,
       });
     } catch (cause) {
       if (twoFactorMethodFromError(cause)) {
         this.pendingTwoFactorLoginIdentifierHash = loginIdentifierHash;
         await this.patchActiveProfile({
-          twoFactorCookie: null,
           twoFactorCookieLoginIdentifierHash: loginIdentifierHash,
           pendingTwoFactorLoginIdentifier: username,
         });
@@ -338,10 +410,31 @@ export class VRChatAuth {
 
   public loginNewAccount(username: string, password: string): Promise<void> {
     return this.queueTransition(async () => {
+      const previousProfile = await this.getActiveProfile();
+      if (previousProfile?.draft && !previousProfile.sourceProfileId) {
+        await this.login(username, password, true);
+        return;
+      }
+      const previousUser = this.userSubject.value;
       await this.deactivate();
-      await this.mutateSettings((settings) =>
-        createVRChatDraftProfile(pruneVRChatDraftProfiles(setActiveVRChatProfile(settings, null)))
-      );
+      let settings: VRChatApiSettings;
+      try {
+        settings = await this.mutateSettings((settings) =>
+          createVRChatDraftProfile(pruneVRChatDraftProfiles(settings))
+        );
+      } catch (cause) {
+        if (previousUser) {
+          this.setCurrentUser(previousUser);
+          this.statusSubject.next('LOGGED_IN');
+        }
+        throw cause;
+      }
+      if (previousProfile && previousUser && settings.activeProfileId) {
+        this.suspendedSessions.set(settings.activeProfileId, {
+          profileId: previousProfile.id,
+          user: previousUser,
+        });
+      }
       await this.login(username, password, true);
     });
   }
@@ -355,7 +448,6 @@ export class VRChatAuth {
     await this.api.clearCaches();
     const { authCookie } = await this.requireActiveProfile();
     if (!authCookie) throw new Error('Called verify2FA() before successfully calling login()');
-    await this.clearTwoFactorCookie(this.pendingTwoFactorLoginIdentifierHash !== undefined);
     await this.api.verify2FA(code, method);
     await this.patchActiveProfile({
       pendingTwoFactorLoginIdentifier: null,
@@ -364,7 +456,14 @@ export class VRChatAuth {
         : {}),
     });
     this.pendingTwoFactorLoginIdentifierHash = undefined;
-    await this.completeLogin(await this.getCurrentUserAfter2FA());
+    let user: CurrentUser;
+    try {
+      user = await this.getCurrentUserAfter2FA();
+    } catch (cause) {
+      this.scheduleSessionRestore();
+      throw cause;
+    }
+    await this.completeLogin(user);
   }
 
   public logout(): Promise<void> {
@@ -383,25 +482,59 @@ export class VRChatAuth {
     return this.queueTransition(() => this.activateProfileNow(profileId));
   }
 
-  private async activateProfileNow(profileId: string): Promise<void> {
+  private async activateProfileNow(profileId: string, force = false): Promise<void> {
     const current = await this.getActiveProfile();
-    if (current?.id === profileId && this.statusSubject.value === 'LOGGED_IN') return;
+    if (!force && current?.id === profileId && this.statusSubject.value === 'LOGGED_IN') return;
+    const previousUser = this.userSubject.value;
     await this.deactivate();
-    await this.mutateSettings((settings) => setActiveVRChatProfile(settings, profileId));
+    let settings: VRChatApiSettings;
+    try {
+      settings = await this.mutateSettings((settings) =>
+        createVRChatProfileAttempt(pruneVRChatDraftProfiles(settings), profileId)
+      );
+    } catch (cause) {
+      if (previousUser) {
+        this.setCurrentUser(previousUser);
+        this.statusSubject.next('LOGGED_IN');
+      }
+      throw cause;
+    }
+    const attempt = getActiveVRChatProfile(settings);
+    if (!attempt) throw new Error('Failed to create VRChat profile attempt');
+    if (current && previousUser) {
+      this.suspendedSessions.set(attempt.id, { profileId: current.id, user: previousUser });
+    }
     const result = await this.loadSession();
     if (result.status === 'RESTORED') {
       await this.completeLogin(result.user);
       return;
     }
+    const restoreProfileIdOnCancel =
+      this.suspendedSessions.get(attempt.id)?.profileId ?? attempt.sourceProfileId ?? undefined;
     if (result.status === 'TWO_FACTOR_REQUIRED') {
-      this.showLoginModal(false, result.method, undefined, result.loginIdentifier);
+      this.showLoginModal(
+        false,
+        result.method,
+        undefined,
+        result.loginIdentifier,
+        false,
+        restoreProfileIdOnCancel,
+        true
+      );
       return;
     }
     if (result.status === 'RETRY') {
+      if (this.suspendedSessions.has(attempt.id)) {
+        await this.restoreProfileAttempt(attempt, restoreProfileIdOnCancel);
+        return;
+      }
       this.handleSessionRestoreResult(result);
       return;
     }
-
+    if (result.status === 'TEMPORARILY_REJECTED') {
+      this.handleSessionRestoreResult(result);
+      return;
+    }
     const credentials = await this.loadCredentials();
     if (credentials) {
       try {
@@ -409,15 +542,22 @@ export class VRChatAuth {
         return;
       } catch (cause) {
         const method = twoFactorMethodFromError(cause);
+        const temporaryFailure =
+          !method && !['INVALID_CREDENTIALS', 'PROFILE_MISMATCH'].includes(String(cause));
+        if (temporaryFailure && this.suspendedSessions.has(attempt.id)) {
+          await this.restoreProfileAttempt(attempt, restoreProfileIdOnCancel);
+          return;
+        }
         this.showLoginModal(
           false,
           method,
           method ? undefined : String(cause),
           credentials.username,
           false,
-          undefined,
+          restoreProfileIdOnCancel,
           true
         );
+        if (temporaryFailure) this.scheduleSessionRestore();
         return;
       }
     }
@@ -428,9 +568,10 @@ export class VRChatAuth {
       result.status === 'LOGIN_REQUIRED' ? result.error : undefined,
       profile.username ?? undefined,
       false,
-      undefined,
+      restoreProfileIdOnCancel,
       true
     );
+    this.scheduleSessionRestore();
   }
 
   public prepareNewLogin(): Promise<void> {
@@ -438,19 +579,35 @@ export class VRChatAuth {
   }
 
   private async prepareNewLoginNow(): Promise<void> {
-    const restoreProfileIdOnCancel = this.userSubject.value
-      ? (await this.getActiveProfile())?.id
-      : undefined;
+    const settings = await firstValueFrom(this.settings);
+    const active = getActiveVRChatProfile(settings);
+    const restoreProfileIdOnCancel = active?.draft
+      ? (getVRChatProfileAttemptSource(settings, active)?.id ?? undefined)
+      : active?.id;
     this.showLoginModal(false, undefined, undefined, undefined, true, restoreProfileIdOnCancel);
   }
 
   public removeProfile(profileId: string): Promise<void> {
     return this.queueTransition(async () => {
-      if ((await this.getActiveProfile())?.id === profileId) await this.deactivate();
+      const settings = await firstValueFrom(this.settings);
+      const attempts = settings.profiles.filter(
+        (profile) =>
+          profile.draft &&
+          (profile.sourceProfileId === profileId || profile.restoreProfileId === profileId)
+      );
+      const active = getActiveVRChatProfile(settings);
+      if (active?.id === profileId || attempts.some((attempt) => attempt.id === active?.id)) {
+        await this.deactivate();
+      }
       await this.api
         .logoutProfile(profileId)
         .catch((cause) => warn(`[VRChat] Failed to invalidate removed profile: ${cause}`));
-      await this.mutateSettings((settings) => removeVRChatProfile(settings, profileId));
+      await this.mutateSettings((currentSettings) => {
+        let updated = currentSettings;
+        for (const attempt of attempts) updated = removeVRChatProfile(updated, attempt.id);
+        return removeVRChatProfile(updated, profileId);
+      });
+      for (const attempt of attempts) this.suspendedSessions.delete(attempt.id);
     });
   }
 
@@ -477,6 +634,7 @@ export class VRChatAuth {
       throw 'PROFILE_MISMATCH';
     }
     await this.mutateSettings((settings) => adoptVRChatProfileIdentity(settings, user));
+    this.suspendedSessions.delete(active.id);
     this.setCurrentUser(user);
     this.statusSubject.next('LOGGED_IN');
     info(`[VRChat] Logged in: ${user.displayName}`);
@@ -517,12 +675,44 @@ export class VRChatAuth {
   private async selectLoginProfile(loginIdentifierHash: string): Promise<void> {
     await this.mutateSettings((settings) => {
       const matching = settings.profiles.find(
-        (profile) => profile.twoFactorCookieLoginIdentifierHash === loginIdentifierHash
+        (profile) =>
+          !profile.draft && profile.twoFactorCookieLoginIdentifierHash === loginIdentifierHash
       );
-      if (matching) return setActiveVRChatProfile(settings, matching.id);
+      if (matching) {
+        return createVRChatProfileAttempt(pruneVRChatDraftProfiles(settings), matching.id);
+      }
       const active = getActiveVRChatProfile(settings);
-      return active && !active.userId ? settings : createVRChatDraftProfile(settings);
+      return active && !active.userId
+        ? settings
+        : createVRChatDraftProfile(pruneVRChatDraftProfiles(settings));
     });
+  }
+
+  private async restoreProfileAttempt(
+    attempt: VRChatAccountProfile,
+    fallbackProfileId?: string
+  ): Promise<boolean> {
+    const suspended = this.suspendedSessions.get(attempt.id);
+    const settings = await firstValueFrom(this.settings);
+    const source = getVRChatProfileAttemptSource(settings, attempt);
+    const profileId =
+      suspended?.profileId ?? attempt.restoreProfileId ?? source?.id ?? fallbackProfileId;
+    await this.mutateSettings((currentSettings) => {
+      const pruned = pruneVRChatDraftProfiles(currentSettings);
+      return profileId && pruned.profiles.some((profile) => profile.id === profileId)
+        ? setActiveVRChatProfile(pruned, profileId)
+        : setActiveVRChatProfile(pruned, null);
+    });
+    this.suspendedSessions.delete(attempt.id);
+    if (!suspended) {
+      this.userSubject.next(null);
+      this.statusSubject.next('LOGGED_OUT');
+      return false;
+    }
+    this.setCurrentUser(suspended.user);
+    this.statusSubject.next('LOGGED_IN');
+    info(`[VRChat] Restored previous account after unsuccessful login attempt`);
+    return true;
   }
 
   private async loadPendingTwoFactorLoginIdentifier(): Promise<string | undefined> {
@@ -549,17 +739,34 @@ export class VRChatAuth {
     interval(STATUS_POLL_INTERVAL).subscribe(async () => {
       if (this.statusSubject.value !== 'LOGGED_IN') return;
       const needsPolling =
-        Date.now() - this.lastUserUpdateAt > SOCKET_UPDATE_HEALTH_WINDOW &&
+        Date.now() - this.lastUserUpdateAt > SOCKET_UPDATE_HEALTH_WINDOW ||
         Date.now() - this.lastStatusUpdateAt > STATUS_FRESHNESS_WINDOW;
       if (!needsPolling) return;
-      try {
-        const result = await this.api.pollCurrentUser();
-        if (result.error) throw result.error;
-        if (result.result) this.patchCurrentUser(result.result);
-      } catch (e) {
-        error(`[VRChat] Error polling user: ${JSON.stringify(e)}`);
-      }
+      await this.revalidateSession();
     });
+  }
+
+  public async revalidateSession(): Promise<void> {
+    if (this.statusSubject.value !== 'LOGGED_IN') return;
+    let polledProfileId: string | undefined;
+    try {
+      const active = await this.getActiveProfile();
+      polledProfileId = active?.id;
+      const result = await this.api.pollCurrentUser(active?.userId ?? undefined);
+      if (result.error) throw result.error;
+      if (result.result) this.patchCurrentUser(result.result);
+    } catch (cause) {
+      error(`[VRChat] Error polling user: ${JSON.stringify(cause)}`);
+      if (!requiresSessionReauthentication(cause)) return;
+      await this.queueTransition(async () => {
+        if (this.statusSubject.value !== 'LOGGED_IN') return;
+        const active = await this.getActiveProfile();
+        if (!active || active.draft || active.id !== polledProfileId) return;
+        await this.activateProfileNow(active.id, true);
+      }).catch((recoveryCause) =>
+        error(`[VRChat] Failed to recover expired session: ${recoveryCause}`)
+      );
+    }
   }
 
   // remembered credentials
@@ -572,10 +779,14 @@ export class VRChatAuth {
   }
 
   public async forgetCredentials(): Promise<void> {
-    await this.patchActiveProfile({
-      rememberedCredentials: null,
-      rememberCredentials: false,
-    });
+    const profile = await this.getActiveProfile();
+    if (!profile) return;
+    await this.mutateSettings((settings) =>
+      patchVRChatProfile(settings, profile.id, {
+        rememberedCredentials: null,
+        rememberCredentials: false,
+      })
+    );
   }
 
   public async loadCredentials(): Promise<{ username: string; password: string } | null> {

--- a/src-ui/app/services/vrchat-api/vrchat-auth.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-auth.ts
@@ -1,4 +1,4 @@
-import { error, info } from '@tauri-apps/plugin-log';
+import { error, info, warn } from '@tauri-apps/plugin-log';
 import { twoFactorMethodFromError, VRChatAPI, VRChatTwoFactorMethod } from './vrchat-api';
 import { ModalService } from '../modal.service';
 import { VRChatLoginModalComponent } from 'src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component';
@@ -11,14 +11,20 @@ import {
   Observable,
 } from 'rxjs';
 import type { CurrentUser } from 'vrchat';
-import { VRChatApiSettings } from 'src-ui/app/models/vrchat-api-settings';
 import {
-  decryptStorageData,
-  deserializeStorageCryptoKey,
-  encryptStorageData,
-  generateStorageCryptoKey,
-  serializeStorageCryptoKey,
-} from 'src-ui/app/utils/crypto';
+  getActiveVRChatProfile,
+  VRChatAccountProfile,
+  VRChatApiSettings,
+} from 'src-ui/app/models/vrchat-api-settings';
+import {
+  adoptVRChatProfileIdentity,
+  createVRChatDraftProfile,
+  patchVRChatProfile,
+  pruneVRChatDraftProfiles,
+  removeVRChatProfile,
+  setActiveVRChatProfile,
+  VRChatProfileSessionPatch,
+} from './vrchat-profiles';
 
 export type VRChatAuthStatus = 'PRE_INIT' | 'LOGGED_OUT' | 'LOGGED_IN';
 
@@ -69,6 +75,7 @@ export class VRChatAuth {
   private pendingTwoFactorLoginIdentifierHash?: string;
   private lastUserUpdateAt = 0;
   private lastStatusUpdateAt = 0;
+  private transition: Promise<void> = Promise.resolve();
 
   public readonly status = this.statusSubject.asObservable();
   public readonly user = this.userSubject.asObservable();
@@ -76,15 +83,24 @@ export class VRChatAuth {
   constructor(
     private readonly api: VRChatAPI,
     private readonly modalService: ModalService,
-    private readonly updateSettings: (settings: Partial<VRChatApiSettings>) => Promise<void>,
+    private readonly mutateSettings: (
+      mutator: (settings: VRChatApiSettings) => VRChatApiSettings
+    ) => Promise<VRChatApiSettings>,
     private readonly settings: Observable<VRChatApiSettings>
   ) {}
 
   // session restoration
 
   public async init(): Promise<void> {
-    const restoreResult = await this.loadSession();
-    if (restoreResult.status === 'RESTORED') this.setCurrentUser(restoreResult.user);
+    let restoreResult = await this.loadSession();
+    if (restoreResult.status === 'RESTORED') {
+      try {
+        await this.completeLogin(restoreResult.user);
+      } catch (cause) {
+        error(`[VRChat] Failed to complete restored login: ${cause}`);
+        restoreResult = { status: 'LOGIN_REQUIRED', error: 'UNEXPECTED_RESPONSE' };
+      }
+    }
     this.statusSubject.next(this.userSubject.value ? 'LOGGED_IN' : 'LOGGED_OUT');
     this.handleSessionRestoreResult(restoreResult);
     this.startStatusPolling();
@@ -103,17 +119,21 @@ export class VRChatAuth {
   }
 
   private async loadSession(signal?: AbortSignal): Promise<SessionRestoreResult> {
-    const savedSettings = await firstValueFrom(this.settings);
-    if (!savedSettings.authCookie) {
-      if (savedSettings.encryptedPendingTwoFactorLoginIdentifier) {
-        await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
+    const savedProfile = await this.getActiveProfile();
+    if (!savedProfile?.authCookie) {
+      if (savedProfile?.pendingTwoFactorLoginIdentifier) {
+        await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
       }
       return { status: 'NONE' };
     }
     try {
       const user = await this.api.getCurrentUser({ signal });
-      if (savedSettings.encryptedPendingTwoFactorLoginIdentifier) {
-        await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
+      if (savedProfile.userId && savedProfile.userId !== user.id) {
+        await this.patchActiveProfile({ authCookie: null });
+        return { status: 'LOGIN_REQUIRED', error: 'PROFILE_MISMATCH' };
+      }
+      if (savedProfile.pendingTwoFactorLoginIdentifier) {
+        await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
       }
       info(`[VRChat] Restored existing session`);
       return { status: 'RESTORED', user };
@@ -131,19 +151,19 @@ export class VRChatAuth {
         case 'MISSING_CREDENTIALS':
           await this.api.clearCaches();
           if (signal?.aborted) return { status: 'RETRY' };
-          await this.updateSettings({
+          await this.patchActiveProfile({
             authCookie: null,
-            encryptedPendingTwoFactorLoginIdentifier: null,
+            pendingTwoFactorLoginIdentifier: null,
           });
           info(`[VRChat] Failed to restore session: ${e}`);
           return { status: 'LOGIN_REQUIRED' };
         case 'CHECK_EMAIL':
         case 'UNSUPPORTED_2FA_METHOD':
-          await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
+          await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
           info(`[VRChat] Failed to restore session: ${e}`);
           return { status: 'LOGIN_REQUIRED', error: String(e) };
         case 'AUTHENTICATION_REJECTED':
-          await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
+          await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
           info(`[VRChat] Failed to restore session: ${e}`);
           return { status: 'LOGIN_REQUIRED', error: 'UNEXPECTED_RESPONSE' };
         default:
@@ -160,7 +180,7 @@ export class VRChatAuth {
         break;
       case 'LOGIN_REQUIRED':
         info(`[VRChat] Login expired.`);
-        this.showLoginModal(true, undefined, result.error);
+        this.showLoginModal(true, undefined, result.error, undefined, false, undefined, true);
         break;
       case 'RETRY':
         this.scheduleSessionRestore();
@@ -188,8 +208,7 @@ export class VRChatAuth {
       }
       if (generation !== this.sessionRestoreGeneration) return;
       if (result.status === 'RESTORED') {
-        this.setCurrentUser(result.user);
-        this.statusSubject.next('LOGGED_IN');
+        await this.completeLogin(result.user);
         this.modalService.closeModal(LOGIN_MODAL_ID);
       }
       this.handleSessionRestoreResult(result);
@@ -215,38 +234,73 @@ export class VRChatAuth {
     autoLogin = false,
     twoFactorMethod?: VRChatTwoFactorMethod,
     initialError?: string,
-    username?: string
+    username?: string,
+    newAccount = false,
+    restoreProfileIdOnCancel?: string,
+    keepActiveProfile = false
   ): void {
     if (this.modalService.isModalOpen(LOGIN_MODAL_ID)) return;
     this.modalService
       .addModal(
         VRChatLoginModalComponent,
-        { autoLogin, twoFactorMethod, initialError, ...(username ? { username } : {}) },
+        {
+          autoLogin,
+          newAccount,
+          keepActiveProfile,
+          twoFactorMethod,
+          initialError,
+          ...(username ? { username } : {}),
+        },
         {
           closeOnEscape: false,
           id: LOGIN_MODAL_ID,
         }
       )
-      .subscribe(() => {});
+      .subscribe(() => {
+        void this.finishLoginModal(newAccount, restoreProfileIdOnCancel);
+      });
   }
 
-  public async login(username: string, password: string): Promise<void> {
+  private async finishLoginModal(
+    newAccount: boolean,
+    restoreProfileIdOnCancel?: string
+  ): Promise<void> {
+    const incompleteProfile = !this.userSubject.value
+      ? await this.getActiveProfile().then((profile) => (profile?.draft ? profile : null))
+      : null;
+    if (incompleteProfile) {
+      await this.api
+        .logoutProfile(incompleteProfile.id)
+        .catch((cause) => warn(`[VRChat] Failed to invalidate cancelled login: ${cause}`));
+    }
+    await this.mutateSettings(pruneVRChatDraftProfiles).catch((cause) =>
+      error(`[VRChat] Failed to clean up login profiles: ${cause}`)
+    );
+    if (newAccount && restoreProfileIdOnCancel && !this.userSubject.value) {
+      await this.activateProfile(restoreProfileIdOnCancel).catch((cause) =>
+        error(`[VRChat] Failed to restore the previous profile: ${cause}`)
+      );
+    }
+  }
+
+  public async login(username: string, password: string, keepActiveProfile = false): Promise<void> {
     if (this.statusSubject.value !== 'LOGGED_OUT')
       throw new Error('Tried calling login() while already logged in');
     this.cancelSessionRestore();
     this.pendingTwoFactorLoginIdentifierHash = undefined;
-    await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
     const loginIdentifierHash = await hashLoginIdentifier(username);
-    const savedSettings = await firstValueFrom(this.settings);
-    const rememberedCredentials = savedSettings.twoFactorCookieLoginIdentifierHash
+    if (!keepActiveProfile) await this.selectLoginProfile(loginIdentifierHash);
+    await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
+    const savedProfile = await this.requireActiveProfile();
+    const rememberedCredentials = savedProfile.twoFactorCookieLoginIdentifierHash
       ? null
       : await this.loadCredentials();
     const rememberedLoginIdentifierHash = rememberedCredentials
       ? await hashLoginIdentifier(rememberedCredentials.username)
       : null;
     const reuseTwoFactorCookie =
-      !!savedSettings.twoFactorCookie &&
-      (savedSettings.twoFactorCookieLoginIdentifierHash === loginIdentifierHash ||
+      !!savedProfile.twoFactorCookie &&
+      (savedProfile.twoFactorCookieLoginIdentifierHash === loginIdentifierHash ||
         (rememberedLoginIdentifierHash === loginIdentifierHash &&
           rememberedCredentials?.password === password));
     await this.api.clearCaches();
@@ -259,28 +313,37 @@ export class VRChatAuth {
     } catch (cause) {
       if (twoFactorMethodFromError(cause)) {
         this.pendingTwoFactorLoginIdentifierHash = loginIdentifierHash;
-        await this.updateSettings({
+        await this.patchActiveProfile({
           twoFactorCookie: null,
           twoFactorCookieLoginIdentifierHash: loginIdentifierHash,
-          encryptedPendingTwoFactorLoginIdentifier:
-            await this.encryptPendingTwoFactorLoginIdentifier(username),
+          pendingTwoFactorLoginIdentifier: username,
         });
       }
       throw cause;
     }
     this.pendingTwoFactorLoginIdentifierHash = undefined;
-    const currentSettings = await firstValueFrom(this.settings);
+    const currentProfile = await this.requireActiveProfile();
     if (
       !reuseTwoFactorCookie &&
-      savedSettings.twoFactorCookie &&
-      currentSettings.twoFactorCookie === savedSettings.twoFactorCookie
+      savedProfile.twoFactorCookie &&
+      currentProfile.twoFactorCookie === savedProfile.twoFactorCookie
     ) {
       await this.clearTwoFactorCookie();
-    } else if (currentSettings.twoFactorCookie) {
-      await this.updateSettings({ twoFactorCookieLoginIdentifierHash: loginIdentifierHash });
+    } else if (currentProfile.twoFactorCookie) {
+      await this.patchActiveProfile({ twoFactorCookieLoginIdentifierHash: loginIdentifierHash });
     }
-    await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
-    this.completeLogin(user);
+    await this.patchActiveProfile({ pendingTwoFactorLoginIdentifier: null });
+    await this.completeLogin(user);
+  }
+
+  public loginNewAccount(username: string, password: string): Promise<void> {
+    return this.queueTransition(async () => {
+      await this.deactivate();
+      await this.mutateSettings((settings) =>
+        createVRChatDraftProfile(pruneVRChatDraftProfiles(setActiveVRChatProfile(settings, null)))
+      );
+      await this.login(username, password, true);
+    });
   }
 
   public async verify2FA(code: string, method: VRChatTwoFactorMethod): Promise<void> {
@@ -290,35 +353,130 @@ export class VRChatAuth {
     }
     this.cancelSessionRestore();
     await this.api.clearCaches();
-    const { authCookie } = await firstValueFrom(this.settings);
+    const { authCookie } = await this.requireActiveProfile();
     if (!authCookie) throw new Error('Called verify2FA() before successfully calling login()');
     await this.clearTwoFactorCookie(this.pendingTwoFactorLoginIdentifierHash !== undefined);
     await this.api.verify2FA(code, method);
-    await this.updateSettings({
-      encryptedPendingTwoFactorLoginIdentifier: null,
+    await this.patchActiveProfile({
+      pendingTwoFactorLoginIdentifier: null,
       ...(this.pendingTwoFactorLoginIdentifierHash
         ? { twoFactorCookieLoginIdentifierHash: this.pendingTwoFactorLoginIdentifierHash }
         : {}),
     });
     this.pendingTwoFactorLoginIdentifierHash = undefined;
-    this.completeLogin(await this.getCurrentUserAfter2FA());
+    await this.completeLogin(await this.getCurrentUserAfter2FA());
   }
 
-  public async logout(): Promise<void> {
-    this.cancelSessionRestore();
-    await this.api.clearCaches();
-    await this.updateSettings({
-      authCookie: null,
-      twoFactorCookie: null,
-      twoFactorCookieLoginIdentifierHash: null,
-      encryptedPendingTwoFactorLoginIdentifier: null,
+  public logout(): Promise<void> {
+    return this.queueTransition(() => this.disconnect());
+  }
+
+  private async disconnect(): Promise<void> {
+    await this.deactivate();
+    await this.mutateSettings((settings) =>
+      pruneVRChatDraftProfiles(setActiveVRChatProfile(settings, null))
+    );
+    info(`[VRChat] Disconnected`);
+  }
+
+  public activateProfile(profileId: string): Promise<void> {
+    return this.queueTransition(() => this.activateProfileNow(profileId));
+  }
+
+  private async activateProfileNow(profileId: string): Promise<void> {
+    const current = await this.getActiveProfile();
+    if (current?.id === profileId && this.statusSubject.value === 'LOGGED_IN') return;
+    await this.deactivate();
+    await this.mutateSettings((settings) => setActiveVRChatProfile(settings, profileId));
+    const result = await this.loadSession();
+    if (result.status === 'RESTORED') {
+      await this.completeLogin(result.user);
+      return;
+    }
+    if (result.status === 'TWO_FACTOR_REQUIRED') {
+      this.showLoginModal(false, result.method, undefined, result.loginIdentifier);
+      return;
+    }
+    if (result.status === 'RETRY') {
+      this.handleSessionRestoreResult(result);
+      return;
+    }
+
+    const credentials = await this.loadCredentials();
+    if (credentials) {
+      try {
+        await this.login(credentials.username, credentials.password, true);
+        return;
+      } catch (cause) {
+        const method = twoFactorMethodFromError(cause);
+        this.showLoginModal(
+          false,
+          method,
+          method ? undefined : String(cause),
+          credentials.username,
+          false,
+          undefined,
+          true
+        );
+        return;
+      }
+    }
+    const profile = await this.requireActiveProfile();
+    this.showLoginModal(
+      false,
+      undefined,
+      result.status === 'LOGIN_REQUIRED' ? result.error : undefined,
+      profile.username ?? undefined,
+      false,
+      undefined,
+      true
+    );
+  }
+
+  public prepareNewLogin(): Promise<void> {
+    return this.queueTransition(() => this.prepareNewLoginNow());
+  }
+
+  private async prepareNewLoginNow(): Promise<void> {
+    const restoreProfileIdOnCancel = this.userSubject.value
+      ? (await this.getActiveProfile())?.id
+      : undefined;
+    this.showLoginModal(false, undefined, undefined, undefined, true, restoreProfileIdOnCancel);
+  }
+
+  public removeProfile(profileId: string): Promise<void> {
+    return this.queueTransition(async () => {
+      if ((await this.getActiveProfile())?.id === profileId) await this.deactivate();
+      await this.api
+        .logoutProfile(profileId)
+        .catch((cause) => warn(`[VRChat] Failed to invalidate removed profile: ${cause}`));
+      await this.mutateSettings((settings) => removeVRChatProfile(settings, profileId));
     });
+  }
+
+  private queueTransition(action: () => Promise<void>): Promise<void> {
+    const transition = this.transition.then(action, action);
+    this.transition = transition.catch(() => undefined);
+    return transition;
+  }
+
+  private async deactivate(): Promise<void> {
+    this.cancelSessionRestore();
+    this.pendingTwoFactorLoginIdentifierHash = undefined;
+    this.lastUserUpdateAt = 0;
+    this.lastStatusUpdateAt = 0;
     this.userSubject.next(null);
     this.statusSubject.next('LOGGED_OUT');
-    info(`[VRChat] Logged out`);
+    await this.api.clearCaches();
   }
 
-  private completeLogin(user: CurrentUser): void {
+  private async completeLogin(user: CurrentUser): Promise<void> {
+    const active = await this.requireActiveProfile();
+    if (active.userId && active.userId !== user.id) {
+      await this.patchActiveProfile({ authCookie: null });
+      throw 'PROFILE_MISMATCH';
+    }
+    await this.mutateSettings((settings) => adoptVRChatProfileIdentity(settings, user));
     this.setCurrentUser(user);
     this.statusSubject.next('LOGGED_IN');
     info(`[VRChat] Logged in: ${user.displayName}`);
@@ -335,37 +493,40 @@ export class VRChatAuth {
   }
 
   private async clearTwoFactorCookie(clearLoginIdentifier = true): Promise<void> {
-    await this.updateSettings({
+    await this.patchActiveProfile({
       twoFactorCookie: null,
       ...(clearLoginIdentifier ? { twoFactorCookieLoginIdentifierHash: null } : {}),
     });
   }
 
-  private async encryptPendingTwoFactorLoginIdentifier(identifier: string): Promise<string | null> {
-    const { credentialCryptoKey } = await firstValueFrom(this.settings);
-    if (!credentialCryptoKey) return null;
-    try {
-      const key = await deserializeStorageCryptoKey(credentialCryptoKey);
-      return await encryptStorageData(identifier, key);
-    } catch (e) {
-      error('[VRChat] Failed to encrypt pending login identifier: ' + JSON.stringify(e));
-      return null;
-    }
+  private async getActiveProfile(): Promise<VRChatAccountProfile | null> {
+    return getActiveVRChatProfile(await firstValueFrom(this.settings));
+  }
+
+  private async requireActiveProfile(): Promise<VRChatAccountProfile> {
+    const profile = await this.getActiveProfile();
+    if (!profile) throw new Error('VRChat authentication requires an active profile');
+    return profile;
+  }
+
+  private async patchActiveProfile(patch: VRChatProfileSessionPatch): Promise<void> {
+    const profile = await this.requireActiveProfile();
+    await this.mutateSettings((settings) => patchVRChatProfile(settings, profile.id, patch));
+  }
+
+  private async selectLoginProfile(loginIdentifierHash: string): Promise<void> {
+    await this.mutateSettings((settings) => {
+      const matching = settings.profiles.find(
+        (profile) => profile.twoFactorCookieLoginIdentifierHash === loginIdentifierHash
+      );
+      if (matching) return setActiveVRChatProfile(settings, matching.id);
+      const active = getActiveVRChatProfile(settings);
+      return active && !active.userId ? settings : createVRChatDraftProfile(settings);
+    });
   }
 
   private async loadPendingTwoFactorLoginIdentifier(): Promise<string | undefined> {
-    const { credentialCryptoKey, encryptedPendingTwoFactorLoginIdentifier } = await firstValueFrom(
-      this.settings
-    );
-    if (!credentialCryptoKey || !encryptedPendingTwoFactorLoginIdentifier) return undefined;
-    try {
-      const key = await deserializeStorageCryptoKey(credentialCryptoKey);
-      return await decryptStorageData(encryptedPendingTwoFactorLoginIdentifier, key);
-    } catch (e) {
-      error('[VRChat] Failed to decrypt pending login identifier: ' + JSON.stringify(e));
-      await this.updateSettings({ encryptedPendingTwoFactorLoginIdentifier: null });
-      return undefined;
-    }
+    return (await this.requireActiveProfile()).pendingTwoFactorLoginIdentifier ?? undefined;
   }
 
   // user state
@@ -404,61 +565,21 @@ export class VRChatAuth {
   // remembered credentials
 
   public async rememberCredentials(username: string, password: string): Promise<void> {
-    const credentialCryptoKey = (await firstValueFrom(this.settings)).credentialCryptoKey;
-    if (!credentialCryptoKey) return;
-    let key: CryptoKey;
-    try {
-      key = await deserializeStorageCryptoKey(credentialCryptoKey);
-    } catch (e) {
-      error('[VRChat] Failed to deserialize storage crypto key: ' + JSON.stringify(e));
-      await this.cycleCredentialCryptoKey();
-      return;
-    }
-    const credentials = btoa(username) + ':' + btoa(password);
-    const encryptedCredentials = await encryptStorageData(credentials, key);
-    await this.updateSettings({
-      rememberedCredentials: encryptedCredentials,
+    await this.patchActiveProfile({
+      rememberedCredentials: { username, password },
       rememberCredentials: true,
     });
   }
 
   public async forgetCredentials(): Promise<void> {
-    await this.updateSettings({
+    await this.patchActiveProfile({
       rememberedCredentials: null,
       rememberCredentials: false,
     });
   }
 
   public async loadCredentials(): Promise<{ username: string; password: string } | null> {
-    const { credentialCryptoKey, rememberedCredentials } = await firstValueFrom(this.settings);
-    if (!credentialCryptoKey || !rememberedCredentials) return null;
-    let key: CryptoKey;
-    try {
-      key = await deserializeStorageCryptoKey(credentialCryptoKey);
-    } catch (e) {
-      error('[VRChat] Failed to deserialize storage crypto key: ' + JSON.stringify(e));
-      await this.cycleCredentialCryptoKey();
-      return null;
-    }
-    let credentials: string;
-    try {
-      credentials = await decryptStorageData(rememberedCredentials, key);
-      const [username, password] = credentials.split(':').map((c) => atob(c));
-      return { username, password };
-    } catch (e) {
-      error('[VRChat] Failed to decrypt remembered credentials: ' + JSON.stringify(e));
-      await this.cycleCredentialCryptoKey();
-      return null;
-    }
-  }
-
-  private async cycleCredentialCryptoKey(): Promise<void> {
-    info('[VRChat] Cycling the storage crypto key');
-    await this.updateSettings({
-      rememberedCredentials: null,
-      rememberCredentials: false,
-      encryptedPendingTwoFactorLoginIdentifier: null,
-      credentialCryptoKey: await serializeStorageCryptoKey(await generateStorageCryptoKey()),
-    });
+    const rememberedCredentials = (await this.getActiveProfile())?.rememberedCredentials;
+    return rememberedCredentials ? { ...rememberedCredentials } : null;
   }
 }

--- a/src-ui/app/services/vrchat-api/vrchat-auth.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-auth.ts
@@ -299,6 +299,7 @@ export class VRChatAuth {
 
   private setCurrentUser(user: CurrentUser): void {
     this.userSubject.next(user);
+    this.lastUserUpdateAt = Date.now();
     this.lastStatusUpdateAt = Date.now();
   }
 
@@ -344,8 +345,8 @@ export class VRChatAuth {
     if (incompleteProfile) {
       const settings = await firstValueFrom(this.settings);
       if (!getVRChatProfileAttemptSource(settings, incompleteProfile)) {
-        await this.api
-          .logoutProfile(incompleteProfile.id)
+        void this.api
+          .logoutProfile(incompleteProfile)
           .catch((cause) => warn(`[VRChat] Failed to invalidate cancelled login: ${cause}`));
       }
       await this.restoreProfileAttempt(incompleteProfile, restoreProfileIdOnCancel).catch((cause) =>
@@ -450,7 +451,11 @@ export class VRChatAuth {
     });
   }
 
-  public async verify2FA(code: string, method: VRChatTwoFactorMethod): Promise<void> {
+  public verify2FA(code: string, method: VRChatTwoFactorMethod): Promise<void> {
+    return this.queueTransition(() => this.verify2FANow(code, method));
+  }
+
+  private async verify2FANow(code: string, method: VRChatTwoFactorMethod): Promise<void> {
     if (this.statusSubject.value !== 'LOGGED_OUT') {
       error(`[VRChat] Tried calling verify2FA() while already logged in`);
       throw new Error('Tried calling verify2FA() while already logged in');
@@ -512,7 +517,7 @@ export class VRChatAuth {
     }
     const attempt = getActiveVRChatProfile(settings);
     if (!attempt) throw new Error('Failed to create VRChat profile attempt');
-    if (current && previousUser) {
+    if (!force && current && previousUser) {
       this.suspendedSessions.set(attempt.id, { profileId: current.id, user: previousUser });
     }
     const result = await this.loadSession();
@@ -602,8 +607,9 @@ export class VRChatAuth {
       if (active?.id === profileId || attempts.some((attempt) => attempt.id === active?.id)) {
         await this.deactivate();
       }
+      const profile = settings.profiles.find((candidate) => candidate.id === profileId);
       await this.api
-        .logoutProfile(profileId)
+        .logoutProfile(profile)
         .catch((cause) => warn(`[VRChat] Failed to invalidate removed profile: ${cause}`));
       await this.mutateSettings((currentSettings) => {
         let updated = currentSettings;
@@ -704,14 +710,14 @@ export class VRChatAuth {
     const source = getVRChatProfileAttemptSource(settings, attempt);
     const profileId =
       suspended?.profileId ?? attempt.restoreProfileId ?? source?.id ?? fallbackProfileId;
-    await this.mutateSettings((currentSettings) => {
+    const restoredSettings = await this.mutateSettings((currentSettings) => {
       const pruned = pruneVRChatDraftProfiles(currentSettings);
       return profileId && pruned.profiles.some((profile) => profile.id === profileId)
         ? setActiveVRChatProfile(pruned, profileId)
         : setActiveVRChatProfile(pruned, null);
     });
     this.suspendedSessions.delete(attempt.id);
-    if (!suspended) {
+    if (!suspended || restoredSettings.activeProfileId !== profileId) {
       this.userSubject.next(null);
       this.statusSubject.next('LOGGED_OUT');
       return false;
@@ -761,7 +767,7 @@ export class VRChatAuth {
       polledProfileId = active?.id;
       const result = await this.api.pollCurrentUser(active?.userId ?? undefined);
       if (result.error) throw result.error;
-      if (result.result) this.patchCurrentUser(result.result);
+      if (result.result) this.setCurrentUser(result.result);
     } catch (cause) {
       error(`[VRChat] Error polling user: ${JSON.stringify(cause)}`);
       if (!requiresSessionReauthentication(cause)) return;

--- a/src-ui/app/services/vrchat-api/vrchat-profiles.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-profiles.ts
@@ -1,0 +1,124 @@
+import type { CurrentUser } from 'vrchat';
+import {
+  normalizeVRChatAccountProfile,
+  VRChatAccountProfile,
+  VRChatApiSettings,
+} from 'src-ui/app/models/vrchat-api-settings';
+
+export type VRChatProfileSessionPatch = Partial<
+  Pick<
+    VRChatAccountProfile,
+    | 'authCookie'
+    | 'twoFactorCookie'
+    | 'twoFactorCookieLoginIdentifierHash'
+    | 'pendingTwoFactorLoginIdentifier'
+    | 'rememberCredentials'
+    | 'rememberedCredentials'
+  >
+>;
+
+export function normalizeVRChatProfiles(settings: VRChatApiSettings): VRChatApiSettings {
+  const profiles = settings.profiles.map(normalizeVRChatAccountProfile);
+  const activeProfileId = profiles.some((profile) => profile.id === settings.activeProfileId)
+    ? settings.activeProfileId
+    : null;
+  return { ...settings, profiles, activeProfileId };
+}
+
+export function createVRChatDraftProfile(settings: VRChatApiSettings): VRChatApiSettings {
+  const draft = normalizeVRChatAccountProfile({ id: crypto.randomUUID(), draft: true });
+  return {
+    ...settings,
+    profiles: [draft, ...settings.profiles],
+    activeProfileId: draft.id,
+  };
+}
+
+export function patchVRChatProfile(
+  settings: VRChatApiSettings,
+  profileId: string,
+  patch: Partial<VRChatAccountProfile>
+): VRChatApiSettings {
+  if (!settings.profiles.some((profile) => profile.id === profileId)) return settings;
+  return {
+    ...settings,
+    profiles: settings.profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, ...patch, id: profile.id } : profile
+    ),
+  };
+}
+
+export function setActiveVRChatProfile(
+  settings: VRChatApiSettings,
+  profileId: string | null
+): VRChatApiSettings {
+  if (profileId && !settings.profiles.some((profile) => profile.id === profileId)) {
+    throw new Error(`Unknown VRChat profile: ${profileId}`);
+  }
+  return { ...settings, activeProfileId: profileId };
+}
+
+export function adoptVRChatProfileIdentity(
+  settings: VRChatApiSettings,
+  user: CurrentUser
+): VRChatApiSettings {
+  const active = settings.profiles.find((profile) => profile.id === settings.activeProfileId);
+  if (!active) throw new Error('Cannot save a VRChat account without an active profile');
+
+  const existing = settings.profiles.find(
+    (profile) => profile.id !== active.id && profile.userId === user.id
+  );
+  const updated = {
+    ...active,
+    userId: user.id,
+    username: user.username ?? null,
+    displayName: user.displayName,
+    draft: false,
+  };
+  if (!existing) {
+    return {
+      ...settings,
+      profiles: [updated, ...settings.profiles.filter((profile) => profile.id !== active.id)],
+    };
+  }
+
+  const merged = {
+    ...existing,
+    ...updated,
+    id: existing.id,
+    rememberCredentials: updated.rememberCredentials || existing.rememberCredentials,
+    rememberedCredentials: updated.rememberedCredentials ?? existing.rememberedCredentials,
+  };
+  return {
+    ...settings,
+    activeProfileId: existing.id,
+    profiles: [
+      merged,
+      ...settings.profiles.filter(
+        (profile) => profile.id !== active.id && profile.id !== existing.id
+      ),
+    ],
+  };
+}
+
+export function removeVRChatProfile(
+  settings: VRChatApiSettings,
+  profileId: string
+): VRChatApiSettings {
+  return {
+    ...settings,
+    activeProfileId: settings.activeProfileId === profileId ? null : settings.activeProfileId,
+    profiles: settings.profiles.filter((profile) => profile.id !== profileId),
+  };
+}
+
+export function pruneVRChatDraftProfiles(settings: VRChatApiSettings): VRChatApiSettings {
+  const profiles = settings.profiles.filter((profile) => !profile.draft);
+  return {
+    ...settings,
+    profiles,
+    activeProfileId: profiles.some((profile) => profile.id === settings.activeProfileId)
+      ? settings.activeProfileId
+      : null,
+  };
+}

--- a/src-ui/app/services/vrchat-api/vrchat-profiles.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-profiles.ts
@@ -1,5 +1,6 @@
 import type { CurrentUser } from 'vrchat';
 import {
+  getActiveVRChatProfile,
   normalizeVRChatAccountProfile,
   VRChatAccountProfile,
   VRChatApiSettings,
@@ -26,12 +27,47 @@ export function normalizeVRChatProfiles(settings: VRChatApiSettings): VRChatApiS
 }
 
 export function createVRChatDraftProfile(settings: VRChatApiSettings): VRChatApiSettings {
-  const draft = normalizeVRChatAccountProfile({ id: crypto.randomUUID(), draft: true });
+  const active = getActiveVRChatProfile(settings);
+  const draft = normalizeVRChatAccountProfile({
+    id: crypto.randomUUID(),
+    sourceProfileId: null,
+    restoreProfileId: active?.draft ? active.restoreProfileId : (active?.id ?? null),
+    draft: true,
+  });
   return {
     ...settings,
     profiles: [draft, ...settings.profiles],
     activeProfileId: draft.id,
   };
+}
+
+export function createVRChatProfileAttempt(
+  settings: VRChatApiSettings,
+  profileId: string
+): VRChatApiSettings {
+  const source = settings.profiles.find((profile) => profile.id === profileId && !profile.draft);
+  if (!source) throw new Error(`Unknown VRChat profile: ${profileId}`);
+  const active = getActiveVRChatProfile(settings);
+  const draft = normalizeVRChatAccountProfile({
+    ...source,
+    id: crypto.randomUUID(),
+    sourceProfileId: source.id,
+    restoreProfileId: active?.draft ? active.restoreProfileId : (active?.id ?? null),
+    draft: true,
+  });
+  return {
+    ...settings,
+    profiles: [draft, ...settings.profiles.filter((profile) => !profile.draft)],
+    activeProfileId: draft.id,
+  };
+}
+
+export function getVRChatProfileAttemptSource(
+  settings: VRChatApiSettings,
+  profile: VRChatAccountProfile
+): VRChatAccountProfile | null {
+  if (!profile.sourceProfileId) return null;
+  return settings.profiles.find((candidate) => candidate.id === profile.sourceProfileId) ?? null;
 }
 
 export function patchVRChatProfile(
@@ -65,11 +101,17 @@ export function adoptVRChatProfileIdentity(
   const active = settings.profiles.find((profile) => profile.id === settings.activeProfileId);
   if (!active) throw new Error('Cannot save a VRChat account without an active profile');
 
-  const existing = settings.profiles.find(
-    (profile) => profile.id !== active.id && profile.userId === user.id
+  const source = getVRChatProfileAttemptSource(settings, active);
+  const matching = settings.profiles.find(
+    (profile) => !profile.draft && profile.id !== active.id && profile.userId === user.id
   );
+  const existing = source && (!source.userId || source.userId === user.id) ? source : matching;
   const updated = {
     ...active,
+    sourceProfileId: null,
+    restoreProfileId: null,
+    protectedSecret: null,
+    secretLocked: false,
     userId: user.id,
     username: user.username ?? null,
     displayName: user.displayName,
@@ -82,13 +124,16 @@ export function adoptVRChatProfileIdentity(
     };
   }
 
-  const merged = {
-    ...existing,
-    ...updated,
-    id: existing.id,
-    rememberCredentials: updated.rememberCredentials || existing.rememberCredentials,
-    rememberedCredentials: updated.rememberedCredentials ?? existing.rememberedCredentials,
-  };
+  const merged =
+    source?.id === existing.id
+      ? { ...existing, ...updated, id: existing.id }
+      : {
+          ...existing,
+          ...updated,
+          id: existing.id,
+          rememberCredentials: updated.rememberCredentials || existing.rememberCredentials,
+          rememberedCredentials: updated.rememberedCredentials ?? existing.rememberedCredentials,
+        };
   return {
     ...settings,
     activeProfileId: existing.id,

--- a/src-ui/app/services/vrchat-api/vrchat-socket.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-socket.ts
@@ -11,7 +11,7 @@ import {
   switchMap,
   take,
 } from 'rxjs';
-import { VRChatApiSettings } from 'src-ui/app/models/vrchat-api-settings';
+import { getActiveVRChatProfile, VRChatApiSettings } from 'src-ui/app/models/vrchat-api-settings';
 import { GroupMemberUpdatedHandler } from './event-handlers/group-member-updated-handler';
 import { NotificationHandler } from './event-handlers/notification-handler';
 import { UserUpdateHandler } from './event-handlers/user-update-handler';
@@ -91,7 +91,7 @@ export class VRChatSocket {
     this.closeSocket();
     const connectionGeneration = this.connectionGeneration;
     this.statusSubject.next('OPENING');
-    const authToken = (await firstValueFrom(this.settings)).authCookie;
+    const authToken = getActiveVRChatProfile(await firstValueFrom(this.settings))?.authCookie;
     if (connectionGeneration !== this.connectionGeneration) return;
     if (!authToken) {
       this.statusSubject.next('CLOSED');

--- a/src-ui/app/services/vrchat-api/vrchat-socket.ts
+++ b/src-ui/app/services/vrchat-api/vrchat-socket.ts
@@ -157,6 +157,12 @@ export class VRChatSocket {
         )
       );
     }
+    if (
+      this.consecutiveFailures >= FAILURE_REPORT_THRESHOLD &&
+      this.consecutiveFailures % FAILURE_REPORT_THRESHOLD === 0
+    ) {
+      void this.auth.revalidateSession();
+    }
   }
 
   private handleError(socket: WebSocket): void {

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -58,6 +58,9 @@ export class VRChatService {
   private readonly auth: VRChatAuth;
   private readonly socket: VRChatSocket;
   private settingsUpdate: Promise<void> = Promise.resolve();
+  private readonly failedLegacyProfiles = new Map<string, Record<string, unknown>>();
+  private failedLegacyCredentialCryptoKey: string | null = null;
+  private lockedActiveProfileId: string | null = null;
 
   public readonly settings = this.settingsSubject.asObservable();
   public readonly profiles = this.settings.pipe(
@@ -84,6 +87,7 @@ export class VRChatService {
       this.mutateSettings.bind(this),
       this.settings
     );
+    this.api.setAuthenticationFailureHandler(() => void this.auth.revalidateSession());
     this.socket = new VRChatSocket(this.auth, this.api, this.settings, reportError);
     this.user = this.auth.user;
     this.status = this.auth.status;
@@ -278,6 +282,9 @@ export class VRChatService {
   }
 
   private async loadProfileSecrets(settings: VRChatApiSettings): Promise<VRChatApiSettings> {
+    this.failedLegacyProfiles.clear();
+    this.failedLegacyCredentialCryptoKey = settings.legacyCredentialCryptoKey;
+    this.lockedActiveProfileId = null;
     const needsLegacyKey = settings.profiles.some((profile) => {
       const legacy = profile as VRChatAccountProfile & {
         encryptedPendingTwoFactorLoginIdentifier?: string | null;
@@ -319,13 +326,15 @@ export class VRChatService {
             secret = await this.loadLegacyProfileSecret(profile, legacyKey);
           } catch (cause) {
             error(`[VRChat] Failed to migrate credentials for profile ${profile.id}: ${cause}`);
-            secret = {
+            this.failedLegacyProfiles.set(
+              profile.id,
+              structuredClone(profile as unknown as Record<string, unknown>)
+            );
+            return normalizeVRChatAccountProfile({
+              ...profile,
               ...VRCHAT_ACCOUNT_SECRET_EMPTY,
-              authCookie: profile.authCookie ?? null,
-              twoFactorCookie: profile.twoFactorCookie ?? null,
-              twoFactorCookieLoginIdentifierHash:
-                profile.twoFactorCookieLoginIdentifierHash ?? null,
-            };
+              secretLocked: true,
+            });
           }
         }
         return normalizeVRChatAccountProfile({
@@ -338,6 +347,11 @@ export class VRChatService {
     );
     const activeProfileId = profiles.some(
       (profile) => profile.id === settings.activeProfileId && !profile.secretLocked
+    )
+      ? settings.activeProfileId
+      : null;
+    this.lockedActiveProfileId = profiles.some(
+      (profile) => profile.id === settings.activeProfileId && profile.secretLocked
     )
       ? settings.activeProfileId
       : null;
@@ -412,25 +426,42 @@ export class VRChatService {
 
   private async saveSettings(settings: VRChatApiSettings): Promise<void> {
     const profiles = await Promise.all(
-      settings.profiles.map(async (profile) => ({
-        id: profile.id,
-        userId: profile.userId,
-        username: profile.username,
-        displayName: profile.displayName,
-        draft: profile.draft,
-        protectedSecret: profile.secretLocked
-          ? profile.protectedSecret
-          : await invoke<string>('protect_vrchat_secret', {
-              secret: JSON.stringify(getVRChatAccountSecret(profile)),
-            }),
-      }))
+      settings.profiles.map(async (profile) => {
+        const failedLegacyProfile = this.failedLegacyProfiles.get(profile.id);
+        if (profile.secretLocked && failedLegacyProfile) return failedLegacyProfile;
+        return {
+          id: profile.id,
+          sourceProfileId: profile.sourceProfileId,
+          restoreProfileId: profile.restoreProfileId,
+          userId: profile.userId,
+          username: profile.username,
+          displayName: profile.displayName,
+          draft: profile.draft,
+          protectedSecret: profile.secretLocked
+            ? profile.protectedSecret
+            : await invoke<string>('protect_vrchat_secret', {
+                secret: JSON.stringify(getVRChatAccountSecret(profile)),
+              }),
+        };
+      })
     );
+    const hasFailedLegacyProfile = settings.profiles.some(
+      (profile) => profile.secretLocked && this.failedLegacyProfiles.has(profile.id)
+    );
+    const lockedActiveProfileId = settings.profiles.some(
+      (profile) => profile.id === this.lockedActiveProfileId && profile.secretLocked
+    )
+      ? this.lockedActiveProfileId
+      : null;
     const persisted = {
       version: settings.version,
       profiles,
-      activeProfileId: settings.activeProfileId,
-      legacyCredentialCryptoKey: null,
+      activeProfileId: settings.activeProfileId ?? lockedActiveProfileId,
+      legacyCredentialCryptoKey: hasFailedLegacyProfile
+        ? this.failedLegacyCredentialCryptoKey
+        : null,
     } as unknown as VRChatApiSettings;
     await SETTINGS_STORE.set(SETTINGS_KEY_VRCHAT_API, persisted);
+    this.lockedActiveProfileId = null;
   }
 }

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -37,6 +37,18 @@ import {
   VRChatProfileSessionPatch,
 } from './vrchat-profiles';
 
+function toPublicProfile(profile: VRChatAccountProfile): VRChatAccountProfile {
+  return {
+    ...profile,
+    protectedSecret: null,
+    authCookie: null,
+    twoFactorCookie: null,
+    twoFactorCookieLoginIdentifierHash: null,
+    pendingTwoFactorLoginIdentifier: null,
+    rememberedCredentials: null,
+  };
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -62,11 +74,18 @@ export class VRChatService {
   private failedLegacyCredentialCryptoKey: string | null = null;
   private lockedActiveProfileId: string | null = null;
 
-  public readonly settings = this.settingsSubject.asObservable();
+  private readonly settings = this.settingsSubject.asObservable();
   public readonly profiles = this.settings.pipe(
-    map((settings) => settings.profiles.filter((profile) => !profile.draft))
+    map((settings) =>
+      settings.profiles.filter((profile) => !profile.draft).map(toPublicProfile)
+    )
   );
-  public readonly activeProfile = this.settings.pipe(map(getActiveVRChatProfile));
+  public readonly activeProfile = this.settings.pipe(
+    map((settings) => {
+      const profile = getActiveVRChatProfile(settings);
+      return profile ? toPublicProfile(profile) : null;
+    })
+  );
   public readonly user: Observable<CurrentUser | null>;
   public readonly status: Observable<VRChatAuthStatus>;
   public readonly notifications: Observable<Notification>;
@@ -333,7 +352,11 @@ export class VRChatService {
             return normalizeVRChatAccountProfile({
               ...profile,
               ...VRCHAT_ACCOUNT_SECRET_EMPTY,
-              secretLocked: true,
+              authCookie: profile.authCookie ?? null,
+              twoFactorCookie: profile.twoFactorCookie ?? null,
+              twoFactorCookieLoginIdentifierHash:
+                profile.twoFactorCookieLoginIdentifierHash ?? null,
+              secretLocked: false,
             });
           }
         }
@@ -428,7 +451,8 @@ export class VRChatService {
     const profiles = await Promise.all(
       settings.profiles.map(async (profile) => {
         const failedLegacyProfile = this.failedLegacyProfiles.get(profile.id);
-        if (profile.secretLocked && failedLegacyProfile) return failedLegacyProfile;
+        if (failedLegacyProfile && !profile.userId) return failedLegacyProfile;
+        if (failedLegacyProfile) this.failedLegacyProfiles.delete(profile.id);
         return {
           id: profile.id,
           sourceProfileId: profile.sourceProfileId,
@@ -445,8 +469,8 @@ export class VRChatService {
         };
       })
     );
-    const hasFailedLegacyProfile = settings.profiles.some(
-      (profile) => profile.secretLocked && this.failedLegacyProfiles.has(profile.id)
+    const hasFailedLegacyProfile = settings.profiles.some((profile) =>
+      this.failedLegacyProfiles.has(profile.id)
     );
     const lockedActiveProfileId = settings.profiles.some(
       (profile) => profile.id === this.lockedActiveProfileId && profile.secretLocked

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -170,7 +170,7 @@ export class VRChatService {
   // authentication
 
   public showLoginModal(autoLogin = false): void {
-    this.auth.showLoginModal(autoLogin);
+    this.auth.showLoginModal({ autoLogin });
   }
 
   public login(username: string, password: string, keepActiveProfile = false): Promise<void> {

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -1,13 +1,23 @@
 import { inject, Injectable } from '@angular/core';
 import type { CurrentUser, LimitedUserFriend, Notification, LimitedUserGroups } from 'vrchat';
 import { SETTINGS_KEY_VRCHAT_API, SETTINGS_STORE } from '../../globals';
-import { VRCHAT_API_SETTINGS_DEFAULT, VRChatApiSettings } from '../../models/vrchat-api-settings';
+import {
+  getVRChatAccountSecret,
+  getActiveVRChatProfile,
+  normalizeVRChatAccountProfile,
+  parseVRChatAccountSecret,
+  VRCHAT_ACCOUNT_SECRET_EMPTY,
+  VRCHAT_API_SETTINGS_DEFAULT,
+  VRChatAccountProfile,
+  VRChatAccountSecret,
+  VRChatApiSettings,
+} from '../../models/vrchat-api-settings';
 import { migrateVRChatApiSettings } from '../../migrations/vrchat-api-settings.migrations';
 import { BehaviorSubject, combineLatest, filter, firstValueFrom, map, Observable } from 'rxjs';
 import { ModalService } from 'src-ui/app/services/modal.service';
 import { AvatarEx, UserStatus, WorldContext } from '../../models/vrchat';
 import { VRChatLogService } from '../vrchat-log.service';
-import { generateStorageCryptoKey, serializeStorageCryptoKey } from '../../utils/crypto';
+import { decryptStorageData, deserializeStorageCryptoKey } from '../../utils/crypto';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { VRChatAPI, VRChatTwoFactorMethod } from './vrchat-api';
@@ -21,6 +31,11 @@ import type {
 } from '../../models/vrchat-log-event';
 import type { VRChatSocketStatus } from './vrchat-socket';
 import { ErrorReportingService } from '../error-reporting.service';
+import {
+  normalizeVRChatProfiles,
+  patchVRChatProfile,
+  VRChatProfileSessionPatch,
+} from './vrchat-profiles';
 
 @Injectable({
   providedIn: 'root',
@@ -42,8 +57,13 @@ export class VRChatService {
   private readonly api: VRChatAPI;
   private readonly auth: VRChatAuth;
   private readonly socket: VRChatSocket;
+  private settingsUpdate: Promise<void> = Promise.resolve();
 
   public readonly settings = this.settingsSubject.asObservable();
+  public readonly profiles = this.settings.pipe(
+    map((settings) => settings.profiles.filter((profile) => !profile.draft))
+  );
+  public readonly activeProfile = this.settings.pipe(map(getActiveVRChatProfile));
   public readonly user: Observable<CurrentUser | null>;
   public readonly status: Observable<VRChatAuthStatus>;
   public readonly notifications: Observable<Notification>;
@@ -57,11 +77,11 @@ export class VRChatService {
 
   constructor() {
     const reportError = (cause: Error) => this.errorReporting.captureException(cause);
-    this.api = new VRChatAPI(this.settings, this.updateSettings.bind(this), reportError);
+    this.api = new VRChatAPI(this.settings, this.updateProfile.bind(this), reportError);
     this.auth = new VRChatAuth(
       this.api,
       this.modalService,
-      this.updateSettings.bind(this),
+      this.mutateSettings.bind(this),
       this.settings
     );
     this.socket = new VRChatSocket(this.auth, this.api, this.settings, reportError);
@@ -149,12 +169,28 @@ export class VRChatService {
     this.auth.showLoginModal(autoLogin);
   }
 
-  public login(username: string, password: string): Promise<void> {
-    return this.auth.login(username, password);
+  public login(username: string, password: string, keepActiveProfile = false): Promise<void> {
+    return this.auth.login(username, password, keepActiveProfile);
+  }
+
+  public loginNewAccount(username: string, password: string): Promise<void> {
+    return this.auth.loginNewAccount(username, password);
   }
 
   public logout(): Promise<void> {
     return this.auth.logout();
+  }
+
+  public activateProfile(profileId: string): Promise<void> {
+    return this.auth.activateProfile(profileId);
+  }
+
+  public prepareNewLogin(): Promise<void> {
+    return this.auth.prepareNewLogin();
+  }
+
+  public removeProfile(profileId: string): Promise<void> {
+    return this.auth.removeProfile(profileId);
   }
 
   public verify2FA(code: string, method: VRChatTwoFactorMethod): Promise<void> {
@@ -230,23 +266,171 @@ export class VRChatService {
   // settings
 
   private async loadSettings(): Promise<void> {
-    let settings: VRChatApiSettings | undefined =
-      await SETTINGS_STORE.get<VRChatApiSettings>(SETTINGS_KEY_VRCHAT_API);
-    settings = settings ? migrateVRChatApiSettings(settings) : { ...this.settingsSubject.value };
-    if (!settings.credentialCryptoKey) {
-      const key = await generateStorageCryptoKey();
-      settings.credentialCryptoKey = await serializeStorageCryptoKey(key);
-    }
+    const stored = await SETTINGS_STORE.get<VRChatApiSettings>(SETTINGS_KEY_VRCHAT_API);
+    let settings = stored
+      ? migrateVRChatApiSettings(stored)
+      : structuredClone(VRCHAT_API_SETTINGS_DEFAULT);
+    settings = normalizeVRChatProfiles(await this.loadProfileSecrets(settings));
+    await this.saveSettings(settings).catch((cause) =>
+      error(`[VRChat] Failed to persist loaded settings: ${cause}`)
+    );
     this.settingsSubject.next(settings);
-    await this.saveSettings();
   }
 
-  private async updateSettings(settings: Partial<VRChatApiSettings>): Promise<void> {
-    this.settingsSubject.next({ ...this.settingsSubject.value, ...settings });
-    await this.saveSettings();
+  private async loadProfileSecrets(settings: VRChatApiSettings): Promise<VRChatApiSettings> {
+    const needsLegacyKey = settings.profiles.some((profile) => {
+      const legacy = profile as VRChatAccountProfile & {
+        encryptedPendingTwoFactorLoginIdentifier?: string | null;
+      };
+      return (
+        legacy.encryptedPendingTwoFactorLoginIdentifier != null ||
+        typeof profile.rememberedCredentials === 'string'
+      );
+    });
+    let legacyKey: CryptoKey | null = null;
+    if (needsLegacyKey) {
+      if (settings.legacyCredentialCryptoKey) {
+        try {
+          legacyKey = await deserializeStorageCryptoKey(settings.legacyCredentialCryptoKey);
+        } catch (cause) {
+          error(`[VRChat] Failed to unlock legacy credential key: ${cause}`);
+        }
+      }
+    }
+    const profiles = await Promise.all(
+      settings.profiles.map(async (profile) => {
+        let secret: VRChatAccountSecret;
+        if (profile.protectedSecret != null) {
+          try {
+            const json = await invoke<string>('unprotect_vrchat_secret', {
+              secret: profile.protectedSecret,
+            });
+            secret = parseVRChatAccountSecret(JSON.parse(json));
+          } catch (cause) {
+            error(`[VRChat] Failed to unlock profile ${profile.id}: ${cause}`);
+            return normalizeVRChatAccountProfile({
+              ...profile,
+              ...VRCHAT_ACCOUNT_SECRET_EMPTY,
+              secretLocked: true,
+            });
+          }
+        } else {
+          try {
+            secret = await this.loadLegacyProfileSecret(profile, legacyKey);
+          } catch (cause) {
+            error(`[VRChat] Failed to migrate credentials for profile ${profile.id}: ${cause}`);
+            secret = {
+              ...VRCHAT_ACCOUNT_SECRET_EMPTY,
+              authCookie: profile.authCookie ?? null,
+              twoFactorCookie: profile.twoFactorCookie ?? null,
+              twoFactorCookieLoginIdentifierHash:
+                profile.twoFactorCookieLoginIdentifierHash ?? null,
+            };
+          }
+        }
+        return normalizeVRChatAccountProfile({
+          ...profile,
+          ...secret,
+          protectedSecret: null,
+          secretLocked: false,
+        });
+      })
+    );
+    const activeProfileId = profiles.some(
+      (profile) => profile.id === settings.activeProfileId && !profile.secretLocked
+    )
+      ? settings.activeProfileId
+      : null;
+    return { ...settings, profiles, activeProfileId, legacyCredentialCryptoKey: null };
   }
 
-  private async saveSettings(): Promise<void> {
-    await SETTINGS_STORE.set(SETTINGS_KEY_VRCHAT_API, this.settingsSubject.value);
+  private async loadLegacyProfileSecret(
+    profile: VRChatAccountProfile,
+    key: CryptoKey | null
+  ): Promise<VRChatAccountSecret> {
+    const legacy = profile as VRChatAccountProfile & {
+      encryptedPendingTwoFactorLoginIdentifier?: string | null;
+    };
+    const rawCredentials: unknown = profile.rememberedCredentials;
+    if (
+      !key &&
+      (legacy.encryptedPendingTwoFactorLoginIdentifier != null ||
+        typeof rawCredentials === 'string')
+    ) {
+      throw new Error('Cannot migrate encrypted credentials without their key');
+    }
+    let pendingTwoFactorLoginIdentifier = profile.pendingTwoFactorLoginIdentifier ?? null;
+    let rememberedCredentials =
+      rawCredentials &&
+      typeof rawCredentials === 'object' &&
+      typeof (rawCredentials as Record<string, unknown>)['username'] === 'string' &&
+      typeof (rawCredentials as Record<string, unknown>)['password'] === 'string'
+        ? (rawCredentials as { username: string; password: string })
+        : null;
+    if (key && legacy.encryptedPendingTwoFactorLoginIdentifier != null) {
+      pendingTwoFactorLoginIdentifier = await decryptStorageData(
+        legacy.encryptedPendingTwoFactorLoginIdentifier,
+        key
+      );
+    }
+    if (key && typeof rawCredentials === 'string') {
+      const encoded = await decryptStorageData(rawCredentials, key);
+      const separator = encoded.indexOf(':');
+      if (separator < 0) throw new Error('Invalid credential encoding');
+      rememberedCredentials = {
+        username: atob(encoded.slice(0, separator)),
+        password: atob(encoded.slice(separator + 1)),
+      };
+    }
+    return {
+      authCookie: profile.authCookie ?? null,
+      twoFactorCookie: profile.twoFactorCookie ?? null,
+      twoFactorCookieLoginIdentifierHash: profile.twoFactorCookieLoginIdentifierHash ?? null,
+      pendingTwoFactorLoginIdentifier,
+      rememberCredentials: !!rememberedCredentials && !!profile.rememberCredentials,
+      rememberedCredentials,
+    };
+  }
+
+  private async mutateSettings(
+    mutator: (settings: VRChatApiSettings) => VRChatApiSettings
+  ): Promise<VRChatApiSettings> {
+    let updated = this.settingsSubject.value;
+    const mutation = this.settingsUpdate.then(async () => {
+      updated = mutator(this.settingsSubject.value);
+      await this.saveSettings(updated);
+      this.settingsSubject.next(updated);
+    });
+    this.settingsUpdate = mutation.catch(() => undefined);
+    await mutation;
+    return updated;
+  }
+
+  private async updateProfile(profileId: string, patch: VRChatProfileSessionPatch): Promise<void> {
+    await this.mutateSettings((settings) => patchVRChatProfile(settings, profileId, patch));
+  }
+
+  private async saveSettings(settings: VRChatApiSettings): Promise<void> {
+    const profiles = await Promise.all(
+      settings.profiles.map(async (profile) => ({
+        id: profile.id,
+        userId: profile.userId,
+        username: profile.username,
+        displayName: profile.displayName,
+        draft: profile.draft,
+        protectedSecret: profile.secretLocked
+          ? profile.protectedSecret
+          : await invoke<string>('protect_vrchat_secret', {
+              secret: JSON.stringify(getVRChatAccountSecret(profile)),
+            }),
+      }))
+    );
+    const persisted = {
+      version: settings.version,
+      profiles,
+      activeProfileId: settings.activeProfileId,
+      legacyCredentialCryptoKey: null,
+    } as unknown as VRChatApiSettings;
+    await SETTINGS_STORE.set(SETTINGS_KEY_VRCHAT_API, persisted);
   }
 }

--- a/src-ui/app/utils/task-queue.ts
+++ b/src-ui/app/utils/task-queue.ts
@@ -6,6 +6,12 @@ export interface QueueTask<T> {
   typeId?: string;
 }
 
+interface PendingQueueTask<T> extends QueueTask<T> {
+  cancel: (error: unknown) => void;
+}
+
+const TASK_QUEUE_TASK_REPLACED = 'TASK_REPLACED';
+
 export interface TaskQueueRateLimiter {
   totalPerMinute?: number;
   typePerMinute?: { [typeId: string]: number };
@@ -14,7 +20,7 @@ export interface TaskQueueRateLimiter {
 export class TaskQueue {
   private readonly runUniqueTasksConcurrently: boolean;
   private readonly rateLimiter?: TaskQueueRateLimiter;
-  private queue: QueueTask<any>[] = [];
+  private queue: PendingQueueTask<any>[] = [];
   private running = false;
   private runHistory: Array<{ typeId?: string; timestamp: number }> = [];
 
@@ -32,24 +38,38 @@ export class TaskQueue {
     replaceSameType = false
   ): Promise<CompletionResult<T>> {
     if (task.typeId && replaceSameType) {
-      this.queue = this.queue.filter((t) => t.typeId !== task.typeId);
+      this.cancelPending(TASK_QUEUE_TASK_REPLACED, (queued) => queued.typeId === task.typeId);
     }
     const completer = new Completer<T>();
-    const oldRunnable = task.runnable;
-    task.runnable = async () => {
-      let returnValue: T;
-      try {
-        returnValue = await oldRunnable();
-        completer.complete(returnValue);
-        return returnValue;
-      } catch (e) {
-        completer.completeWithError(e);
-        throw e;
-      }
+    const queuedTask: PendingQueueTask<T> = {
+      ...task,
+      cancel: (error) => completer.completeWithError(error),
+      runnable: async () => {
+        try {
+          const returnValue = await task.runnable();
+          completer.complete(returnValue);
+          return returnValue;
+        } catch (e) {
+          completer.completeWithError(e);
+          throw e;
+        }
+      },
     };
-    this.queue.push(task);
+    this.queue.push(queuedTask);
     noop(this.run());
     return completer.completion;
+  }
+
+  cancelPending(
+    error: unknown,
+    predicate: (task: QueueTask<unknown>) => boolean = () => true
+  ): void {
+    const retained: PendingQueueTask<any>[] = [];
+    for (const task of this.queue) {
+      if (predicate(task)) task.cancel(error);
+      else retained.push(task);
+    }
+    this.queue = retained;
   }
 
   private async run() {
@@ -59,7 +79,7 @@ export class TaskQueue {
     this.running = true;
     while (this.queue.length) {
       // Get tasks to run
-      let tasksToRun: QueueTask<any>[] = [];
+      let tasksToRun: PendingQueueTask<any>[] = [];
       if (this.runUniqueTasksConcurrently) {
         this.queue.forEach((task) => {
           if (!tasksToRun.find((t) => t.typeId === task.typeId)) {

--- a/src-ui/app/views/dashboard-view/views/settings-integrations-view/settings-integrations-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/settings-integrations-view/settings-integrations-view.component.html
@@ -22,7 +22,7 @@
             </div>
             <div class="setting-row-action">
               @if (vrchat.user | async) {
-                <div class="connected" @hshrink>
+                <div class="connected">
                   <div class="connected-info">
                     <i class="material-icons-round">check_circle</i>
                     <div class="connected-info-account">
@@ -31,18 +31,25 @@
                   </div>
                   <button
                     class="btn btn-secondary connected-disconnect"
-                    (click)="vrchat.logout()"
-                    transloco="settings.integrations.disconnect"
+                    (click)="showVRChatAccountsModal()"
+                    transloco="settings.integrations.vrchat.accounts"
                   ></button>
                 </div>
               }
               @if ((vrchat.user | async) === null) {
-                <button
-                  class="btn btn-primary"
-                  (click)="vrchat.showLoginModal()"
-                  transloco="settings.integrations.connect"
-                  @hshrink
-                ></button>
+                @if ((vrchat.profiles | async)?.length) {
+                  <button
+                    class="btn btn-primary"
+                    (click)="showVRChatAccountsModal()"
+                    transloco="settings.integrations.vrchat.chooseAccount"
+                  ></button>
+                } @else {
+                  <button
+                    class="btn btn-primary"
+                    (click)="vrchat.prepareNewLogin()"
+                    transloco="settings.integrations.connect"
+                  ></button>
+                }
               }
             </div>
           </div>
@@ -67,7 +74,7 @@
             </div>
             <div class="setting-row-action">
               @if (pulsoid.loggedInUser | async) {
-                <div class="connected" @hshrink>
+                <div class="connected">
                   <div
                     class="connected-info"
                     [tooltip]="'settings.integrations.reveal'"
@@ -91,7 +98,7 @@
                 </div>
               }
               @if ((pulsoid.loggedInUser | async) === null) {
-                <div @hshrink class="connect-row">
+                <div class="connect-row">
                   <button
                     class="btn btn-copy btn-secondary"
                     tooltip="settings.integrations.copy"
@@ -99,10 +106,10 @@
                     (click)="copyToClipboard('PULSOID')"
                   >
                     @if (!copiedToClipboard.includes('PULSOID')) {
-                      <i class="material-icons" @hshrink>copy_all</i>
+                      <i class="material-icons">copy_all</i>
                     }
                     @if (copiedToClipboard.includes('PULSOID')) {
-                      <i class="material-icons success" @hshrink>check</i>
+                      <i class="material-icons success">check</i>
                     }
                   </button>
                   <button
@@ -140,7 +147,7 @@
             ) {
               <div class="setting-row-action">
                 @if (data.mqttClient) {
-                  <div class="connected" @hshrink>
+                  <div class="connected">
                     <div class="connected-info">
                       <i class="material-icons-round">check_circle</i>
                       <div class="connected-info-account">
@@ -151,7 +158,6 @@
                       class="btn btn-secondary connected-disconnect"
                       (click)="showMqttConfigModal()"
                       transloco="settings.integrations.configure"
-                      @hshrink
                     ></button>
                   </div>
                 }
@@ -160,7 +166,6 @@
                     class="btn btn-primary"
                     (click)="showMqttConfigModal()"
                     transloco="settings.integrations.configure"
-                    @hshrink
                   ></button>
                 }
               </div>

--- a/src-ui/app/views/dashboard-view/views/settings-integrations-view/settings-integrations-view.component.scss
+++ b/src-ui/app/views/dashboard-view/views/settings-integrations-view/settings-integrations-view.component.scss
@@ -101,6 +101,10 @@
   &-disconnect {
     background-color: var(--color-surface-1);
 
+    & + & {
+      margin-top: 0.5em;
+    }
+
     &:hover {
       background-color: var(--color-surface-2);
     }

--- a/src-ui/app/views/dashboard-view/views/settings-integrations-view/settings-integrations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-integrations-view/settings-integrations-view.component.ts
@@ -1,7 +1,6 @@
 import { Component, DestroyRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { warn } from '@tauri-apps/plugin-log';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
-import { hshrink } from 'src-ui/app/utils/animations';
 import { PulsoidService } from '../../../../services/integrations/pulsoid.service';
 import { VRChatService } from '../../../../services/vrchat-api/vrchat.service';
 import { PULSOID_REFERRAL_ID } from 'src-ui/app/globals';
@@ -12,12 +11,12 @@ import { SelectBoxItem } from 'src-ui/app/components/select-box/select-box.compo
 import { AppSettingsService } from 'src-ui/app/services/app-settings.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { APP_SETTINGS_DEFAULT, AppSettings, DiscordActivityMode } from 'src-ui/app/models/settings';
+import { VRChatAccountsModalComponent } from '../../../../components/vrchat-accounts-modal/vrchat-accounts-modal.component';
 
 @Component({
   selector: 'app-settings-integrations-view',
   templateUrl: './settings-integrations-view.component.html',
   styleUrls: ['./settings-integrations-view.component.scss'],
-  animations: [hshrink()],
   changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
@@ -95,6 +94,10 @@ export class SettingsIntegrationsViewComponent implements OnInit {
 
   protected showMqttConfigModal() {
     this.modalService.addModal(MqttConfigModalComponent).subscribe();
+  }
+
+  protected showVRChatAccountsModal() {
+    this.modalService.addModal(VRChatAccountsModalComponent).subscribe();
   }
 
   protected setDiscordActivityOnlyWhenVRChatIsRunning(enabled: boolean) {

--- a/src-ui/assets/i18n/en.json
+++ b/src-ui/assets/i18n/en.json
@@ -1004,7 +1004,6 @@
       "errors": {
         "CHECK_EMAIL": "Login failed: For details, check the mailbox of the e-mail address that is tied to your VRChat account.",
         "INVALID_CREDENTIALS": "The credentials you have provided are incorrect.",
-        "PROFILE_MISMATCH": "This saved session belongs to a different VRChat account. Please log in again.",
         "UNEXPECTED_RESPONSE": "Login failed: an unknown error occurred. Please verify your connection or try again later.",
         "UNSUPPORTED_2FA_METHOD": "Login failed: this account requires a VRChat recovery code. Please log in through VRChat instead."
       },

--- a/src-ui/assets/i18n/en.json
+++ b/src-ui/assets/i18n/en.json
@@ -982,6 +982,19 @@
       },
       "title": "Select Avatar"
     },
+    "vrchat-accounts-modal": {
+      "add": "Use another account",
+      "description": "Choose a saved VRChat account or add another one.",
+      "forget": {
+        "confirm": "Forget Account",
+        "message": "Forget ''{account}''? OyasumiVR will delete the saved login data for this account. You will need to log in again to add it back.",
+        "title": "Forget VRChat Account",
+        "tooltip": "Forget account"
+      },
+      "locked": "Saved login data could not be opened",
+      "title": "VRChat Accounts",
+      "unknownAccount": "Saved account"
+    },
     "vrchat-login-modal": {
       "disclaimers": {
         "brand": "OyasumiVR isn't endorsed by VRChat and doesn't reflect the views or opinions of VRChat or anyone officially involved in producing or managing VRChat. VRChat is trademark of VRChat Inc. VRChat © VRChat Inc.",
@@ -991,6 +1004,7 @@
       "errors": {
         "CHECK_EMAIL": "Login failed: For details, check the mailbox of the e-mail address that is tied to your VRChat account.",
         "INVALID_CREDENTIALS": "The credentials you have provided are incorrect.",
+        "PROFILE_MISMATCH": "This saved session belongs to a different VRChat account. Please log in again.",
         "UNEXPECTED_RESPONSE": "Login failed: an unknown error occurred. Please verify your connection or try again later.",
         "UNSUPPORTED_2FA_METHOD": "Login failed: this account requires a VRChat recovery code. Please log in through VRChat instead."
       },
@@ -2215,6 +2229,8 @@
       "reveal": "Reveal",
       "title": "Integrations",
       "vrchat": {
+        "accounts": "Accounts",
+        "chooseAccount": "Choose Account",
         "description": "Linking your account provides access to some of OyasumiVR's VRChat-related automations.",
         "title": "VRChat"
       },


### PR DESCRIPTION
## Summary

- store multiple VRChat account profiles and switch between them without entering credentials again
- protect retained session cookies and credentials with Windows user-scoped DPAPI
- isolate API, cache, queue, and socket state across account transitions
- add account management to Integrations, including disconnecting and forgetting accounts
- migrate existing VRChat login state into the profile store

This builds on the VRChat login reliability changes merged in #229.

## Testing

- `npx ng build oyasumivr --configuration development`
- `npx tsc -p tsconfig.app.json --noEmit --incremental false`
- targeted ESLint and Prettier checks
- `npm run tl:check-icu`
- `cargo check`
- `cargo test commands::vrchat_secrets::tests`

## Still to test

- switching between two real VRChat accounts
- expired cookies with saved credential fallback
- cancelled 2FA for new and existing accounts
- migration from existing VRChat login settings
- forgetting accounts while offline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manage multiple VRChat accounts from a dedicated account selector.
  - Switch profiles, add accounts, disconnect sessions, or permanently forget saved accounts.
  - View active, locked, and saved account states with accessible controls.
  - Choose whether credentials remain available for existing accounts.
- **Security**
  - VRChat secrets are securely protected on Windows.
- **Bug Fixes**
  - Improved authentication, session restoration, logout handling, profile validation, and stale request cancellation.
- **Migration**
  - Existing VRChat settings are upgraded automatically to the new multi-account format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->