### PR TITLE
Stop rewriting a settings file that has not changed

### DIFF
--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -42,6 +42,19 @@ use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Settings6;
 
 use crate::globals::APTABASE_HOST;
 
+fn serialize_store_sorted(
+    cache: &std::collections::HashMap<String, serde_json::Value>,
+) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let sorted: std::collections::BTreeMap<&String, &serde_json::Value> = cache.iter().collect();
+    Ok(serde_json::to_vec_pretty(&sorted)?)
+}
+
+fn configure_tauri_plugin_store() -> TauriPlugin<Wry> {
+    tauri_plugin_store::Builder::new()
+        .default_serialize_fn(serialize_store_sorted)
+        .build()
+}
+
 #[tokio::main]
 async fn main() {
     // Construct OyasumiVR Tauri application
@@ -56,12 +69,11 @@ async fn main() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_store::Builder::new().build())
+        .plugin(configure_tauri_plugin_store())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(configure_tauri_plugin_aptabase())
         .setup(|app| {
             #[cfg(windows)]

--- a/src-ui/app/services/app-settings.service.ts
+++ b/src-ui/app/services/app-settings.service.ts
@@ -33,6 +33,7 @@ export class AppSettingsService {
     APP_SETTINGS_DEFAULT
   );
   settings: Observable<AppSettings> = this._settings.asObservable();
+  private storedMqttPassword: { plain: string; protected: string } | null = null;
   public get settingsSync(): AppSettings {
     return this._settings.value;
   }
@@ -75,6 +76,8 @@ export class AppSettingsService {
     if (settings.userLanguage === 'DEBUG') settings.userLanguage = 'en';
     const stored = settings.mqttProtectedPassword;
     settings.mqttPassword = await unprotectSecret(stored);
+    this.storedMqttPassword =
+      stored && settings.mqttPassword ? { plain: settings.mqttPassword, protected: stored } : null;
     // Hold on to a password that cannot be unlocked, so the save below rewrites it instead of nothing
     settings.mqttProtectedPassword = settings.mqttPassword ? null : stored;
     this._settings.next(settings);
@@ -84,17 +87,27 @@ export class AppSettingsService {
 
   async saveSettings() {
     const settings = this._settings.value;
-    let mqttProtectedPassword: string | null;
-    try {
-      mqttProtectedPassword = await protectSecret(settings.mqttPassword);
-    } catch (cause) {
-      error(`[AppSettings] Could not protect the MQTT password, keeping the stored one: ${cause}`);
-      return;
+    let mqttProtectedPassword = settings.mqttProtectedPassword;
+    if (settings.mqttPassword && this.storedMqttPassword?.plain === settings.mqttPassword) {
+      mqttProtectedPassword = this.storedMqttPassword.protected;
+    } else if (settings.mqttPassword) {
+      try {
+        mqttProtectedPassword = await protectSecret(settings.mqttPassword);
+        this.storedMqttPassword = mqttProtectedPassword
+          ? { plain: settings.mqttPassword, protected: mqttProtectedPassword }
+          : null;
+      } catch (cause) {
+        error(
+          `[AppSettings] Could not protect the MQTT password, so the stored one goes: ${cause}`
+        );
+        mqttProtectedPassword = null;
+        this.storedMqttPassword = null;
+      }
     }
     await SETTINGS_STORE.set(SETTINGS_KEY_APP_SETTINGS, {
       ...settings,
       mqttPassword: null,
-      mqttProtectedPassword: mqttProtectedPassword ?? settings.mqttProtectedPassword,
+      mqttProtectedPassword,
     });
   }
 

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -70,6 +70,10 @@ export class VRChatService {
   private readonly socket: VRChatSocket;
   private settingsUpdate: Promise<void> = Promise.resolve();
   private lockedActiveProfileId: string | null = null;
+  private readonly protectedSecretsByProfileId = new Map<
+    string,
+    { plain: string; protected: string }
+  >();
 
   private readonly settings = this.settingsSubject.asObservable();
   public readonly profiles = this.settings.pipe(
@@ -306,6 +310,10 @@ export class VRChatService {
           const json = await unprotectSecret(profile.protectedSecret);
           if (json == null) throw new Error('the secret could not be unlocked');
           const secret = parseVRChatAccountSecret(JSON.parse(json));
+          this.protectedSecretsByProfileId.set(profile.id, {
+            plain: json,
+            protected: profile.protectedSecret,
+          });
           return normalizeVRChatAccountProfile({
             ...profile,
             ...secret,
@@ -353,6 +361,15 @@ export class VRChatService {
     await this.mutateSettings((settings) => patchVRChatProfile(settings, profileId, patch));
   }
 
+  private async protectProfileSecret(profile: VRChatAccountProfile): Promise<string | null> {
+    const plain = JSON.stringify(getVRChatAccountSecret(profile));
+    const cached = this.protectedSecretsByProfileId.get(profile.id);
+    if (cached?.plain === plain) return cached.protected;
+    const stored = await protectSecret(plain);
+    if (stored) this.protectedSecretsByProfileId.set(profile.id, { plain, protected: stored });
+    return stored;
+  }
+
   private async saveSettings(settings: VRChatApiSettings): Promise<void> {
     const profiles = await Promise.all(
       settings.profiles.map(async (profile) => {
@@ -366,7 +383,7 @@ export class VRChatService {
           draft: profile.draft,
           protectedSecret: profile.secretLocked
             ? profile.protectedSecret
-            : await protectSecret(JSON.stringify(getVRChatAccountSecret(profile))),
+            : await this.protectProfileSecret(profile),
         };
       })
     );


### PR DESCRIPTION
`settings.dat` changed on every launch, for two reasons. That made a content-diffing backup useless, gave `StoreProtector` a new snapshot every time, and buried real changes in noise.

### The key order

`tauri-plugin-store` keeps its cache in a `HashMap<String, JsonValue>` and hands that map straight to `to_vec_pretty`. A Rust `HashMap` iterates in a different order in every process, so the plugin wrote the top-level keys in a different order on every launch. The `Builder` accepts a serializer, so ours collects into a `BTreeMap` first. The format stays the same and the keys come out sorted.

This also drops the second registration of the store plugin. `develop` registers it twice, at `main.rs:59` with `Builder::new()` and at `:64` with `Builder::default()`. Leaving both would give one registration a serializer and the other none.

### The secrets

`AppSettingsService` and `VRChatService` protected their secret again on every save, and `CryptProtectData` returns different bytes every time for the same value. Both now remember the plain value behind what they stored, seeded on load from what was already on disk, so an unchanged secret keeps the bytes it has. VRChat keeps one entry per profile, because `saveSettings` writes every profile.

`PulsoidService` already does this, from #240.

One behaviour change comes with it. When protecting a changed MQTT password fails, the stored password is now cleared rather than left alone, which matches what #240 does for the Pulsoid token. With the skip in place, a failure can only involve a password that differs from the stored one, so keeping that one would leave a password on disk that no longer matches the settings.

### Testing

Three launches against a seeded store, killing the app in between. The first migrates. The second and third are identical byte for byte, with the same sorted key order:

```
launch 1 (migrating): sha=a6c46ce3ab0d5e11 keys=APP_SETTINGS,AUTOMATION_CONFIGS,DEVICE_MANAGER,PULSOID_API,TELEMETRY_SETTINGS,VRCHAT_API
launch 2:             sha=0ce193fdcd7fb087 keys=APP_SETTINGS,AUTOMATION_CONFIGS,DEVICE_MANAGER,PULSOID_API,TELEMETRY_SETTINGS,VRCHAT_API
launch 3:             sha=0ce193fdcd7fb087 keys=APP_SETTINGS,AUTOMATION_CONFIGS,DEVICE_MANAGER,PULSOID_API,TELEMETRY_SETTINGS,VRCHAT_API
```

`tsc`, eslint and `cargo build` are clean.

### What a reviewer should check

- Whether sorted output suits `cache.dat` and `event_log.dat` as well. `default_serialize_fn` applies to every store the plugin creates.
- The cache check in both services. It compares the plain value, so a changed secret gets protected again and a cleared one writes null.
- That dropping the duplicate plugin registration has no side effect. Registering the same plugin name twice looks like an oversight, but you would know.
