### PR TITLE
Store the Run Automations commands as plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   `--console` to open one
 - The Chinese Steam release is now the same build as the international Steam release. It switches to
   CN compliance mode at runtime.
-- The commands of the "Run Automations" are now stored as plain text, so you can read and edit them in
+- The Run Automations commands are now stored as plain text, so you can read and edit them in
   OyasumiVR's settings file
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   `--console` to open one
 - The Chinese Steam release is now the same build as the international Steam release. It switches to
   CN compliance mode at runtime.
+- The commands of the "Run Automations" are now stored as plain text, so you can read and edit them in
+  OyasumiVR's settings file
 
 ### Fixed
 

--- a/src-ui/app/migrations/automation-configs.migrations.ts
+++ b/src-ui/app/migrations/automation-configs.migrations.ts
@@ -37,8 +37,11 @@ const RUN_AUTOMATION_COMMAND_FIELDS = [
 ];
 
 async function from19to20(data: any): Promise<any> {
-  data.version = 20;
-  if (!data.RUN_AUTOMATIONS) return data;
+  if (!data.RUN_AUTOMATIONS) {
+    data.version = 20;
+    return data;
+  }
+  const original = structuredClone(data);
   const legacyKey = data.RUN_AUTOMATIONS.runAutomationsCryptoKey;
   delete data.RUN_AUTOMATIONS.runAutomationsCryptoKey;
   let key: CryptoKey | null = null;
@@ -49,6 +52,7 @@ async function from19to20(data: any): Promise<any> {
       error("[automation-configs-migrations] Couldn't read the Run Automations command key: " + e);
     }
   }
+  let discarded = false;
   for (const field of RUN_AUTOMATION_COMMAND_FIELDS) {
     const commands = data.RUN_AUTOMATIONS[field];
     if (!commands) continue;
@@ -58,8 +62,15 @@ async function from19to20(data: any): Promise<any> {
     } catch (e) {
       error("[automation-configs-migrations] Couldn't migrate " + field + ': ' + e);
       data.RUN_AUTOMATIONS[field] = '';
+      discarded = true;
     }
   }
+  if (discarded) {
+    await saveBackup(original).catch((e) =>
+      error("[automation-configs-migrations] Couldn't write the backup: " + e)
+    );
+  }
+  data.version = 20;
   return data;
 }
 

--- a/src-ui/app/migrations/automation-configs.migrations.ts
+++ b/src-ui/app/migrations/automation-configs.migrations.ts
@@ -5,6 +5,7 @@ import { message } from '@tauri-apps/plugin-dialog';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { migrateOscScript } from './osc-script.migrations';
 import { migrateKnownLighthouseDeviceId } from './lighthouse-device-id';
+import { decryptStorageData, deserializeStorageCryptoKey } from '../utils/crypto';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
@@ -26,7 +27,41 @@ const migrations: { [v: number]: (data: any) => any } = {
   17: from16to17,
   18: from17to18,
   19: from18to19,
+  20: from19to20,
 };
+
+const RUN_AUTOMATION_COMMAND_FIELDS = [
+  'onSleepModeEnableCommands',
+  'onSleepModeDisableCommands',
+  'onSleepPreparationCommands',
+];
+
+async function from19to20(data: any): Promise<any> {
+  data.version = 20;
+  if (!data.RUN_AUTOMATIONS) return data;
+  const legacyKey = data.RUN_AUTOMATIONS.runAutomationsCryptoKey;
+  delete data.RUN_AUTOMATIONS.runAutomationsCryptoKey;
+  let key: CryptoKey | null = null;
+  if (legacyKey) {
+    try {
+      key = await deserializeStorageCryptoKey(legacyKey);
+    } catch (e) {
+      error("[automation-configs-migrations] Couldn't read the Run Automations command key: " + e);
+    }
+  }
+  for (const field of RUN_AUTOMATION_COMMAND_FIELDS) {
+    const commands = data.RUN_AUTOMATIONS[field];
+    if (!commands) continue;
+    try {
+      if (!key) throw new Error('No command key available');
+      data.RUN_AUTOMATIONS[field] = await decryptStorageData(commands, key);
+    } catch (e) {
+      error("[automation-configs-migrations] Couldn't migrate " + field + ': ' + e);
+      data.RUN_AUTOMATIONS[field] = '';
+    }
+  }
+  return data;
+}
 
 function from18to19(data: any): any {
   data.version = 19;
@@ -51,7 +86,7 @@ function migrateSelectedDeviceIds(value: any) {
   Object.values(value).forEach(migrateSelectedDeviceIds);
 }
 
-export function migrateAutomationConfigs(data: any): AutomationConfigs {
+export async function migrateAutomationConfigs(data: any): Promise<AutomationConfigs> {
   let currentVersion = data.version || 0;
   // Reset to latest when the current version is higher than the latest
   if (currentVersion > AUTOMATION_CONFIGS_DEFAULT.version) {
@@ -65,7 +100,7 @@ export function migrateAutomationConfigs(data: any): AutomationConfigs {
   while (currentVersion < AUTOMATION_CONFIGS_DEFAULT.version) {
     try {
       console.log('Migrating to version', currentVersion + 1);
-      data = migrations[++currentVersion](structuredClone(data));
+      data = await migrations[++currentVersion](structuredClone(data));
     } catch (e) {
       error(
         "[automation-configs-migrations] Couldn't migrate to version " +

--- a/src-ui/app/models/automations.ts
+++ b/src-ui/app/models/automations.ts
@@ -49,7 +49,7 @@ export type AutomationType =
   | 'RUN_AUTOMATIONS';
 
 export interface AutomationConfigs {
-  version: 19;
+  version: 20;
   // CORE SLEEP FUNCTIONALITY
   SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR: SleepModeEnableForSleepDetectorAutomationConfig;
   SLEEP_MODE_ENABLE_AT_TIME: SleepModeEnableAtTimeAutomationConfig;
@@ -509,7 +509,6 @@ export interface RunAutomationsConfig extends AutomationConfig {
   onSleepModeDisableCommands: string;
   onSleepPreparation: boolean;
   onSleepPreparationCommands: string;
-  runAutomationsCryptoKey?: string;
 }
 
 //
@@ -517,7 +516,7 @@ export interface RunAutomationsConfig extends AutomationConfig {
 //
 
 export const AUTOMATION_CONFIGS_DEFAULT: AutomationConfigs = {
-  version: 19,
+  version: 20,
   // CORE SLEEP FUNCTIONALITY
   SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR: {
     enabled: false,

--- a/src-ui/app/services/automation-config.service.ts
+++ b/src-ui/app/services/automation-config.service.ts
@@ -58,7 +58,7 @@ export class AutomationConfigService {
     let configs: AutomationConfigs | undefined = await SETTINGS_STORE.get<AutomationConfigs>(
       SETTINGS_KEY_AUTOMATION_CONFIGS
     );
-    configs = configs ? migrateAutomationConfigs(configs) : this._configs.value;
+    configs = configs ? await migrateAutomationConfigs(configs) : this._configs.value;
     this._configs.next(configs);
     await this.saveConfigs();
   }

--- a/src-ui/app/services/run-automations.service.ts
+++ b/src-ui/app/services/run-automations.service.ts
@@ -2,15 +2,8 @@ import { Injectable } from '@angular/core';
 import { AutomationConfigService } from './automation-config.service';
 import { AUTOMATION_CONFIGS_DEFAULT, RunAutomationsConfig } from '../models/automations';
 import { debounceTime, distinctUntilChanged, skip, take } from 'rxjs';
-import {
-  decryptStorageData,
-  deserializeStorageCryptoKey,
-  encryptStorageData,
-  generateStorageCryptoKey,
-  serializeStorageCryptoKey,
-} from '../utils/crypto';
-import { firstValueFrom, ReplaySubject } from 'rxjs';
-import { debug, info, warn } from '@tauri-apps/plugin-log';
+import { firstValueFrom } from 'rxjs';
+import { debug, warn } from '@tauri-apps/plugin-log';
 import { invoke } from '@tauri-apps/api/core';
 import { SleepService } from './sleep.service';
 import { SleepPreparationService } from './sleep-preparation.service';
@@ -23,7 +16,6 @@ export class RunAutomationsService {
   private config: RunAutomationsConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.RUN_AUTOMATIONS
   );
-  private cryptoKey: ReplaySubject<CryptoKey> = new ReplaySubject<CryptoKey>(1);
 
   constructor(
     private automationsConfigService: AutomationConfigService,
@@ -36,8 +28,6 @@ export class RunAutomationsService {
     this.config = (
       await firstValueFrom(this.automationsConfigService.configs.pipe(take(1)))
     ).RUN_AUTOMATIONS;
-    const key = await this.getCryptoKey();
-    this.cryptoKey.next(key);
     this.automationsConfigService.configs.subscribe((configs) => {
       this.config = configs.RUN_AUTOMATIONS;
     });
@@ -52,22 +42,15 @@ export class RunAutomationsService {
     automation: 'onSleepModeEnable' | 'onSleepModeDisable' | 'onSleepPreparation',
     commands: string
   ) {
-    const key = await firstValueFrom(this.cryptoKey);
-    const encryptedCommands = await encryptStorageData(commands, key);
     this.automationsConfigService.updateAutomationConfig<RunAutomationsConfig>('RUN_AUTOMATIONS', {
-      [automation + 'Commands']: encryptedCommands,
+      [automation + 'Commands']: commands,
     });
   }
 
   public async getCommands(
     automation: 'onSleepModeEnable' | 'onSleepModeDisable' | 'onSleepPreparation'
   ): Promise<string> {
-    const key = await firstValueFrom(this.cryptoKey);
-    const encryptedCommands = this.config[
-      `${automation}Commands` as keyof RunAutomationsConfig
-    ] as string;
-    if (!encryptedCommands) return '';
-    return await decryptStorageData(encryptedCommands, key);
+    return (this.config[`${automation}Commands` as keyof RunAutomationsConfig] as string) ?? '';
   }
 
   public async testCommands(commands: string): Promise<void> {
@@ -125,24 +108,6 @@ export class RunAutomationsService {
           warn(`[RunAutomationsService] Failed to execute onSleepPreparation commands: ${error}`);
         }
       }
-    }
-  }
-
-  private async getCryptoKey(): Promise<CryptoKey> {
-    if (this.config.runAutomationsCryptoKey) {
-      info('[RunAutomationsService] Using existing crypto key');
-      return await deserializeStorageCryptoKey(this.config.runAutomationsCryptoKey);
-    } else {
-      info('[RunAutomationsService] Generating new crypto key');
-      const key = await generateStorageCryptoKey();
-      const wrappedKey = await serializeStorageCryptoKey(key);
-      await this.automationsConfigService.updateAutomationConfig<RunAutomationsConfig>(
-        'RUN_AUTOMATIONS',
-        {
-          runAutomationsCryptoKey: wrappedKey,
-        }
-      );
-      return key;
     }
   }
 }


### PR DESCRIPTION
Stacked on #238.

The commands were encrypted with AES-GCM under `STORAGE_MASTER_CRYPTO_KEY`, a master key checked into this repository, so the encryption protected nothing. Writing `settings.dat` already needs code execution as that Windows user, and such an attacker has the Startup folder and the Run key, which are easier and unprotected. The main process never runs elevated either, so there is nothing to gain by going through OyasumiVR.

The commands are user configuration rather than a secret, and plain text is easier to read and edit.

Version 20 decrypts the old blobs and drops `runAutomationsCryptoKey`. A command it cannot decrypt becomes empty, so a value nobody can verify is never handed to `cmd.exe`. That also closes a hole in the current code: when the key was missing it returned early and left ciphertext in a field that `getCommands` passes straight to `run_cmd_commands`.

`migrateAutomationConfigs` is async now, because decrypting is, and its caller awaits it.

Worth a reviewer's eye: a command that is already plain text at version 19 is also emptied. At that version a command must be ciphertext, and the old code produced an empty command when decryption failed, so this matches the old behavior rather than newly executing an unverified value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run Automations commands are now stored as editable plain text in the application settings.
  * Existing encrypted commands are migrated automatically when settings are loaded.

* **Bug Fixes**
  * Commands that cannot be recovered during migration are safely cleared, with the original configuration backed up.

* **Documentation**
  * Added a changelog entry describing the updated command storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->