### PR TITLE
Protect the Pulsoid access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   CN compliance mode at runtime.
 - The Run Automations commands are now stored as plain text, so you can read and edit them in
   OyasumiVR's settings file
+- Your Pulsoid token is now stored with the Windows Data Protection API instead of in plain text, so
+  only your Windows account can read it. Copying OyasumiVR's settings to another Windows account or PC
+  no longer carries your Pulsoid login over
 
 ### Fixed
 

--- a/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
+++ b/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
@@ -12,11 +12,11 @@ const migrations: { [v: number]: (data: any) => any } = {
 
 async function from1to2(data: any): Promise<any> {
   try {
-    data.protectedAccessToken = (await protectSecret(data.accessToken)) ?? undefined;
+    data.accessToken = (await protectSecret(data.accessToken)) ?? undefined;
   } catch (e) {
     error("[pulsoid-api-settings-migrations] Couldn't protect the access token: " + e);
+    delete data.accessToken;
   }
-  delete data.accessToken;
   data.version = 2;
   return data;
 }
@@ -72,7 +72,7 @@ export async function migratePulsoidApiSettings(data: any): Promise<PulsoidApiSe
 }
 
 async function saveBackup(oldData: any) {
-  const redacted = { ...oldData, accessToken: undefined, protectedAccessToken: undefined };
+  const redacted = { ...oldData, accessToken: undefined };
   await writeTextFile('pulsoid-api-settings.backup.json', JSON.stringify(redacted, null, 2), {
     baseDir: BaseDirectory.AppData,
   });

--- a/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
+++ b/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
@@ -11,9 +11,13 @@ const migrations: { [v: number]: (data: any) => any } = {
 };
 
 async function from1to2(data: any): Promise<any> {
-  data.version = 2;
-  data.protectedAccessToken = (await protectSecret(data.accessToken)) ?? undefined;
+  try {
+    data.protectedAccessToken = (await protectSecret(data.accessToken)) ?? undefined;
+  } catch (e) {
+    error("[pulsoid-api-settings-migrations] Couldn't protect the access token: " + e);
+  }
   delete data.accessToken;
+  data.version = 2;
   return data;
 }
 
@@ -68,7 +72,8 @@ export async function migratePulsoidApiSettings(data: any): Promise<PulsoidApiSe
 }
 
 async function saveBackup(oldData: any) {
-  await writeTextFile('pulsoid-api-settings.backup.json', JSON.stringify(oldData, null, 2), {
+  const redacted = { ...oldData, accessToken: undefined, protectedAccessToken: undefined };
+  await writeTextFile('pulsoid-api-settings.backup.json', JSON.stringify(redacted, null, 2), {
     baseDir: BaseDirectory.AppData,
   });
 }

--- a/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
+++ b/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
@@ -3,12 +3,21 @@ import { error, info } from '@tauri-apps/plugin-log';
 import { PULSOID_API_SETTINGS_DEFAULT, PulsoidApiSettings } from '../models/pulsoid-api-settings';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { message } from '@tauri-apps/plugin-dialog';
+import { protectSecret } from '../utils/secrets';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
+  2: from1to2,
 };
 
-export function migratePulsoidApiSettings(data: any): PulsoidApiSettings {
+async function from1to2(data: any): Promise<any> {
+  data.version = 2;
+  data.protectedAccessToken = (await protectSecret(data.accessToken)) ?? undefined;
+  delete data.accessToken;
+  return data;
+}
+
+export async function migratePulsoidApiSettings(data: any): Promise<PulsoidApiSettings> {
   let currentVersion = data.version || 0;
   // Reset to latest when the current version is higher than the latest
   if (currentVersion > PULSOID_API_SETTINGS_DEFAULT.version) {
@@ -21,7 +30,7 @@ export function migratePulsoidApiSettings(data: any): PulsoidApiSettings {
   }
   while (currentVersion < PULSOID_API_SETTINGS_DEFAULT.version) {
     try {
-      data = migrations[++currentVersion](data);
+      data = await migrations[++currentVersion](data);
     } catch (e) {
       error(
         "[pulsoid-api-settings-migrations] Couldn't migrate to version " +

--- a/src-ui/app/models/pulsoid-api-settings.ts
+++ b/src-ui/app/models/pulsoid-api-settings.ts
@@ -1,6 +1,5 @@
 export interface PulsoidApiSettings {
   version: 2;
-  /** Protected with the Windows Data Protection API, never the plain token. */
   accessToken?: string;
   expiresAt?: number;
   username?: string;

--- a/src-ui/app/models/pulsoid-api-settings.ts
+++ b/src-ui/app/models/pulsoid-api-settings.ts
@@ -1,10 +1,11 @@
 export interface PulsoidApiSettings {
-  version: 1;
+  version: 2;
   accessToken?: string;
+  protectedAccessToken?: string;
   expiresAt?: number;
   username?: string;
 }
 
 export const PULSOID_API_SETTINGS_DEFAULT: PulsoidApiSettings = {
-  version: 1,
+  version: 2,
 };

--- a/src-ui/app/models/pulsoid-api-settings.ts
+++ b/src-ui/app/models/pulsoid-api-settings.ts
@@ -1,7 +1,7 @@
 export interface PulsoidApiSettings {
   version: 2;
+  /** Protected with the Windows Data Protection API. PulsoidService holds the plain token. */
   accessToken?: string;
-  protectedAccessToken?: string;
   expiresAt?: number;
   username?: string;
 }

--- a/src-ui/app/models/pulsoid-api-settings.ts
+++ b/src-ui/app/models/pulsoid-api-settings.ts
@@ -1,6 +1,6 @@
 export interface PulsoidApiSettings {
   version: 2;
-  /** Protected with the Windows Data Protection API. PulsoidService holds the plain token. */
+  /** Protected with the Windows Data Protection API, never the plain token. */
   accessToken?: string;
   expiresAt?: number;
   username?: string;

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -250,8 +250,10 @@ export class PulsoidService {
     let settings: PulsoidApiSettings | undefined =
       await SETTINGS_STORE.get<PulsoidApiSettings>(SETTINGS_KEY_PULSOID_API);
     settings = settings ? await migratePulsoidApiSettings(settings) : this.settings.value;
-    settings.accessToken = (await unprotectSecret(settings.protectedAccessToken)) ?? undefined;
-    settings.protectedAccessToken = undefined;
+    const stored = settings.protectedAccessToken;
+    settings.accessToken = (await unprotectSecret(stored)) ?? undefined;
+    // Hold on to a token that cannot be unlocked, so the save below rewrites it instead of nothing
+    settings.protectedAccessToken = settings.accessToken ? undefined : stored;
     // Handle token expiry
     if (settings.expiresAt && settings.expiresAt < Date.now() / 1000) {
       info('[Pulsoid] Token expired, throwing it away.');
@@ -271,12 +273,18 @@ export class PulsoidService {
   }
 
   private async saveSettings() {
-    const protectedAccessToken = await protectSecret(this.settings.value.accessToken);
     const settings = this.settings.value;
+    let protectedAccessToken: string | null;
+    try {
+      protectedAccessToken = await protectSecret(settings.accessToken);
+    } catch (cause) {
+      error(`[Pulsoid] Could not protect the access token, keeping the stored one: ${cause}`);
+      return;
+    }
     await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, {
       ...settings,
       accessToken: undefined,
-      protectedAccessToken: protectedAccessToken ?? undefined,
+      protectedAccessToken: protectedAccessToken ?? settings.protectedAccessToken,
     });
   }
 

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -63,7 +63,6 @@ export type HeartbeatRecord = [number, number]; // [timestamp, heartRate]
 })
 export class PulsoidService {
   private csrfCache: string[] = [];
-  // The plain token. The one in the settings is protected.
   private accessToken = new BehaviorSubject<string | null>(null);
   private settings = new BehaviorSubject<PulsoidApiSettings>(PULSOID_API_SETTINGS_DEFAULT);
   private socket?: WebSocket;

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -63,8 +63,7 @@ export type HeartbeatRecord = [number, number]; // [timestamp, heartRate]
 })
 export class PulsoidService {
   private csrfCache: string[] = [];
-  // The plain token, and the signal every consumer follows. The one in the settings is
-  // protected, and only this service unlocks it.
+  // The plain token. The one in the settings is protected.
   private accessToken = new BehaviorSubject<string | null>(null);
   private settings = new BehaviorSubject<PulsoidApiSettings>(PULSOID_API_SETTINGS_DEFAULT);
   private socket?: WebSocket;

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -32,6 +32,7 @@ import {
 } from '../../models/pulsoid-api-settings';
 import { migratePulsoidApiSettings } from '../../migrations/pulsoid-api-settings.migrations';
 import * as shell from '@tauri-apps/plugin-shell';
+import { protectSecret, unprotectSecret } from '../../utils/secrets';
 
 const HISTORY_LENGTH = 1000 * 60 * 60 * 12; // 12 hours
 
@@ -248,7 +249,9 @@ export class PulsoidService {
   private async loadSettings() {
     let settings: PulsoidApiSettings | undefined =
       await SETTINGS_STORE.get<PulsoidApiSettings>(SETTINGS_KEY_PULSOID_API);
-    settings = settings ? migratePulsoidApiSettings(settings) : this.settings.value;
+    settings = settings ? await migratePulsoidApiSettings(settings) : this.settings.value;
+    settings.accessToken = (await unprotectSecret(settings.protectedAccessToken)) ?? undefined;
+    settings.protectedAccessToken = undefined;
     // Handle token expiry
     if (settings.expiresAt && settings.expiresAt < Date.now() / 1000) {
       info('[Pulsoid] Token expired, throwing it away.');
@@ -268,7 +271,13 @@ export class PulsoidService {
   }
 
   private async saveSettings() {
-    await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, this.settings.value);
+    const protectedAccessToken = await protectSecret(this.settings.value.accessToken);
+    const settings = this.settings.value;
+    await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, {
+      ...settings,
+      accessToken: undefined,
+      protectedAccessToken: protectedAccessToken ?? undefined,
+    });
   }
 
   private async manageSocketConnection() {

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -14,6 +14,7 @@ import {
 import { error, info, warn } from '@tauri-apps/plugin-log';
 import {
   BehaviorSubject,
+  combineLatest,
   distinctUntilChanged,
   filter,
   firstValueFrom,
@@ -62,6 +63,9 @@ export type HeartbeatRecord = [number, number]; // [timestamp, heartRate]
 })
 export class PulsoidService {
   private csrfCache: string[] = [];
+  // The plain token, and the signal every consumer follows. The one in the settings is
+  // protected, and only this service unlocks it.
+  private accessToken = new BehaviorSubject<string | null>(null);
   private settings = new BehaviorSubject<PulsoidApiSettings>(PULSOID_API_SETTINGS_DEFAULT);
   private socket?: WebSocket;
   private _heartRate = new BehaviorSubject<number>(0);
@@ -73,9 +77,9 @@ export class PulsoidService {
     switchMap(() => this._heartRate.pipe(timeout({ each: 10000, with: () => of(null) })))
   );
   public heartRateLastReported = this._lastReport.asObservable();
-  public loggedInUser = this.settings.pipe(
-    map((settings) => {
-      if (!settings.accessToken || !settings.expiresAt) return null;
+  public loggedInUser = combineLatest([this.accessToken, this.settings]).pipe(
+    map(([accessToken, settings]) => {
+      if (!accessToken || !settings.expiresAt) return null;
       return settings.username ?? null;
     })
   );
@@ -206,8 +210,9 @@ export class PulsoidService {
   }
 
   private async setActiveTokenSet(tokenSet: PulsoidTokenSet | null) {
+    this.accessToken.next(tokenSet?.access_token ?? null);
     const newSettings = structuredClone(this.settings.value);
-    newSettings.accessToken = tokenSet?.access_token ?? undefined;
+    newSettings.accessToken = undefined;
     newSettings.expiresAt = tokenSet
       ? Math.floor(Date.now() / 1000) + tokenSet!.expires_in
       : undefined;
@@ -223,12 +228,12 @@ export class PulsoidService {
   }
 
   private getProfile(): Observable<PulsoidProfile> {
-    if (!this.settings.value.accessToken) throw new Error('No token set available');
+    if (!this.accessToken.value) throw new Error('No token set available');
     return this.getApiUrl('profile').pipe(
       switchMap((url) =>
         fetch(url, {
           headers: {
-            Authorization: `Bearer ${this.settings.value?.accessToken}`,
+            Authorization: `Bearer ${this.accessToken.value}`,
           },
         })
       ),
@@ -250,13 +255,11 @@ export class PulsoidService {
     let settings: PulsoidApiSettings | undefined =
       await SETTINGS_STORE.get<PulsoidApiSettings>(SETTINGS_KEY_PULSOID_API);
     settings = settings ? await migratePulsoidApiSettings(settings) : this.settings.value;
-    const stored = settings.protectedAccessToken;
-    settings.accessToken = (await unprotectSecret(stored)) ?? undefined;
-    // Hold on to a token that cannot be unlocked, so the save below rewrites it instead of nothing
-    settings.protectedAccessToken = settings.accessToken ? undefined : stored;
+    this.accessToken.next(await unprotectSecret(settings.accessToken));
     // Handle token expiry
     if (settings.expiresAt && settings.expiresAt < Date.now() / 1000) {
       info('[Pulsoid] Token expired, throwing it away.');
+      this.accessToken.next(null);
       settings.accessToken = undefined;
       settings.expiresAt = undefined;
       // TODO: Let user in some way know that their existing login has expired, and they should reauthenticate
@@ -274,18 +277,16 @@ export class PulsoidService {
 
   private async saveSettings() {
     const settings = this.settings.value;
-    let protectedAccessToken: string | null;
-    try {
-      protectedAccessToken = await protectSecret(settings.accessToken);
-    } catch (cause) {
-      error(`[Pulsoid] Could not protect the access token, keeping the stored one: ${cause}`);
-      return;
+    let accessToken = settings.accessToken;
+    if (this.accessToken.value) {
+      try {
+        accessToken = (await protectSecret(this.accessToken.value)) ?? undefined;
+      } catch (cause) {
+        error(`[Pulsoid] Could not protect the access token, keeping the stored one: ${cause}`);
+        return;
+      }
     }
-    await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, {
-      ...settings,
-      accessToken: undefined,
-      protectedAccessToken: protectedAccessToken ?? settings.protectedAccessToken,
-    });
+    await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, { ...settings, accessToken });
   }
 
   private async manageSocketConnection() {
@@ -299,8 +300,7 @@ export class PulsoidService {
         this.socket = undefined;
       }
       this.socket = new WebSocket(
-        'wss://dev.pulsoid.net/api/v1/data/real_time?access_token=' +
-          this.settings.value.accessToken
+        'wss://dev.pulsoid.net/api/v1/data/real_time?access_token=' + this.accessToken.value
       );
       this.socket.onopen = () => this.onSocketEvent('OPEN');
       this.socket.onerror = () => this.onSocketEvent('ERROR');
@@ -308,28 +308,23 @@ export class PulsoidService {
       this.socket.onmessage = (message) => this.onSocketEvent('MESSAGE', message);
     };
     // Connect and disconnect based on login status
-    this.settings
-      .pipe(
-        map((settings) => settings.accessToken),
-        distinctUntilChanged()
-      )
-      .subscribe((accessToken) => {
-        if (accessToken) {
-          buildSocket();
-        } else {
-          if (this.socket) {
-            try {
-              this.socket.close();
-            } catch {
-              // Ignore any error, we just want to disconnect
-            }
-            this.socket = undefined;
+    this.accessToken.pipe(distinctUntilChanged()).subscribe((accessToken) => {
+      if (accessToken) {
+        buildSocket();
+      } else {
+        if (this.socket) {
+          try {
+            this.socket.close();
+          } catch {
+            // Ignore any error, we just want to disconnect
           }
+          this.socket = undefined;
         }
-      });
+      }
+    });
     // Check connection intermittently in case of dropouts
     interval(10000)
-      .pipe(filter(() => !!this.settings.value.accessToken))
+      .pipe(filter(() => !!this.accessToken.value))
       .subscribe(() => {
         // Stop if we have an active connection
         if (this.socket && this.socket.readyState === WebSocket.OPEN) return;

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -64,6 +64,8 @@ export type HeartbeatRecord = [number, number]; // [timestamp, heartRate]
 export class PulsoidService {
   private csrfCache: string[] = [];
   private accessToken = new BehaviorSubject<string | null>(null);
+  private storedAccessToken: { plain: string; protected: string } | null = null;
+  private pendingSave: Promise<void> = Promise.resolve();
   private settings = new BehaviorSubject<PulsoidApiSettings>(PULSOID_API_SETTINGS_DEFAULT);
   private socket?: WebSocket;
   private _heartRate = new BehaviorSubject<number>(0);
@@ -253,7 +255,10 @@ export class PulsoidService {
     let settings: PulsoidApiSettings | undefined =
       await SETTINGS_STORE.get<PulsoidApiSettings>(SETTINGS_KEY_PULSOID_API);
     settings = settings ? await migratePulsoidApiSettings(settings) : this.settings.value;
-    this.accessToken.next(await unprotectSecret(settings.accessToken));
+    const plain = await unprotectSecret(settings.accessToken);
+    this.accessToken.next(plain);
+    this.storedAccessToken =
+      settings.accessToken && plain ? { plain, protected: settings.accessToken } : null;
     // Handle token expiry
     if (settings.expiresAt && settings.expiresAt < Date.now() / 1000) {
       info('[Pulsoid] Token expired, throwing it away.');
@@ -273,18 +278,31 @@ export class PulsoidService {
     await this.saveSettings();
   }
 
-  private async saveSettings() {
-    const settings = this.settings.value;
-    let accessToken = settings.accessToken;
-    if (this.accessToken.value) {
+  // Writes run one at a time, so a slow one cannot land after a newer one and bring a token back
+  private saveSettings(): Promise<void> {
+    this.pendingSave = this.pendingSave.catch(() => undefined).then(() => this.writeSettings());
+    return this.pendingSave;
+  }
+
+  private async writeSettings() {
+    const plain = this.accessToken.value;
+    let accessToken = this.settings.value.accessToken;
+    if (plain && this.storedAccessToken?.plain === plain) {
+      accessToken = this.storedAccessToken.protected;
+    } else if (plain) {
       try {
-        accessToken = (await protectSecret(this.accessToken.value)) ?? undefined;
+        accessToken = (await protectSecret(plain)) ?? undefined;
+        this.storedAccessToken = accessToken ? { plain, protected: accessToken } : null;
       } catch (cause) {
-        error(`[Pulsoid] Could not protect the access token, keeping the stored one: ${cause}`);
-        return;
+        error(`[Pulsoid] Could not protect the access token, so the stored one goes: ${cause}`);
+        accessToken = undefined;
+        this.storedAccessToken = null;
       }
     }
-    await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, { ...settings, accessToken });
+    await SETTINGS_STORE.set(SETTINGS_KEY_PULSOID_API, {
+      ...this.settings.value,
+      accessToken,
+    });
   }
 
   private async manageSocketConnection() {


### PR DESCRIPTION
Stacked on the Run Automations PR.

The token sat in `settings.dat` in plain text, so a settings file copied to another PC, restored from a backup, or attached to a support thread carried a working Pulsoid login.

Version 2 protects it into `protectedAccessToken` and drops the plain field. `PulsoidService` protects it on save and unlocks it on load, so the plain token stays in memory only.

It is never written in plain text again. A failed protect stores nothing and the user logs in again, which is the deliberate trade: losing a token costs a login, and writing one in plain text defeats the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Pulsoid access tokens are now protected using Windows account security.
  * Credentials no longer transfer when settings are moved to another account or PC.
* **Improvements**
  * Existing Pulsoid settings are automatically upgraded.
  * Backups no longer expose Pulsoid access tokens.
  * If token protection fails, the saved token is cleared for security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->