### PR TITLE
Protect the MQTT password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Your Pulsoid token is now stored with the Windows Data Protection API instead of in plain text, so
   only your Windows account can read it. Copying OyasumiVR's settings to another Windows account or PC
   no longer carries your Pulsoid login over
+- Your MQTT password is now stored with the Windows Data Protection API instead of in plain text, so
+  only your Windows account can read it
 
 ### Fixed
 

--- a/src-ui/app/migrations/app-settings.migrations.ts
+++ b/src-ui/app/migrations/app-settings.migrations.ts
@@ -22,9 +22,13 @@ const migrations: { [v: number]: (data: any) => any } = {
 };
 
 async function from11to12(data: any): Promise<any> {
-  data.version = 12;
-  data.mqttProtectedPassword = await protectSecret(data.mqttPassword);
+  try {
+    data.mqttProtectedPassword = await protectSecret(data.mqttPassword);
+  } catch (e) {
+    error("[app-settings-migrations] Couldn't protect the MQTT password: " + e);
+  }
   data.mqttPassword = null;
+  data.version = 12;
   return data;
 }
 
@@ -75,7 +79,8 @@ export async function migrateAppSettings(data: any): Promise<AppSettings> {
 }
 
 async function saveBackup(oldData: any) {
-  await writeTextFile('app-settings.backup.json', JSON.stringify(oldData, null, 2), {
+  const redacted = { ...oldData, mqttPassword: undefined, mqttProtectedPassword: undefined };
+  await writeTextFile('app-settings.backup.json', JSON.stringify(redacted, null, 2), {
     baseDir: BaseDirectory.AppData,
   });
 }

--- a/src-ui/app/migrations/app-settings.migrations.ts
+++ b/src-ui/app/migrations/app-settings.migrations.ts
@@ -4,6 +4,7 @@ import { error, info } from '@tauri-apps/plugin-log';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { message } from '@tauri-apps/plugin-dialog';
 import { migrateLighthouseDeviceId } from './lighthouse-device-id';
+import { protectSecret } from '../utils/secrets';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
@@ -17,9 +18,17 @@ const migrations: { [v: number]: (data: any) => any } = {
   9: from8to9,
   10: from9to10,
   11: from10to11,
+  12: from11to12,
 };
 
-export function migrateAppSettings(data: any): AppSettings {
+async function from11to12(data: any): Promise<any> {
+  data.version = 12;
+  data.mqttProtectedPassword = await protectSecret(data.mqttPassword);
+  data.mqttPassword = null;
+  return data;
+}
+
+export async function migrateAppSettings(data: any): Promise<AppSettings> {
   let currentVersion = data.version || 0;
   // Reset to latest when the current version is higher than the latest
   if (currentVersion > APP_SETTINGS_DEFAULT.version) {
@@ -32,7 +41,7 @@ export function migrateAppSettings(data: any): AppSettings {
   }
   while (currentVersion < APP_SETTINGS_DEFAULT.version) {
     try {
-      data = migrations[++currentVersion](data);
+      data = await migrations[++currentVersion](data);
     } catch (e) {
       error(
         "[app-settings-migrations] Couldn't migrate to version " +

--- a/src-ui/app/models/settings.ts
+++ b/src-ui/app/models/settings.ts
@@ -4,7 +4,7 @@ import { OneTimeFlag } from './one-time-flags';
 import { EventLogType } from './event-log-entry';
 
 export interface AppSettings {
-  version: 11;
+  version: 12;
   // General Settings
   userLanguage: string;
   userLanguagePicked: boolean;
@@ -51,6 +51,7 @@ export interface AppSettings {
   mqttPort: number | null;
   mqttUsername: string | null;
   mqttPassword: string | null;
+  mqttProtectedPassword: string | null;
   mqttSecureSocket: boolean;
   // Brightness & CCT
   cctControlEnabled: boolean;
@@ -94,7 +95,7 @@ export const NotificationTypes = [
 export type NotificationType = (typeof NotificationTypes)[number];
 
 export const APP_SETTINGS_DEFAULT: AppSettings = {
-  version: 11,
+  version: 12,
   // General Settings
   userLanguage: 'en',
   userLanguagePicked: false,
@@ -140,6 +141,7 @@ export const APP_SETTINGS_DEFAULT: AppSettings = {
   mqttPort: null,
   mqttUsername: null,
   mqttPassword: null,
+  mqttProtectedPassword: null,
   mqttSecureSocket: false,
   // Brightness & CCT
   cctControlEnabled: true,

--- a/src-ui/app/services/app-settings.service.ts
+++ b/src-ui/app/services/app-settings.service.ts
@@ -3,18 +3,19 @@ import { APP_SETTINGS_DEFAULT, AppSettings } from '../models/settings';
 import {
   asyncScheduler,
   BehaviorSubject,
+  concatMap,
   distinctUntilChanged,
   firstValueFrom,
   map,
   Observable,
   skip,
-  switchMap,
   throttleTime,
 } from 'rxjs';
 import { SETTINGS_KEY_APP_SETTINGS, SETTINGS_STORE } from '../globals';
 import { isEqual, uniq } from 'lodash';
 import { migrateAppSettings } from '../migrations/app-settings.migrations';
 import { protectSecret, unprotectSecret } from '../utils/secrets';
+import { error } from '@tauri-apps/plugin-log';
 import { TranslocoService } from '@jsverse/transloco';
 import { OneTimeFlag } from '../models/one-time-flags';
 import { ModalService } from './modal.service';
@@ -52,7 +53,7 @@ export class AppSettingsService {
         skip(1),
         throttleTime(500, asyncScheduler, { leading: true, trailing: true }),
         distinctUntilChanged((a, b) => isEqual(a, b)),
-        switchMap(() => this.saveSettings())
+        concatMap(() => this.saveSettings())
       )
       .subscribe();
   }
@@ -72,20 +73,28 @@ export class AppSettingsService {
       loadedDefaults = true;
     }
     if (settings.userLanguage === 'DEBUG') settings.userLanguage = 'en';
-    settings.mqttPassword = await unprotectSecret(settings.mqttProtectedPassword);
-    settings.mqttProtectedPassword = null;
+    const stored = settings.mqttProtectedPassword;
+    settings.mqttPassword = await unprotectSecret(stored);
+    // Hold on to a password that cannot be unlocked, so the save below rewrites it instead of nothing
+    settings.mqttProtectedPassword = settings.mqttPassword ? null : stored;
     this._settings.next(settings);
     await this.saveSettings();
     this._loadedDefaults.next(loadedDefaults);
   }
 
   async saveSettings() {
-    const mqttProtectedPassword = await protectSecret(this._settings.value.mqttPassword);
     const settings = this._settings.value;
+    let mqttProtectedPassword: string | null;
+    try {
+      mqttProtectedPassword = await protectSecret(settings.mqttPassword);
+    } catch (cause) {
+      error(`[AppSettings] Could not protect the MQTT password, keeping the stored one: ${cause}`);
+      return;
+    }
     await SETTINGS_STORE.set(SETTINGS_KEY_APP_SETTINGS, {
       ...settings,
       mqttPassword: null,
-      mqttProtectedPassword,
+      mqttProtectedPassword: mqttProtectedPassword ?? settings.mqttProtectedPassword,
     });
   }
 

--- a/src-ui/app/services/app-settings.service.ts
+++ b/src-ui/app/services/app-settings.service.ts
@@ -14,6 +14,7 @@ import {
 import { SETTINGS_KEY_APP_SETTINGS, SETTINGS_STORE } from '../globals';
 import { isEqual, uniq } from 'lodash';
 import { migrateAppSettings } from '../migrations/app-settings.migrations';
+import { protectSecret, unprotectSecret } from '../utils/secrets';
 import { TranslocoService } from '@jsverse/transloco';
 import { OneTimeFlag } from '../models/one-time-flags';
 import { ModalService } from './modal.service';
@@ -62,7 +63,7 @@ export class AppSettingsService {
     let loadedDefaults = false;
     if (settings) {
       const oldSettings = structuredClone(settings);
-      settings = migrateAppSettings(settings);
+      settings = await migrateAppSettings(settings);
       if (oldSettings.userLanguage !== settings.userLanguage) {
         this.translateService.setActiveLang(settings.userLanguage);
       }
@@ -71,13 +72,21 @@ export class AppSettingsService {
       loadedDefaults = true;
     }
     if (settings.userLanguage === 'DEBUG') settings.userLanguage = 'en';
+    settings.mqttPassword = await unprotectSecret(settings.mqttProtectedPassword);
+    settings.mqttProtectedPassword = null;
     this._settings.next(settings);
     await this.saveSettings();
     this._loadedDefaults.next(loadedDefaults);
   }
 
   async saveSettings() {
-    await SETTINGS_STORE.set(SETTINGS_KEY_APP_SETTINGS, this._settings.value);
+    const mqttProtectedPassword = await protectSecret(this._settings.value.mqttPassword);
+    const settings = this._settings.value;
+    await SETTINGS_STORE.set(SETTINGS_KEY_APP_SETTINGS, {
+      ...settings,
+      mqttPassword: null,
+      mqttProtectedPassword,
+    });
   }
 
   public updateSettings(settings: Partial<AppSettings>) {


### PR DESCRIPTION
Stacked on #240.

Same story as the Pulsoid token: it sat in `settings.dat` in plain text. Version 12 protects it into `mqttProtectedPassword` and drops the plain field, and `AppSettingsService` protects it on save and unlocks it on load.

The plain password stays in the in-memory settings on purpose. DPAPI returns a different blob every time it protects the same value, so a blob in there would break the `isEqual` guards in `MqttService.init` and `AppSettingsService.init` and cause an endless reconnect and write loop. `mapAppSettingsToMqttConfig` and the MQTT config modal are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MQTT passwords are now securely protected using Windows Data Protection API and restricted to the associated Windows account.
  * Existing settings are upgraded automatically to support secure password storage.

* **Bug Fixes**
  * Plaintext MQTT passwords are no longer included in saved settings or backup files.
  * Password protection failures are logged, and settings are not saved when encryption cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->