### PR TITLE
Redesign the About view so it stops outgrowing the window

### DIFF
--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.html
@@ -1,153 +1,119 @@
 <div class="about-container">
   <div class="logo-row">
-    <div class="logo-side"></div>
     <div class="logo">
       <div class="logo-container">
         <div class="main">Oyasumi<b>VR</b></div>
         <div class="tag-line" transloco="shared.logo.tagline"></div>
       </div>
     </div>
-    <div class="logo-side"></div>
   </div>
 
-  <div class="row" style="margin-top: 1em; margin-bottom: 1em">
-    <div class="left">
-      <div class="author">
-        <div class="author-avatar">
-          <img
-            draggable="false"
-            appImgFallback="assets/img/raphiiko.png"
-            [imgSmoothLoader]="'https://avatars.githubusercontent.com/u/111654848'"
-          />
-        </div>
-        <div class="author-info">
-          <div class="role" transloco="about.author.role"></div>
-          <div class="name">Raphii</div>
-          <div class="twitter">
-            <i class="fa-brands fa-twitter"></i>
-            <a href="https://twitter.com/Raphiiko" target="_blank">&#64;Raphiiko</a>
-          </div>
-          <div class="discord">
-            <i class="fa-brands fa-discord"></i>
-            <span>&#64;raphiiko</span>
-          </div>
-          <div class="github">
-            <i class="fa-brands fa-github"></i>
-            <a href="https://github.com/Raphiiko" target="_blank">Raphiiko</a>
-          </div>
-        </div>
+  <div class="body">
+    <div class="identity">
+      <div class="identity-spacer-top"></div>
+      <div class="identity-avatar">
+        <img
+          draggable="false"
+          appImgFallback="assets/img/raphiiko.png"
+          [imgSmoothLoader]="'https://avatars.githubusercontent.com/u/111654848'"
+        />
       </div>
-    </div>
-    <div class="right">
-      <div class="project-info-title" transloco="about.contributions"></div>
-      <div class="contributor-list">
-        <div class="contributor-list-entry">
-          <span
-            ><a href="https://github.com/neuroblack" target="_blank">neuroblack</a> |
-            <span transloco="about.contributionType.programming"></span
-          ></span>
-        </div>
-        <div class="contributor-list-entry">
-          <span
-            ><a href="https://github.com/TheMrGong" target="_blank">góngo</a> |
-            <span transloco="about.contributionType.programming"></span
-          ></span>
-        </div>
-        <div class="contributor-list-entry">
-          <span
-            ><a href="https://fanyat.su" target="_blank">Fanyatsu</a> |
-            <span transloco="about.contributionType.programming"></span
-          ></span>
-        </div>
-        <div class="contributor-list-entry">
-          <span
-            ><a href="https://github.com/BenjaminZehowlt" target="_blank">BenjaminZehowlt</a> |
-            <span transloco="about.contributionType.programming"></span
-          ></span>
-        </div>
-        <div class="contributor-list-entry">
-          <span
-            ><a href="https://github.com/sofoxe1" target="_blank">sofoxe1</a> |
-            <span transloco="about.contributionType.programming"></span
-          ></span>
-        </div>
-        <div class="contributor-list-entry">
-          <span
-            ><a href="https://github.com/coolGi69" target="_blank">coolGi</a> |
-            <span transloco="about.contributionType.programming"></span
-          ></span>
-        </div>
-        <div class="contributor-list-entry">
-          <span>spaecd | <span transloco="about.contributionType.soundFx"></span></span>
-        </div>
+      <div class="identity-name">
+        <div class="role" transloco="about.author.role"></div>
+        <div class="name">Raphii</div>
       </div>
-      <div class="project-info-title" transloco="about.projectLinks"></div>
+      <div class="identity-socials">
+        <a href="https://raphii.co" target="_blank">
+          <i class="fa-solid fa-globe"></i>
+          <span>raphii.co</span>
+        </a>
+        <a href="https://twitter.com/Raphiiko" target="_blank">
+          <i class="fa-brands fa-twitter"></i>
+          <span>&#64;Raphiiko</span>
+        </a>
+        <span>
+          <i class="fa-brands fa-discord"></i>
+          <span class="selectable">&#64;raphiiko</span>
+        </span>
+        <a href="https://github.com/Raphiiko" target="_blank">
+          <i class="fa-brands fa-github"></i>
+          <span>Raphiiko</span>
+        </a>
+      </div>
       <div class="project-links">
         <a
           href="https://github.com/Raphiiko/OyasumiVR"
           target="_blank"
           transloco="about.sourceLink"
         ></a>
-        <br />
         <a href="https://discord.gg/7MqdPJhYxC" target="_blank" transloco="about.discordInvite"></a>
       </div>
+      <div class="identity-spacer-bottom"></div>
+      <div class="build-info">
+        <div>Oyasumi<b>VR</b></div>
+        <div>v{{ version }}-{{ FLAVOUR }} ({{ BUILD_ID }})</div>
+      </div>
     </div>
-  </div>
 
-  @if (supporterCache.get()?.length) {
-    <div class="row" @vshrink>
-      <div class="supporters-row">
-        <div class="supporters-list" #supportersList>
-          @for (tier of supporterCache.get() ?? []; track tier) {
-            <div class="supporters-tier">
-              <div class="supporters-tier-label">
-                {{ tier.name }}
+    <div class="rail" #rail (scroll)="updateRailFade()">
+      <div class="rail-content" #railContent>
+        @if (supporterCache.get()?.length) {
+          <div class="supporters" @vshrink>
+            <div class="section-title" transloco="about.supporters"></div>
+            @for (tier of supporterCache.get() ?? []; track tier; let rank = $index) {
+              <div class="supporter-tier" [ngClass]="'tier-rank-' + (rank < 2 ? rank : 2)">
+                <div class="supporter-tier-label">{{ tier.name }}</div>
+                <div class="supporter-tier-members">
+                  @for (supporter of tier.supporters; track $index) {
+                    <span>{{ supporter }}</span>
+                  }
+                </div>
               </div>
-              <div class="supporters-tier-members">
-                @for (supporter of tier.supporters; track supporter) {
-                  <div class="supporters-tier-member">
-                    {{ supporter }}
-                  </div>
+            }
+          </div>
+        }
+
+        <div class="credits">
+          <div class="section-title" transloco="about.contributions"></div>
+          @for (group of contributionGroups; track group.type) {
+            <div class="credit-row">
+              <span class="credit-subject">{{
+                'about.contributionType.' + group.type | transloco
+              }}</span>
+              <span class="credit-leader"></span>
+              @for (contributor of group.contributors; track contributor) {
+                @if (contributor.url) {
+                  <a class="credit-name" [href]="contributor.url" target="_blank">{{
+                    contributor.name
+                  }}</a>
+                } @else {
+                  <span class="credit-name">{{ contributor.name }}</span>
                 }
-              </div>
+              }
+            </div>
+          }
+
+          <div class="section-title" transloco="about.translations"></div>
+          @for (language of translationLanguages; track language) {
+            <div class="credit-row">
+              <span class="credit-subject">
+                <span [ngClass]="['fi', 'fi-' + (language.flagCode ?? language.langCode)]"></span>
+                <span>{{ language.langNameNative }}</span>
+              </span>
+              <span class="credit-leader"></span>
+              @for (contributor of language.contributors; track contributor) {
+                @if (contributor.url) {
+                  <a class="credit-name" [href]="contributor.url" target="_blank">{{
+                    contributor.name
+                  }}</a>
+                } @else {
+                  <span class="credit-name">{{ contributor.name }}</span>
+                }
+              }
             </div>
           }
         </div>
-        <div class="supporters-label" transloco="about.supporters"></div>
       </div>
     </div>
-  }
-
-  <div class="row">
-    <div class="left"></div>
-    <div class="right">
-      <div class="project-info-title" transloco="about.translations"></div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="translation-author-list">
-      @for (contributor of translationContributors; track contributor) {
-        <div class="translation-author-list-entry">
-          <span [ngClass]="['fi', 'fi-' + (contributor.flagCode ?? contributor.langCode)]"></span>
-          <span>{{ contributor.langNameNative }}</span>
-          <span>&nbsp;|&nbsp;</span>
-          @if (contributor.url) {
-            <a [href]="contributor.url" target="_blank">{{ contributor.name }}</a>
-          }
-          @if (!contributor.url) {
-            <span>{{ contributor.name }}</span>
-          }
-        </div>
-      }
-    </div>
-  </div>
-
-  <div class="row" style="margin-top: 1em">
-    <div class="left">
-      <div class="build-info">
-        <div>Oyasumi<b>VR</b> v{{ version }}-{{ FLAVOUR }} ({{ BUILD_ID }})</div>
-      </div>
-    </div>
-    <div class="right"></div>
   </div>
 </div>

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.html
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.html
@@ -13,6 +13,7 @@
       <div class="identity-spacer-top"></div>
       <div class="identity-avatar">
         <img
+          alt=""
           draggable="false"
           appImgFallback="assets/img/raphiiko.png"
           [imgSmoothLoader]="'https://avatars.githubusercontent.com/u/111654848'"

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.scss
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.scss
@@ -6,65 +6,18 @@
   align-items: center;
   height: 100%;
   width: 100%;
-  //noinspection CssInvalidPropertyValue
-  overflow: auto;
+  overflow: hidden;
   position: relative;
-
-  &::-webkit-scrollbar {
-    width: 4px;
-    height: 8px;
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--color-surface-4);
-    border-radius: 2px;
-  }
-
-  &::-webkit-scrollbar-track-piece {
-    display: none;
-  }
 }
 
 .about-container {
   width: 100%;
-  max-width: 50em;
+  max-width: 80em;
+  max-height: 100%;
+  margin: 0 auto;
+  padding: 0 0.5em;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: stretch;
-  margin: 0 auto;
-}
-
-.row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-
-  & > div {
-    flex: 1;
-  }
-
-  .left,
-  .right {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-
-  .left {
-    align-items: flex-start;
-    text-align: left;
-  }
-
-  .right {
-    align-items: flex-end;
-    text-align: right;
-  }
 }
 
 .logo-row {
@@ -72,17 +25,7 @@
   flex-direction: row;
   align-items: stretch;
   border-bottom: 1px solid var(--color-surface-4);
-
-  .logo-side {
-    width: 8em;
-    flex-shrink: 0;
-    display: flex;
-    justify-content: flex-end;
-    align-items: flex-end;
-    flex-direction: column;
-    color: var(--color-text-4);
-    transform: translateY(-1.75em);
-  }
+  flex-shrink: 0;
 
   .logo {
     flex: 1;
@@ -106,6 +49,7 @@
         }
       }
 
+      // offsets are in this element's own em, so changing either size breaks the fit
       .tag-line {
         color: var(--color-text-4);
         font-size: 1.35em;
@@ -116,195 +60,225 @@
   }
 }
 
-.author {
+.body {
+  // basis auto, or this collapses when the container sizes to its content
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 16em 1fr;
+  gap: 2em;
+}
+
+.identity {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  flex: 1;
+  text-align: center;
+  padding: 1.2em 0 0.2em 0;
+
+  // flexible gaps, so the column fills whatever height the rail sets
+  &-spacer-top {
+    flex: 2;
+  }
+
+  &-spacer-bottom {
+    flex: 3;
+  }
 
   &-avatar {
     @include shadows.shadow(4, true);
-    overflow: hidden;
-    border-radius: 999999999px;
+    margin-bottom: 0.9em;
     width: 10em;
     height: 10em;
+    border-radius: 50%;
+    overflow: hidden;
     border: 0.25em solid var(--color-surface-6);
-    margin-right: 2em;
+    flex-shrink: 0;
 
     img {
       width: 100%;
       height: 100%;
+      display: block;
     }
   }
 
-  &-info {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-
-    .name {
-      font-size: 2em;
-      padding-bottom: 0.25em;
-    }
+  &-name {
+    margin-bottom: 1.15em;
 
     .role {
       color: var(--color-text-3);
+      font-size: 0.8em;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      line-height: 1.4;
     }
 
-    .discord span {
-      user-select: text;
+    .name {
+      font-size: 1.85em;
+      line-height: 1.15;
     }
+  }
 
-    .twitter,
-    .discord,
-    .github {
+  &-socials {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4em;
+
+    > * {
       display: flex;
       flex-direction: row;
       align-items: center;
-      justify-content: flex-start;
+      gap: 0.6em;
+    }
 
-      i {
-        width: 1.75em;
-        text-align: center;
-        font-size: 1.25em;
-        padding-right: 0.5em;
-      }
+    a {
+      text-decoration: none;
 
-      &:not(:last-child) {
-        padding-bottom: 0.5em;
+      span {
+        text-decoration: underline;
       }
     }
-  }
-}
 
-.project-info {
-  text-align: right;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-
-  &-title {
-    font-size: 1.5em;
-    padding-bottom: 0.25em;
-
-    &:not(:first-child) {
-      margin-top: 1em;
+    i {
+      width: 1.4em;
+      text-align: center;
+      font-size: 1.1em;
+      color: var(--color-text-4);
     }
-  }
-}
 
-.contributor-list {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  padding-bottom: 0.5em;
-
-  &-entry {
-    .fi {
-      margin-left: 0.5em;
-    }
-  }
-}
-
-.translation-author-list {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-gap: 0 1em;
-  padding-bottom: 0.5em;
-  font-size: 0.8em;
-
-  &-entry {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-    .fi {
-      margin: 0 0.5em 0 0;
-    }
-    &:nth-child(4n) {
-      flex-direction: row-reverse;
-      .fi {
-        margin: 0 0 0 0.5em;
-      }
+    .selectable {
+      user-select: text;
     }
   }
 }
 
 .project-links {
-}
-
-.build-info {
-  color: var(--color-text-3);
-  flex-shrink: 0;
-  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3em;
   width: 100%;
+  margin-top: 1.4em;
 }
 
-.supporters-row {
+// the only scrolling region in the view
+.rail {
+  min-height: 0;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.9em;
+  --fade-top: 1.5em;
+  --fade-bottom: 1.5em;
+  mask: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--fade-top),
+    #000 calc(100% - var(--fade-bottom)),
+    transparent 100%
+  );
+
+  &.at-start {
+    --fade-top: 0px;
+  }
+
+  &.at-end {
+    --fade-bottom: 0px;
+  }
+}
+
+.section-title {
+  font-size: 0.85em;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-4);
+  padding-bottom: 0.6em;
+}
+
+.supporters {
+  padding-top: 1em;
+}
+
+.supporter-tier {
+  &:not(:last-child) {
+    padding-bottom: 0.4em;
+  }
+
+  &-label {
+    color: var(--color-text-4);
+    font-size: 0.85em;
+  }
+
+  &-members {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0 0.9em;
+
+    span {
+      line-height: 1.4;
+    }
+  }
+}
+
+// tiers arrive highest first, and each step down reads slightly smaller and dimmer
+.tier-rank-0 .supporter-tier-members span {
+  font-size: 1.35em;
+  color: var(--color-text-1);
+}
+
+.tier-rank-1 .supporter-tier-members span {
+  font-size: 1.25em;
+  color: var(--color-text-2);
+}
+
+.tier-rank-2 .supporter-tier-members span {
+  font-size: 1.15em;
+  color: var(--color-text-3);
+}
+
+.credits {
+  padding-top: 1.25em;
+
+  .section-title:not(:first-child) {
+    padding-top: 1.25em;
+  }
+}
+
+// names stay direct children, or the leader cannot absorb the first line's slack
+.credit-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: flex-end;
+  column-gap: 0.85em;
+  row-gap: 0;
+  padding: 0.18em 0;
+}
+
+.credit-subject {
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 1em 0;
-  overflow: hidden;
-  margin-left: -1em;
+  gap: 0.5em;
+  white-space: nowrap;
+  color: var(--color-text-2);
+}
 
-  * {
-    white-space: nowrap;
-  }
+.credit-leader {
+  flex: 1;
+  min-width: 2.5em;
+  border-bottom: 1px dotted color-mix(in srgb, var(--color-text-4) 35%, transparent);
+  transform: translateY(-0.25em);
+}
 
-  .supporters-label {
-    flex-shrink: 0;
-    font-size: 1.5em;
-    margin-left: 1em;
-  }
+.credit-name {
+  white-space: nowrap;
+}
 
-  .supporters-list {
-    flex: 1;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    overflow-x: hidden;
-    padding: 0 1em;
-    transition: opacity 0.5s ease;
-
-    mask: linear-gradient(
-        to right,
-        rgba(0, 0, 0, 0) 0,
-        rgba(0, 0, 0, 1) 1em,
-        rgba(0, 0, 0, 1) calc(100% - 1em),
-        rgba(0, 0, 0, 0) 100%
-      )
-      100% 50% / 100% 100% repeat-x;
-
-    .supporters-tier {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      justify-content: center;
-
-      &:not(:last-child) {
-        margin-right: 2em;
-      }
-
-      &-label {
-        opacity: 0.6;
-      }
-
-      &-members {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-      }
-
-      &-member {
-        font-size: 1.25em;
-
-        &:not(:last-child) {
-          margin-right: 1em;
-        }
-      }
-    }
-  }
+.build-info {
+  color: var(--color-text-4);
+  font-size: 0.9em;
+  line-height: 1.35;
 }

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
@@ -1,19 +1,16 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   ElementRef,
   OnDestroy,
   OnInit,
   ViewChild,
-  ChangeDetectionStrategy,
 } from '@angular/core';
 import { getVersion } from '../../../../utils/app-utils';
 import { BackgroundService } from '../../../../services/background.service';
 import { BUILD_ID, FLAVOUR } from '../../../../../build';
 import { CachedValue } from '../../../../utils/cached-value';
-import { filter, interval } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { vshrink } from '../../../../utils/animations';
 import { shuffle } from 'lodash';
 import { warn } from '@tauri-apps/plugin-log';
@@ -25,6 +22,12 @@ interface SupporterTier {
   supporters: string[];
 }
 
+interface Contributor {
+  name: string;
+  url?: string;
+  type: 'programming' | 'soundFx';
+}
+
 interface TranslationContributor {
   name: string;
   url?: string;
@@ -32,6 +35,18 @@ interface TranslationContributor {
   flagCode?: string;
   langNameNative: string;
   langNameEnglish: string;
+}
+
+interface ContributionGroup {
+  type: Contributor['type'];
+  contributors: Contributor[];
+}
+
+interface TranslationLanguage {
+  langCode: string;
+  flagCode?: string;
+  langNameNative: string;
+  contributors: TranslationContributor[];
 }
 
 @Component({
@@ -44,12 +59,29 @@ interface TranslationContributor {
 })
 export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
   protected readonly FLAVOUR = FLAVOUR;
-  protected translationContributors: TranslationContributor[] = [];
-  private supportersScrolling = false;
+  protected readonly BUILD_ID = BUILD_ID;
+
+  protected readonly contributors: Contributor[] = [
+    { name: 'neuroblack', url: 'https://github.com/neuroblack', type: 'programming' },
+    { name: 'góngo', url: 'https://github.com/TheMrGong', type: 'programming' },
+    { name: 'Fanyatsu', url: 'https://fanyat.su', type: 'programming' },
+    { name: 'BenjaminZehowlt', url: 'https://github.com/BenjaminZehowlt', type: 'programming' },
+    { name: 'sofoxe1', url: 'https://github.com/sofoxe1', type: 'programming' },
+    { name: 'coolGi', url: 'https://github.com/coolGi69', type: 'programming' },
+    { name: 'spaecd', type: 'soundFx' },
+  ];
+
+  protected readonly contributionGroups: ContributionGroup[] = groupByType(this.contributors);
+
+  protected readonly translationLanguages: TranslationLanguage[] = groupByLanguage(
+    translationContributorData
+  );
 
   version?: string;
 
-  @ViewChild('supportersList') supportersList?: ElementRef;
+  @ViewChild('rail') private rail?: ElementRef<HTMLElement>;
+  @ViewChild('railContent') private railContent?: ElementRef<HTMLElement>;
+  private railObserver?: ResizeObserver;
 
   protected supporterCache: CachedValue<SupporterTier[]> = new CachedValue<SupporterTier[]>(
     undefined,
@@ -57,37 +89,7 @@ export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
     'OYASUMIVR_SUPPORTERS'
   );
 
-  constructor(
-    private background: BackgroundService,
-    private destroyRef: DestroyRef
-  ) {
-    this.buildTranslationContributors(translationContributorData, 4);
-  }
-
-  private buildTranslationContributors(
-    translationContributors: TranslationContributor[],
-    columns: 4
-  ) {
-    const matrix: TranslationContributor[][] = [];
-    const rows = Math.ceil(translationContributors.length / columns);
-    let i = 0;
-    for (let column = 0; column < columns; column++) {
-      for (let row = 0; row < rows; row++) {
-        if (i < translationContributors.length) {
-          if (!matrix[column]) matrix[column] = [];
-          matrix[column][row] = translationContributors[i];
-          i++;
-        }
-      }
-    }
-    for (let row = 0; row < rows; row++) {
-      for (let column = 0; column < columns; column++) {
-        if (matrix[column][row]) {
-          this.translationContributors.push(matrix[column][row]);
-        }
-      }
-    }
-  }
+  constructor(private background: BackgroundService) {}
 
   async ngOnInit() {
     this.version = await getVersion();
@@ -119,45 +121,58 @@ export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  async ngAfterViewInit() {
-    interval(1000)
-      .pipe(
-        filter(() => !this.supportersScrolling),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(() => {
-        if (!this.supportersList) return;
-        const list = this.supportersList.nativeElement as HTMLDivElement;
-        if (list.scrollWidth <= list.clientWidth) return;
-        this.supportersScrolling = true;
-        const scrollToEnd = () => {
-          if (!this.supportersScrolling) {
-            list.scrollLeft = 0;
-            list.style.opacity = '100%';
-            return;
-          }
-          list.scrollLeft += 1;
-          if (list.scrollLeft < list.scrollWidth - list.clientWidth) {
-            setTimeout(() => scrollToEnd(), 16);
-          } else {
-            setTimeout(() => {
-              list.style.opacity = '0%';
-            }, 1500);
-            setTimeout(() => {
-              list.scrollLeft = 0;
-              list.style.opacity = '100%';
-              setTimeout(() => requestAnimationFrame(() => scrollToEnd()), 2000);
-            }, 2000);
-          }
-        };
-        setTimeout(() => requestAnimationFrame(() => scrollToEnd()), 2000);
-      });
+  ngAfterViewInit() {
+    const el = this.rail?.nativeElement;
+    if (!el) return;
+    // the rail's own box never changes when its content grows, so observe both
+    this.railObserver = new ResizeObserver(() => this.updateRailFade());
+    this.railObserver.observe(el);
+    if (this.railContent) this.railObserver.observe(this.railContent.nativeElement);
+    this.updateRailFade();
+  }
+
+  // a class binding here would re-enter change detection, so toggle on the element
+  protected updateRailFade() {
+    const el = this.rail?.nativeElement;
+    if (!el) return;
+    const scrollable = el.scrollHeight - el.clientHeight;
+    el.classList.toggle('at-start', el.scrollTop <= 1);
+    el.classList.toggle('at-end', scrollable - el.scrollTop <= 1);
   }
 
   async ngOnDestroy() {
-    this.supportersScrolling = false;
+    this.railObserver?.disconnect();
     this.background.setBackground(null);
   }
+}
 
-  protected readonly BUILD_ID = BUILD_ID;
+function groupByType(contributors: Contributor[]): ContributionGroup[] {
+  const groups: ContributionGroup[] = [];
+  for (const contributor of contributors) {
+    let group = groups.find((g) => g.type === contributor.type);
+    if (!group) groups.push((group = { type: contributor.type, contributors: [] }));
+    group.contributors.push(contributor);
+  }
+  return groups;
+}
+
+function groupByLanguage(contributors: TranslationContributor[]): TranslationLanguage[] {
+  const languages: TranslationLanguage[] = [];
+  for (const contributor of contributors) {
+    let language = languages.find(
+      (l) => l.langCode === contributor.langCode && l.flagCode === contributor.flagCode
+    );
+    if (!language) {
+      languages.push(
+        (language = {
+          langCode: contributor.langCode,
+          flagCode: contributor.flagCode,
+          langNameNative: contributor.langNameNative,
+          contributors: [],
+        })
+      );
+    }
+    language.contributors.push(contributor);
+  }
+  return languages;
 }

--- a/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/about-view/about-view.component.ts
@@ -131,7 +131,6 @@ export class AboutViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.updateRailFade();
   }
 
-  // a class binding here would re-enter change detection, so toggle on the element
   protected updateRailFade() {
     const el = this.rail?.nativeElement;
     if (!el) return;

--- a/src-ui/assets/i18n/cn.json
+++ b/src-ui/assets/i18n/cn.json
@@ -9,7 +9,6 @@
     },
     "contributions": "贡献者们",
     "discordInvite": "Discord 服务器",
-    "projectLinks": "项目链接",
     "sourceLink": "源代码 @ GitHub",
     "supporters": "支持者们",
     "translations": "翻译人员"

--- a/src-ui/assets/i18n/de.json
+++ b/src-ui/assets/i18n/de.json
@@ -8,7 +8,6 @@
     },
     "contributions": "Beiträge",
     "discordInvite": "Discord Server",
-    "projectLinks": "Projekt Verlinkungen",
     "sourceLink": "Quellcode @ GitHub",
     "supporters": "Unterstützer",
     "translations": "Übersetzungen"

--- a/src-ui/assets/i18n/en.json
+++ b/src-ui/assets/i18n/en.json
@@ -4,13 +4,12 @@
       "role": "Developer"
     },
     "contributionType": {
-      "programming": "Programming",
+      "programming": "Code",
       "soundFx": "Sound FX"
     },
     "contributions": "Contributions",
     "discordInvite": "Discord Server",
-    "projectLinks": "Project Links",
-    "sourceLink": "Source Code @ GitHub",
+    "sourceLink": "Source (GitHub)",
     "supporters": "Supporters",
     "translations": "Translations"
   },

--- a/src-ui/assets/i18n/es.json
+++ b/src-ui/assets/i18n/es.json
@@ -9,7 +9,6 @@
     },
     "contributions": "Contribuciones",
     "discordInvite": "Servidor de Discord",
-    "projectLinks": "Enlaces del proyecto",
     "sourceLink": "Código fuente en GitHub",
     "supporters": "Patrocinadores",
     "translations": "Traducciones"

--- a/src-ui/assets/i18n/fr.json
+++ b/src-ui/assets/i18n/fr.json
@@ -4,7 +4,6 @@
       "role": "Développeur"
     },
     "discordInvite": "Serveur discord",
-    "projectLinks": "Liens",
     "sourceLink": "Code source @ GitHub",
     "translations": "Traductions"
   },

--- a/src-ui/assets/i18n/id.json
+++ b/src-ui/assets/i18n/id.json
@@ -8,7 +8,6 @@
     },
     "contributions": "Kontribusi",
     "discordInvite": "Discord Server",
-    "projectLinks": "Tautan Proyek",
     "sourceLink": "Kode Sumber @ GitHub",
     "translations": "Terjemahan"
   },

--- a/src-ui/assets/i18n/ja.json
+++ b/src-ui/assets/i18n/ja.json
@@ -9,7 +9,6 @@
     },
     "contributions": "共同開発",
     "discordInvite": "Discord",
-    "projectLinks": "プロジェクトリンク",
     "sourceLink": "Source Code @ GitHub",
     "supporters": "サポーター",
     "translations": "翻訳"

--- a/src-ui/assets/i18n/ko.json
+++ b/src-ui/assets/i18n/ko.json
@@ -8,7 +8,6 @@
     },
     "contributions": "기여",
     "discordInvite": "Discord 서버",
-    "projectLinks": "프로젝트 링크",
     "sourceLink": "소스코드 @ GitHub",
     "supporters": "후원자",
     "translations": "번역"

--- a/src-ui/assets/i18n/nl.json
+++ b/src-ui/assets/i18n/nl.json
@@ -9,7 +9,6 @@
     },
     "contributions": "Contributies",
     "discordInvite": "Discord Server",
-    "projectLinks": "Project Links",
     "sourceLink": "Broncode @ GitHub",
     "supporters": "Supporters",
     "translations": "Vertalingen"

--- a/src-ui/assets/i18n/ru.json
+++ b/src-ui/assets/i18n/ru.json
@@ -9,7 +9,6 @@
     },
     "contributions": "Поддержка",
     "discordInvite": "Discord сервер",
-    "projectLinks": "Ссылки проекта",
     "sourceLink": "Исходный код @ GitHub",
     "supporters": "Сторонники",
     "translations": "Переводы"

--- a/src-ui/assets/i18n/tw.json
+++ b/src-ui/assets/i18n/tw.json
@@ -9,7 +9,6 @@
     },
     "contributions": "貢獻者",
     "discordInvite": "Discord 伺服器",
-    "projectLinks": "專案連結",
     "sourceLink": "原始碼 @ GitHub",
     "supporters": "贊助者",
     "translations": "翻譯人員"

--- a/src-ui/assets/i18n/uk.json
+++ b/src-ui/assets/i18n/uk.json
@@ -8,7 +8,6 @@
     },
     "contributions": "Підтримка",
     "discordInvite": "Discord сервер",
-    "projectLinks": "Посилання проєкту",
     "sourceLink": "Початковий код @ GitHub",
     "supporters": "Прихильники",
     "translations": "Переклади"


### PR DESCRIPTION
The About view laid its sections out as full-width rows, two of which were unbounded lists: `.contributor-list` was a `flex-direction: column`, and `.translation-author-list` was a 4-column grid built by a hardcoded column-major matrix. Every new contributor cost a full line and every four translators cost a row, in a right-aligned column that left roughly 450px of the 707px row empty. The window minimum had been raised before to keep up, and the view had started to scroll again.

This rebuilds it as a fixed identity column beside a single scrolling credits column, so growth is absorbed inside the view rather than by the window.

## What changed

- **Two-column body.** A 16em identity column (avatar, name, links, build line) beside a credits column that is the only scrolling region. The two columns always match height; flexible spacers distribute the identity column's free space 40/60 so the avatar is never flush against the logo hairline.
- **Supporters moved to the top of the credits column** and scroll with it. They were pinned at the bottom below the translators.
- **Tier hierarchy.** Supporter names step down per tier, 1.35em/1.25em/1.15em against `--color-text-1`/`-2`/`-3`. Ranks cap at the third step, so a fourth tier from the endpoint renders at the smallest rather than continuing to shrink.
- **Grouping.** Contributions group by type and translators by language, so 7 + 21 rows become 2 + 12. `狐Kon` and `Raphiiko` no longer appear as duplicate rows.
- **The marquee is gone.** `ngAfterViewInit`'s `interval(1000)`/`scrollToEnd()` recursion, the `supportersScrolling` flag, the `#supportersList` `ViewChild` and the horizontal mask are deleted. Names wrap.
- **`buildTranslationContributors()` is gone**, replaced by `groupByLanguage()`.
- **Scroll fade** on the credits column drops at whichever end you reach, driven by a `ResizeObserver` plus the template's `(scroll)`.
- **Content.** `raphii.co` added to the developer links; `Programming` is now `Code`; `Source Code @ GitHub` is now `Source (GitHub)`.
- **`about.projectLinks` removed** from all 12 locales via `npm run tl unset`. It had no remaining reference. That script also re-sorts keys, so I reverted the sort in `es`, `ru` and `tw` and removed the single line by hand, keeping the i18n diff to one line per locale.

The logo block is untouched. The tagline's `translate(-5.3em, -1.5em)` fit inside the wordmark's descender space is preserved exactly, and the wordmark now measures dead centre because the two empty `.logo-side` spacers that were skewing nothing are removed.

## What a reviewer should check

- The tagline still sits inside the wordmark rather than beside it, at both the 980x662 minimum and fullscreen.
- Contribution and translation rows at a narrow window. The row never wraps as a unit; only the names wrap, and the dotted leader keeps its place on the first line.
- Supporter tier ordering. The view trusts the endpoint's JSON key order rather than sorting, which currently matches the intended ranking.

## What I left out

No tests. `src-ui` has no spec files and `package.json` has no test script, so there is nothing to add to.

Verified with `ng build oyasumivr`, eslint and prettier, and by driving the real component in the running app at 964, 980, 1010, 1059, 1400 and 2560px wide: columns match height, no horizontal overflow, no leader under 34px, and the fade variables flip correctly at both ends. Reviewed by Codex and GLM, neither found an actionable regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the About page with clearer sections for identity, credits, translations, supporters, and build information.
  - Added grouped contribution and translation details with optional links.
  - Added tiered supporter displays with improved styling.
  - Added scrolling content with fade indicators for lengthy sections.

- **Style**
  - Improved responsive spacing, typography, visual hierarchy, and social-link presentation.

- **Documentation**
  - Updated contribution labels in English, including “Code” and “Source (GitHub).”
  - Removed obsolete project-link text from localized About-page content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->