### PR TITLE
Move takeUntilDestroyed to the end of every operator chain

### DIFF
--- a/src-ui/app/app.component.ts
+++ b/src-ui/app/app.component.ts
@@ -37,7 +37,6 @@ export class AppComponent implements OnInit {
   ) {
     this.settings.settings
       .pipe(
-        takeUntilDestroyed(),
         map((settings) => settings.userLanguage),
         distinctUntilChanged(),
         // The translation has to be in memory before anything calls translate()
@@ -54,16 +53,19 @@ export class AppComponent implements OnInit {
         }),
         tap((userLanguage) => translate.setActiveLang(userLanguage)),
         debounceTime(10000),
-        tap((userLanguage) => this.telemetry.trackEvent('use_language', { language: userLanguage }))
+        tap((userLanguage) =>
+          this.telemetry.trackEvent('use_language', { language: userLanguage })
+        ),
+        takeUntilDestroyed()
       )
       .subscribe();
     // Snowverlay
     this.settings.settings
       .pipe(
-        takeUntilDestroyed(),
         skip(1),
         map((settings) => settings.hideSnowverlay),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed()
       )
       .subscribe((hideSnowverlay) => {
         this.showSnowverlay = !hideSnowverlay && isHolidaysEventActive();

--- a/src-ui/app/components/brightness-control-modal/brightness-control-modal.component.ts
+++ b/src-ui/app/components/brightness-control-modal/brightness-control-modal.component.ts
@@ -58,7 +58,6 @@ export class BrightnessControlModalComponent
       });
     hardwareBrightnessControl.driverIsAvailable
       .pipe(
-        takeUntilDestroyed(),
         tap((available) => {
           if (!available) this.driverChecked = true;
           this.driverAvailable = available;
@@ -69,7 +68,8 @@ export class BrightnessControlModalComponent
         tap(() => {
           this.driverChecked = true;
           this.cdr.markForCheck();
-        })
+        }),
+        takeUntilDestroyed()
       )
       .subscribe((bounds) => {
         this.hardwareBrightnessBounds = bounds;
@@ -77,23 +77,23 @@ export class BrightnessControlModalComponent
       });
     this.setHardwareBrightness
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         throttleTime(1000 / 30, asyncScheduler, { leading: true, trailing: true }),
-        switchMap((percentage) => this.hardwareBrightnessControl.setBrightness(percentage))
+        switchMap((percentage) => this.hardwareBrightnessControl.setBrightness(percentage)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
     this.setSoftwareBrightness
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         throttleTime(1000 / 30, asyncScheduler, { leading: true, trailing: true }),
-        switchMap((percentage) => this.softwareBrightnessControl.setBrightness(percentage))
+        switchMap((percentage) => this.softwareBrightnessControl.setBrightness(percentage)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
     this.setSimpleBrightness
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         throttleTime(1000 / 30, asyncScheduler, { leading: true, trailing: true }),
-        switchMap((percentage) => this.simpleBrightnessControl.setBrightness(percentage))
+        switchMap((percentage) => this.simpleBrightnessControl.setBrightness(percentage)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src-ui/app/components/bsb-fan-speed-control-modal/bsb-fan-speed-control-modal.component.ts
+++ b/src-ui/app/components/bsb-fan-speed-control-modal/bsb-fan-speed-control-modal.component.ts
@@ -40,19 +40,19 @@ export class BSBFanSpeedControlModalComponent
     super();
     this.automationConfigService.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         map((c) => c.BIGSCREEN_BEYOND_FAN_CONTROL),
         tap((config) => {
           this.fanSpeedBounds = [config.allowUnsafeFanSpeed ? 0 : 40, 100];
           this.cdr.markForCheck();
-        })
+        }),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
     this.setFanSpeed
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         throttleTime(1000 / 30, asyncScheduler, { leading: true, trailing: true }),
-        switchMap((percentage) => this.fanControl.setFanSpeed(percentage))
+        switchMap((percentage) => this.fanControl.setFanSpeed(percentage)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src-ui/app/components/cct-control-modal/cct-control-modal.component.ts
+++ b/src-ui/app/components/cct-control-modal/cct-control-modal.component.ts
@@ -30,9 +30,9 @@ export class CCTControlModalComponent extends BaseModalComponent<void, void> imp
     super();
     this.setCCT
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         throttleTime(1000 / 30, asyncScheduler, { leading: true, trailing: true }),
-        switchMap((cct) => this.cctControl.setCCT(cct))
+        switchMap((cct) => this.cctControl.setCCT(cct)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src-ui/app/components/controller-binding/controller-binding.component.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.ts
@@ -61,17 +61,17 @@ export class ControllerBindingComponent implements OnInit {
   ngOnInit() {
     this.openvr.status
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         pairwise(),
         filter(([prev, current]) => current !== 'INITIALIZED' && prev === 'INITIALIZED'),
-        tap(() => (this.dropdownOpen = false))
+        tap(() => (this.dropdownOpen = false)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
     interval(1000)
       .pipe(
         startWith(void 0),
-        takeUntilDestroyed(this.destroyRef),
-        switchMap(() => this.refreshBindings())
+        switchMap(() => this.refreshBindings()),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src-ui/app/components/device-list/device-list-item/device-list-item.component.ts
+++ b/src-ui/app/components/device-list/device-list-item/device-list-item.component.ts
@@ -184,10 +184,10 @@ export class DeviceListItemComponent implements OnInit {
     });
     this.appSettings.settings
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         map((s) => s.v1LighthouseIdentifiers),
         distinctUntilChanged((a, b) => isEqual(a, b)),
-        skip(1)
+        skip(1),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {
         if (this._lighthouseDevice) this.lighthouseDevice = this._lighthouseDevice;

--- a/src-ui/app/components/device-list/device-list.component.ts
+++ b/src-ui/app/components/device-list/device-list.component.ts
@@ -79,12 +79,12 @@ export class DeviceListComponent implements OnInit {
   ngOnInit(): void {
     combineLatest([
       this.openvr.devices.pipe(
-        takeUntilDestroyed(this.destroyRef),
-        tap((devices) => this.processOpenVRDevices(devices))
+        tap((devices) => this.processOpenVRDevices(devices)),
+        takeUntilDestroyed(this.destroyRef)
       ),
       this.lighthouse.devices.pipe(
-        takeUntilDestroyed(this.destroyRef),
-        tap((devices) => this.processLighthouseDevices(devices))
+        tap((devices) => this.processLighthouseDevices(devices)),
+        takeUntilDestroyed(this.destroyRef)
       ),
     ])
       .pipe(tap(() => this.sortDeviceCategories()))
@@ -94,7 +94,7 @@ export class DeviceListComponent implements OnInit {
       this.cdr.markForCheck();
     });
     this.appSettings.settings
-      .pipe(takeUntilDestroyed(this.destroyRef), debounceTime(100))
+      .pipe(debounceTime(100), takeUntilDestroyed(this.destroyRef))
       .subscribe((settings) => {
         this.lighthousePowerControl = settings.lighthousePowerControl;
         this.cdr.markForCheck();

--- a/src-ui/app/components/device-manager-config-modal/device-manager-config-modal.component.ts
+++ b/src-ui/app/components/device-manager-config-modal/device-manager-config-modal.component.ts
@@ -122,8 +122,8 @@ export class DeviceManagerConfigModalComponent
     this.lighthouseEvaluationSub?.unsubscribe();
     this.lighthouseEvaluationSub = this.lighthouseService.devices
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((devices) => devices.find((d) => d.id === lighthouseId))
+        map((devices) => devices.find((d) => d.id === lighthouseId)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((device) => {
         if (!device || device.deviceType !== 'lighthouseV1') this.v1LighthouseMode = 'NONE';

--- a/src-ui/app/components/event-log/event-log.component.ts
+++ b/src-ui/app/components/event-log/event-log.component.ts
@@ -49,7 +49,6 @@ export class EventLogComponent implements OnInit, AfterViewInit {
     private appSettings: AppSettingsService
   ) {
     this.logsInView = combineLatest([this.eventLog.eventLog, this.showCount, this.filters]).pipe(
-      takeUntilDestroyed(),
       map(
         ([log, showCount, filters]) =>
           [log.logs.filter((log) => !filters.includes(log.type)), showCount, filters] as [
@@ -62,7 +61,8 @@ export class EventLogComponent implements OnInit, AfterViewInit {
         this.entries = logs.length;
         this.cdr.detectChanges();
       }),
-      map(([logs, showCount]) => logs.slice(0, showCount))
+      map(([logs, showCount]) => logs.slice(0, showCount)),
+      takeUntilDestroyed()
     );
     this.appSettings.settings.pipe(takeUntilDestroyed()).subscribe((settings) => {
       this.filters.next(settings.eventLogTypesHidden);

--- a/src-ui/app/components/frame-limiter-selector/frame-limiter-selector.component.ts
+++ b/src-ui/app/components/frame-limiter-selector/frame-limiter-selector.component.ts
@@ -40,9 +40,9 @@ export class FrameLimiterSelectorComponent implements OnInit {
   ngOnInit(): void {
     this.openvr.devices
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         map((devices) => devices.find((d) => d.class === 'HMD')?.displayFrequency),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((displayFrequency) => {
         this.hmdDisplayFrequency = displayFrequency;

--- a/src-ui/app/components/friend-selection-modal/friend-selection-modal.component.ts
+++ b/src-ui/app/components/friend-selection-modal/friend-selection-modal.component.ts
@@ -91,10 +91,10 @@ export class FriendSelectionModalComponent
     await firstValueFrom(this.vrchat.user.pipe(filter(Boolean)));
     this.query
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         debounceTime(200),
         startWith(this.query.value),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((query) => this.search(query));
     this.loadFriends();

--- a/src-ui/app/components/hotkey-selector-modal/hotkey-selector-modal.component.ts
+++ b/src-ui/app/components/hotkey-selector-modal/hotkey-selector-modal.component.ts
@@ -57,9 +57,9 @@ export class HotkeySelectorModalComponent
     await this.hotkeyService.pause();
     merge(fromEvent(document, 'keyup'), fromEvent(document, 'keydown'))
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         takeUntil(this.stopListeningForKeys),
-        map((event) => event as KeyboardEvent)
+        map((event) => event as KeyboardEvent),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async (event: KeyboardEvent) => {
         this.modifiers.Ctrl = event.ctrlKey;

--- a/src-ui/app/components/lighthouse-v1-id-wizard-modal/lighthouse-v1-id-wizard-modal.component.ts
+++ b/src-ui/app/components/lighthouse-v1-id-wizard-modal/lighthouse-v1-id-wizard-modal.component.ts
@@ -104,14 +104,14 @@ export class LighthouseV1IdWizardModalComponent
   ngOnInit(): void {
     interval(1000)
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         filter(() => this.step === 'AUTOMATIC_DETECTION'),
         delay(1500),
-        filter(() => this.step === 'AUTOMATIC_DETECTION')
+        filter(() => this.step === 'AUTOMATIC_DETECTION'),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => this.attemptAutomaticDetection());
     combineLatest([this.openvr.status, this.openvr.devices])
-      .pipe(takeUntilDestroyed(this.destroyRef), debounceTime(1))
+      .pipe(debounceTime(1), takeUntilDestroyed(this.destroyRef))
       .subscribe(([status, devices]) => {
         const openVrInitialized = status === 'INITIALIZED';
         const trackedDeviceDetected = devices.some(

--- a/src-ui/app/components/main-status-bar/main-status-bar.component.ts
+++ b/src-ui/app/components/main-status-bar/main-status-bar.component.ts
@@ -86,8 +86,8 @@ export class MainStatusBarComponent implements OnInit {
     // else here observes.
     this.router.events
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        filter((e) => e instanceof NavigationEnd)
+        filter((e) => e instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => this.cdr.markForCheck());
     // cctCSSColor is a plain property on the service, read straight from the

--- a/src-ui/app/components/osc-script-code-editor/osc-script-code-editor.component.ts
+++ b/src-ui/app/components/osc-script-code-editor/osc-script-code-editor.component.ts
@@ -18,6 +18,7 @@ import { isEqual } from 'lodash';
 import { OscService } from '../../services/osc.service';
 import { parseOscScriptFromCode } from '../../utils/osc-script-utils';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { flushOnDestroy } from '../../utils/rxjs-utils';
 
 @Component({
   selector: 'app-osc-script-code-editor',
@@ -81,14 +82,15 @@ export class OscScriptCodeEditorComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
+    flushOnDestroy(this._code, this.destroyRef);
     this._code
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         tap(() => {
           this.validated = false;
           this.cdr.markForCheck();
         }),
-        debounceTime(500)
+        debounceTime(500),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((code) => {
         this.tooltipErrors = [];

--- a/src-ui/app/components/osc-script-simple-editor/osc-address-autocomplete/osc-address-autocomplete.component.ts
+++ b/src-ui/app/components/osc-script-simple-editor/osc-address-autocomplete/osc-address-autocomplete.component.ts
@@ -69,7 +69,7 @@ export class OscAddressAutocompleteComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     // Setup address search
     this.addressQuery
-      .pipe(takeUntilDestroyed(this.destroyRef), debounceTime(100), distinctUntilChanged())
+      .pipe(debounceTime(100), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((query) => {
         this.searchAddresses(query);
         this.cdr.markForCheck();

--- a/src-ui/app/components/osc-script-simple-editor/osc-script-simple-editor.component.ts
+++ b/src-ui/app/components/osc-script-simple-editor/osc-script-simple-editor.component.ts
@@ -29,6 +29,7 @@ import { OscAddressSelection } from './osc-address-autocomplete/osc-address-auto
 import { AvatarContext, VRChatAvatarParameter } from '../../models/avatar-context';
 import { VRChatService } from 'src-ui/app/services/vrchat-api/vrchat.service';
 import { AppSettingsService } from '../../services/app-settings.service';
+import { flushOnDestroy } from '../../utils/rxjs-utils';
 
 interface ValidationError {
   actionIndex: number;
@@ -117,15 +118,16 @@ export class OscScriptSimpleEditorComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    flushOnDestroy(this.validationTrigger, this.destroyRef);
     this.validationTrigger
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         startWith(void 0),
         tap(() => {
           this.validated = false;
           this.cdr.markForCheck();
         }),
-        debounceTime(500)
+        debounceTime(500),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {
         this.validateScript();

--- a/src-ui/app/components/player-list/player-list.component.ts
+++ b/src-ui/app/components/player-list/player-list.component.ts
@@ -54,7 +54,7 @@ export class PlayerListComponent implements OnInit {
 
   ngOnInit() {
     this.vrchat.status
-      .pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged())
+      .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe(async (status) => {
         this.loggedIn = status === 'LOGGED_IN';
         this.cdr.markForCheck();

--- a/src-ui/app/components/sleeping-pose-viewer/sleeping-pose-viewer.component.ts
+++ b/src-ui/app/components/sleeping-pose-viewer/sleeping-pose-viewer.component.ts
@@ -59,14 +59,14 @@ export class SleepingPoseViewerComponent implements AfterViewInit {
     });
     combineLatest([this.openvr.devices, this.openvr.devicePoses])
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         map(([devices, poses]) => {
           const hmdDevice = devices.find((d) => d.class === 'HMD');
           if (!hmdDevice) return null;
           return poses[hmdDevice.index] || null;
         }),
         filter((hmdPose) => hmdPose !== null),
-        map((hmdPose) => hmdPose as OVRDevicePose)
+        map((hmdPose) => hmdPose as OVRDevicePose),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((hmdPose) => {
         const hmdOrientation = new THREE.Quaternion(...hmdPose.quaternion);

--- a/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
+++ b/src-ui/app/components/vrchat-login-modal/vrchat-login-modal.component.ts
@@ -65,8 +65,8 @@ export class VRChatLoginModalComponent
     this.vrchat.activeProfile
       .pipe(
         map((profile) => profile?.rememberCredentials ?? false),
-        takeUntilDestroyed(this.destroyRef),
-        take(1)
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async (rememberCredentials) => {
         try {

--- a/src-ui/app/components/vrchat-login-tfa-modal/vrchat-login-tfa-modal.component.ts
+++ b/src-ui/app/components/vrchat-login-tfa-modal/vrchat-login-tfa-modal.component.ts
@@ -47,7 +47,7 @@ export class VRChatLoginTFAModalComponent
   ngOnInit(): void {
     if (this.lastCodeInvalid) this.error = 'comp.vrchat-login-tfa-modal.errors.LAST_CODE_INVALID';
     this.code
-      .pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged(), skip(1), debounceTime(300))
+      .pipe(distinctUntilChanged(), skip(1), debounceTime(300), takeUntilDestroyed(this.destroyRef))
       .subscribe((code) => {
         if (/^[0-9]{6}$/.test(code)) {
           this.codeValid = true;

--- a/src-ui/app/modules/translation/views/translation-editor-view/translation-editor-view.component.ts
+++ b/src-ui/app/modules/translation/views/translation-editor-view/translation-editor-view.component.ts
@@ -59,9 +59,9 @@ export class TranslationEditorViewComponent {
       this.locale = locale;
     });
     combineLatest([this.translationEditService.entries, this.translationEditService.suggestions])
-      .pipe(takeUntilDestroyed(), debounceTime(0))
+      .pipe(debounceTime(0), takeUntilDestroyed())
       .subscribe(([entries, suggestions]) => this.processEntryChanges(entries, suggestions));
-    this.changeMade.pipe(takeUntilDestroyed(), debounceTime(500)).subscribe(() => {
+    this.changeMade.pipe(debounceTime(500), takeUntilDestroyed()).subscribe(() => {
       this.calculateKeysTranslated();
     });
   }

--- a/src-ui/app/utils/rxjs-utils.ts
+++ b/src-ui/app/utils/rxjs-utils.ts
@@ -2,9 +2,8 @@ import { DestroyRef } from '@angular/core';
 import { Subject } from 'rxjs';
 
 /**
- * Completes `source` on destroy, so a value still pending in a `debounceTime` reaches the subscriber
- * one last time. Call this before subscribing: destroy callbacks run in registration order, and a
- * `takeUntilDestroyed` at the end of the chain registers its own once the chain is subscribed.
+ * Completes `source` on destroy, so a value pending in a `debounceTime` still reaches the
+ * subscriber. Call before subscribing, or a `takeUntilDestroyed` in the chain tears it down first.
  */
 export function flushOnDestroy<T>(source: Subject<T>, destroyRef: DestroyRef): void {
   destroyRef.onDestroy(() => source.complete());

--- a/src-ui/app/utils/rxjs-utils.ts
+++ b/src-ui/app/utils/rxjs-utils.ts
@@ -1,0 +1,11 @@
+import { DestroyRef } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * Completes `source` on destroy, so a value still pending in a `debounceTime` reaches the subscriber
+ * one last time. Call this before subscribing: destroy callbacks run in registration order, and a
+ * `takeUntilDestroyed` at the end of the chain registers its own once the chain is subscribed.
+ */
+export function flushOnDestroy<T>(source: Subject<T>, destroyRef: DestroyRef): void {
+  destroyRef.onDestroy(() => source.complete());
+}

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
@@ -122,8 +122,8 @@ export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
   async ngAfterViewInit() {
     interval(1000)
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        filter(() => !this.supportersScrolling)
+        filter(() => !this.supportersScrolling),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {
         if (!this.supportersList) return;

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
@@ -155,6 +155,7 @@ export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   async ngOnDestroy() {
+    this.supportersScrolling = false;
     this.background.setBackground(null);
   }
 

--- a/src-ui/app/views/dashboard-view/views/audio-volume-automations-view/audio-volume-automations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/audio-volume-automations-view/audio-volume-automations-view.component.ts
@@ -30,7 +30,6 @@ export class AudioVolumeAutomationsViewComponent implements OnInit {
     this.automationsConfigService.configs
       .pipe(
         map((configs) => configs.AUDIO_DEVICE_AUTOMATIONS),
-        // distinctUntilChanged((previous, current) => isEqual(previous, current)),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((config) => {

--- a/src-ui/app/views/dashboard-view/views/audio-volume-automations-view/audio-volume-automations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/audio-volume-automations-view/audio-volume-automations-view.component.ts
@@ -29,9 +29,9 @@ export class AudioVolumeAutomationsViewComponent implements OnInit {
   ngOnInit() {
     this.automationsConfigService.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((configs) => configs.AUDIO_DEVICE_AUTOMATIONS)
-        // distinctUntilChanged((previous, current) => isEqual(previous, current))
+        map((configs) => configs.AUDIO_DEVICE_AUTOMATIONS),
+        // distinctUntilChanged((previous, current) => isEqual(previous, current)),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((config) => {
         this.config = config;

--- a/src-ui/app/views/dashboard-view/views/brightness-automations-view/tabs/new-brightness-automations-tab/brightness-automations-list/brightness-automations-list.component.ts
+++ b/src-ui/app/views/dashboard-view/views/brightness-automations-view/tabs/new-brightness-automations-tab/brightness-automations-list/brightness-automations-list.component.ts
@@ -80,8 +80,8 @@ export class BrightnessAutomationsListComponent implements OnInit {
     // Get configuration updates and refresh indicators when config changes
     this.automationConfigService.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((configs) => configs.BRIGHTNESS_AUTOMATIONS)
+        map((configs) => configs.BRIGHTNESS_AUTOMATIONS),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((config) => {
         this.config = config;
@@ -96,8 +96,8 @@ export class BrightnessAutomationsListComponent implements OnInit {
       interval(5000).pipe(startWith(0)), // Update every 5 seconds and initially
     ])
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        switchMap(() => this.updateHmdConnectIndicators())
+        switchMap(() => this.updateHmdConnectIndicators()),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src-ui/app/views/dashboard-view/views/frame-limiter-view/frame-limiter-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/frame-limiter-view/frame-limiter-view.component.ts
@@ -44,8 +44,8 @@ export class FrameLimiterViewComponent implements OnInit {
   ngOnInit(): void {
     this.automationConfig.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((configs) => configs.FRAME_LIMIT_AUTOMATIONS)
+        map((configs) => configs.FRAME_LIMIT_AUTOMATIONS),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((config) => (this.config = config));
     this.frameLimiterService.activeFrameLimits

--- a/src-ui/app/views/dashboard-view/views/gpu-automations-view/gpu-powerlimiting-pane/gpu-powerlimiting-pane.component.ts
+++ b/src-ui/app/views/dashboard-view/views/gpu-automations-view/gpu-powerlimiting-pane/gpu-powerlimiting-pane.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { GPUDevice, GPUPowerLimit } from '../../../../../models/gpu-device';
 import { NvmlService } from '../../../../../services/nvml.service';
 import { GpuAutomationsService } from '../../../../../services/gpu-automations.service';
@@ -6,6 +6,7 @@ import { debounceTime, firstValueFrom, Subject } from 'rxjs';
 import { noop, vshrink } from '../../../../../utils/animations';
 import { TString } from 'src-ui/app/models/translatable-string';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { flushOnDestroy } from '../../../../../utils/rxjs-utils';
 
 @Component({
   selector: 'app-gpu-powerlimiting-pane',
@@ -31,7 +32,8 @@ export class GpuPowerlimitingPaneComponent implements OnInit {
 
   constructor(
     private nvml: NvmlService,
-    protected gpuAutomations: GpuAutomationsService
+    protected gpuAutomations: GpuAutomationsService,
+    destroyRef: DestroyRef
   ) {
     this.gpuAutomations.nvmlDevices.pipe(takeUntilDestroyed()).subscribe(async (devices) => {
       this.gpuDevices = devices;
@@ -88,8 +90,9 @@ export class GpuPowerlimitingPaneComponent implements OnInit {
           break;
       }
     });
+    flushOnDestroy(this.powerLimitChange, destroyRef);
     this.powerLimitChange
-      .pipe(takeUntilDestroyed(), debounceTime(100))
+      .pipe(debounceTime(100), takeUntilDestroyed())
       .subscribe(async ({ automation, limit }) => {
         switch (automation) {
           case 'SLEEP_ENABLE':

--- a/src-ui/app/views/dashboard-view/views/invite-and-invite-request-view/invite-and-invite-request-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/invite-and-invite-request-view/invite-and-invite-request-view.component.ts
@@ -36,7 +36,7 @@ export class InviteAndInviteRequestViewComponent implements OnInit {
 
   ngOnInit(): void {
     this.vrchat.status
-      .pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged())
+      .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe(async (status) => {
         this.loggedIn = status === 'LOGGED_IN';
       });

--- a/src-ui/app/views/dashboard-view/views/invite-and-invite-request-view/tabs/invite-requests-tab/invite-requests-tab.component.ts
+++ b/src-ui/app/views/dashboard-view/views/invite-and-invite-request-view/tabs/invite-requests-tab/invite-requests-tab.component.ts
@@ -3,6 +3,7 @@ import { SelectBoxItem } from '../../../../../../components/select-box/select-bo
 import { debounceTime, distinctUntilChanged, map, skip, Subject, tap } from 'rxjs';
 import { VRChatService } from '../../../../../../services/vrchat-api/vrchat.service';
 import { noop, vshrink } from '../../../../../../utils/animations';
+import { flushOnDestroy } from '../../../../../../utils/rxjs-utils';
 import {
   AutoAcceptInviteRequestsAutomationConfig,
   AUTOMATION_CONFIGS_DEFAULT,
@@ -100,7 +101,6 @@ export class InviteRequestsTabComponent implements OnInit {
   ngOnInit(): void {
     this.appSettings.settings
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         map((settings) => settings.playerListPresets),
         distinctUntilChanged(),
         tap((presets) => {
@@ -123,7 +123,8 @@ export class InviteRequestsTabComponent implements OnInit {
               this.presetOption[keyT] = this.presetOptions[0];
             }
           });
-        })
+        }),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
     this.automationConfig.configs
@@ -144,22 +145,24 @@ export class InviteRequestsTabComponent implements OnInit {
           (o) => o.id === this.config.declineOnRequest
         );
       });
+    flushOnDestroy(this.updateAcceptInviteRequestCustomMessage, this.destroyRef);
     this.updateAcceptInviteRequestCustomMessage
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         debounceTime(500),
         map((message) => message.trim().replace(/\s+/g, ' ').slice(0, 64)),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((message) => {
         this.updateConfig({ acceptInviteRequestMessage: message });
       });
+    flushOnDestroy(this.updateDeclineInviteRequestCustomMessage, this.destroyRef);
     this.updateDeclineInviteRequestCustomMessage
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         debounceTime(500),
         map((message) => message.trim().replace(/\s+/g, ' ').slice(0, 64)),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((message) => {
         this.updateConfig({ declineInviteRequestMessage: message });

--- a/src-ui/app/views/dashboard-view/views/invite-and-invite-request-view/tabs/invites-tab/invites-tab.component.ts
+++ b/src-ui/app/views/dashboard-view/views/invite-and-invite-request-view/tabs/invites-tab/invites-tab.component.ts
@@ -7,6 +7,7 @@ import {
 } from 'src-ui/app/models/automations';
 import { AutomationConfigService } from 'src-ui/app/services/automation-config.service';
 import { vshrink } from 'src-ui/app/utils/animations';
+import { flushOnDestroy } from 'src-ui/app/utils/rxjs-utils';
 
 @Component({
   selector: 'app-invites-tab',
@@ -33,12 +34,13 @@ export class InvitesTabComponent implements OnInit {
       .subscribe(async (configs) => {
         this.config = structuredClone(configs.AUTO_ACCEPT_INVITE_REQUESTS);
       });
+    flushOnDestroy(this.updateDeclineInviteWhileAsleepCustomMessage, this.destroyRef);
     this.updateDeclineInviteWhileAsleepCustomMessage
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         debounceTime(500),
         map((message) => message.trim().replace(/\s+/g, ' ').slice(0, 64)),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((message) => {
         this.updateConfig({ declineInviteMessage: message });

--- a/src-ui/app/views/dashboard-view/views/join-notifications-view/join-notifications-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/join-notifications-view/join-notifications-view.component.ts
@@ -63,8 +63,8 @@ export class JoinNotificationsViewComponent implements OnInit {
   ngOnInit() {
     this.automationConfigService.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((config) => config.JOIN_NOTIFICATIONS)
+        map((config) => config.JOIN_NOTIFICATIONS),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((config) => {
         this.config = config;

--- a/src-ui/app/views/dashboard-view/views/nightmare-detection-view/nightmare-detection-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/nightmare-detection-view/nightmare-detection-view.component.ts
@@ -53,8 +53,8 @@ export class NightmareDetectionViewComponent implements OnInit {
   ngOnInit() {
     this.automationConfigService.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((configs) => configs.NIGHTMARE_DETECTION)
+        map((configs) => configs.NIGHTMARE_DETECTION),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async (config) => {
         this.config = config;

--- a/src-ui/app/views/dashboard-view/views/run-automations-view/run-automations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/run-automations-view/run-automations-view.component.ts
@@ -39,11 +39,11 @@ export class RunAutomationsViewComponent implements OnInit {
 
   ngOnInit(): void {
     const config = this.automationConfigService.configs.pipe(
-      takeUntilDestroyed(this.destroyRef),
       map((configs) => configs.RUN_AUTOMATIONS),
       distinctUntilChanged((a, b) => isEqual(a, b)),
       tap((config) => (this.config = config)),
-      share()
+      share(),
+      takeUntilDestroyed(this.destroyRef)
     );
 
     const events: ('onSleepModeEnable' | 'onSleepModeDisable' | 'onSleepPreparation')[] = [
@@ -55,9 +55,9 @@ export class RunAutomationsViewComponent implements OnInit {
     config
       .pipe(
         debounceTime(500),
-        takeUntilDestroyed(this.destroyRef),
         filter((config) => !isEqual(AUTOMATION_CONFIGS_DEFAULT.RUN_AUTOMATIONS, config)),
-        take(1)
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async (config) => {
         // Initialize expanded states based on automation enabled state only on first load

--- a/src-ui/app/views/dashboard-view/views/settings-general-view/settings-general-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-general-view/settings-general-view.component.ts
@@ -18,6 +18,7 @@ import { ModalService } from 'src-ui/app/services/modal.service';
 
 import { LANGUAGES } from '../../../../globals';
 import { vshrink } from '../../../../utils/animations';
+import { flushOnDestroy } from '../../../../utils/rxjs-utils';
 import {
   TELEMETRY_SETTINGS_DEFAULT,
   TelemetrySettings,
@@ -105,8 +106,9 @@ export class SettingsGeneralViewComponent implements OnInit {
     this.lighthouse.consoleStatus
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((status) => this.processLighthouseConsoleStatus(status));
+    flushOnDestroy(this.lighthouseConsolePathInputChange, this.destroyRef);
     this.lighthouseConsolePathInputChange
-      .pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged(), debounceTime(500))
+      .pipe(distinctUntilChanged(), debounceTime(500), takeUntilDestroyed(this.destroyRef))
       .subscribe(async (path) => {
         await this.lighthouse.setConsolePath(path);
       });

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
@@ -104,7 +104,6 @@ export class SettingsOscViewComponent implements OnInit {
       ),
     ])
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         throttleTime(1000, asyncScheduler, { leading: true, trailing: true }),
         map(([vrcOscAddress, { oscCustomTargetHost, oscCustomTargetPort, oscTargets }]) => {
           if (!oscTargets.includes('VRCHAT_OSCQUERY') || !oscTargets.includes('CUSTOM'))
@@ -118,7 +117,8 @@ export class SettingsOscViewComponent implements OnInit {
           const vrcPort = parseInt(vrcOscAddress.split(':')[1]);
           return vrcPort === oscCustomTargetPort;
         }),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((showAlert) => (this.showVRCTargetWarning = showAlert));
   }

--- a/src-ui/app/views/dashboard-view/views/sleep-detection-view/modals/heart-rate-calm-period-enable-sleepmode-modal/heart-rate-chart/heart-rate-chart.component.ts
+++ b/src-ui/app/views/dashboard-view/views/sleep-detection-view/modals/heart-rate-calm-period-enable-sleepmode-modal/heart-rate-chart/heart-rate-chart.component.ts
@@ -47,9 +47,9 @@ export class HeartRateChartComponent implements OnInit, AfterViewInit, OnDestroy
   ngOnInit(): void {
     this.pulsoid.heartbeatRecords
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        filter((records) => !!records.length)
-        // throttleTime(1000 * 60, asyncScheduler, { leading: true, trailing: true })
+        filter((records) => !!records.length),
+        // throttleTime(1000 * 60, asyncScheduler, { leading: true, trailing: true }),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((data) => {
         this.processData(data, 24);

--- a/src-ui/app/views/dashboard-view/views/sleep-detection-view/modals/heart-rate-calm-period-enable-sleepmode-modal/heart-rate-chart/heart-rate-chart.component.ts
+++ b/src-ui/app/views/dashboard-view/views/sleep-detection-view/modals/heart-rate-calm-period-enable-sleepmode-modal/heart-rate-chart/heart-rate-chart.component.ts
@@ -48,7 +48,6 @@ export class HeartRateChartComponent implements OnInit, AfterViewInit, OnDestroy
     this.pulsoid.heartbeatRecords
       .pipe(
         filter((records) => !!records.length),
-        // throttleTime(1000 * 60, asyncScheduler, { leading: true, trailing: true }),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((data) => {

--- a/src-ui/app/views/dashboard-view/views/status-automations-view/tabs/status-automations-player-limit-tab/status-automations-player-limit-tab.component.ts
+++ b/src-ui/app/views/dashboard-view/views/status-automations-view/tabs/status-automations-player-limit-tab/status-automations-player-limit-tab.component.ts
@@ -26,6 +26,7 @@ import {
   ConfirmModalOutputModel,
 } from '../../../../../../components/confirm-modal/confirm-modal.component';
 import { hshrink, noop, vshrink } from '../../../../../../utils/animations';
+import { flushOnDestroy } from '../../../../../../utils/rxjs-utils';
 
 @Component({
   selector: 'app-status-automations-player-limit-tab',
@@ -107,9 +108,9 @@ export class StatusAutomationsPlayerLimitTabComponent implements OnInit {
       this.loggedIn = status === 'LOGGED_IN';
       this.cdr.markForCheck();
     });
+    flushOnDestroy(this.limit, this.destroyRef);
     this.limit
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
         tap((limit) => {
           this.bedLimit = Math.min(limit, 10);
           this.cdr.markForCheck();
@@ -117,7 +118,8 @@ export class StatusAutomationsPlayerLimitTabComponent implements OnInit {
         distinctUntilChanged(),
         filter((limit) => limit !== this.config.limit),
         debounceTime(300),
-        switchMap((limit) => this.updateConfig({ limit }))
+        switchMap((limit) => this.updateConfig({ limit })),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src-ui/app/views/dashboard-view/views/system-mic-mute-automations-view/system-mic-mute-automations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/system-mic-mute-automations-view/system-mic-mute-automations-view.component.ts
@@ -138,9 +138,9 @@ export class SystemMicMuteAutomationsViewComponent implements OnInit, OnDestroy 
   async ngOnInit() {
     // Obtain config changes
     const $config = this.automationConfigService.configs.pipe(
-      takeUntilDestroyed(this.destroyRef),
       map((configs) => configs.SYSTEM_MIC_MUTE_AUTOMATIONS),
-      distinctUntilChanged((a, b) => isEqual(a, b))
+      distinctUntilChanged((a, b) => isEqual(a, b)),
+      takeUntilDestroyed(this.destroyRef)
     );
     // Process config changes
     $config.subscribe((config) => {

--- a/src-ui/app/views/dashboard-view/views/vrchat-mic-mute-automations-view/vrchat-mic-mute-automations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/vrchat-mic-mute-automations-view/vrchat-mic-mute-automations-view.component.ts
@@ -54,8 +54,8 @@ export class VRChatMicMuteAutomationsViewComponent implements OnInit {
   async ngOnInit() {
     this.automationConfigService.configs
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        map((configs) => configs.VRCHAT_MIC_MUTE_AUTOMATIONS)
+        map((configs) => configs.VRCHAT_MIC_MUTE_AUTOMATIONS),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((config) => {
         this.onSleepEnableMuteOption = this.muteActionOptions.find(


### PR DESCRIPTION
`takeUntilDestroyed` only guards the operators downstream of it. Placed early in a `.pipe()`, it completes the chain on destroy, and operators after it can still deliver a value: `switchMap` keeps its inner subscription alive, `delay` hands over its buffered value, and `debounceTime` flushes on complete. I swept `src-ui`, `src-overlay-ui` and `src-shared-ts` and found 53 pipes where it was not the last operator. It now is, in all 142.

Concrete leaks this closes:

- `brightness-control-modal`, `cct-control-modal` and `bsb-fan-speed-control-modal` kept writing brightness, CCT and fan speed through a `switchMap` after the modal closed.
- `lighthouse-v1-id-wizard-modal` still ran `attemptAutomaticDetection()` 1500 ms after close, behind a `delay`.
- 14 chains ran their subscriber once more after destroy, because `debounceTime` and `throttleTime({trailing: true})` flush on complete.
- 8 chains called `markForCheck()` or `detectChanges()` on a destroyed view.

## The part that needs a reviewer's eye

That flush-on-complete was load-bearing in eight chains, so a plain reorder would have lost a write.

`osc-script-simple-editor` and `osc-script-code-editor` emit `scriptChange` only from inside a `debounceTime(500)` subscriber. That emit is the only path back to `osc-script-modal`, because the simple editor `structuredClone`s its `@Input()` and the code editor re-parses. The modal renders each editor under `@if (activeTab === ...)`, so switching between the SIMPLE and SCRIPT tabs destroys the editor. Before this change, destroy completed the chain, the debounce flushed, and the parent got the edit. A plain reorder would drop it, and the modal would save a stale script.

Six more chains write config or settings from a debounced subscriber: both custom-message inputs in `invite-requests-tab`, the one in `invites-tab`, the lighthouse console path in `settings-general-view`, the player limit in `status-automations-player-limit-tab`, and the GPU power limit in `gpu-powerlimiting-pane`. For the three text inputs the trigger is `(change)`, which fires on blur, so clicking another tab emits the value and destroys the component in the same task and the 500 ms never elapses.

`flushOnDestroy` in the new `src-ui/app/utils/rxjs-utils.ts` completes the source subject on destroy. The pending value flushes once, synchronously, and `takeUntilDestroyed` stays last.

It depends on an ordering invariant, which is the thing worth checking in review: destroy callbacks run in registration order, and `takeUntil` subscribes its notifier before its source, so a `takeUntilDestroyed` in last position registers its callback when the chain is subscribed. A `flushOnDestroy` call placed before `.subscribe()` therefore runs first. Called after `.subscribe()`, it silently does nothing. The helper's doc comment says so.

I checked both halves against the installed packages: Angular 22.1.1 iterates `ON_DESTROY_HOOKS` forward over a push-ordered array, and RxJS 7.8.2 `takeUntil` subscribes the notifier before the source. Then I ran both directions against real RxJS, and the negative control does lose the value.

## What I left alone

The trailing-throttle flush in the brightness, CCT and fan modals is also gone, but the window is `1000/30` ms and `setBrightness` is a promise that the unsubscribe cannot cancel, so the write still lands. `settings-osc-view` loses the same flush and only sets a view flag.

`run-automations-view.component.ts:100` already dropped a pending `debounceTime(1000)` command write on destroy before this change. I did not touch it.

## Checks

`prettier` is clean. `tsc -p tsconfig.app.json --noEmit` reports nothing in these files; the only errors are pre-existing `@sentry/angular` resolution failures in `app.module.ts` and `error-reporting.service.ts`.

There are no tests, because the repo has no `*.spec.ts` and no test script, so the ordering check above is not committed. Worth testing by hand: type a custom message in the invite or invites tab and immediately click another tab, then confirm it persisted. Same for an OSC script edit followed by a SIMPLE/SCRIPT tab switch and a save.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of settings, device, automation, and modal activity when leaving a screen.
  * Prevented stale updates from in-flight requests and background refreshes after components close.
  * Preserved pending debounced changes, including custom messages, console paths, validation, and player limits, during teardown.
  * Reset scrolling state correctly when leaving the About view.
  * Improved language-change telemetry tracking.

* **Reliability**
  * Refined event filtering, throttling, and debouncing for more consistent UI updates while preserving existing controls and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->