### PR TITLE
fix: pace audio meter retries after a read error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed the Windows notification provider not showing any notifications
 - Fixed the VR overlay failing to start when system-wide ad blockers or proxies intercepted
   OyasumiVR's local connection
+- Fixed OyasumiVR using up an entire CPU core when Windows stopped reporting the microphone level
+  for the capture device used by the system microphone automations
 - The VR overlay now writes the reason for an unexpected shutdown to its log file, instead of stopping without a trace
 - Changing the VR overlay's GPU acceleration setting now restarts it right away, instead of waiting out the retry delay
   of up to five minutes

--- a/src-core/src/os/audio_devices/device.rs
+++ b/src-core/src/os/audio_devices/device.rs
@@ -293,8 +293,10 @@ impl AudioDevice {
         drop(metering_enabled);
         tokio::spawn(async move {
             const ACTIVATION_TIMEOUT: i64 = 1000;
+            const SAMPLE_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_millis(20);
             let mut last_activation = DateTime::from_timestamp_millis(0).unwrap();
             let mut previously_active = false;
+            let mut meter_error_logged = false;
             loop {
                 // Stop if metering has been disabled
                 let metering_enabled = state.metering_enabled.lock().await;
@@ -304,13 +306,25 @@ impl AudioDevice {
                 drop(metering_enabled);
                 // Get the meter value
                 let meter = state.meter_information.lock().await;
-                let value = match unsafe { meter.0.GetPeakValue() } {
-                    Ok(value) => value,
+                let peak_value = unsafe { meter.0.GetPeakValue() };
+                drop(meter);
+                let value = match peak_value {
+                    Ok(value) => {
+                        meter_error_logged = false;
+                        value
+                    }
                     Err(e) => {
+                        if !meter_error_logged {
+                            meter_error_logged = true;
+                            error!(
+                                "[Core] Could not read the peak level of audio device '{}': {e:?}",
+                                state.name
+                            );
+                        }
+                        tokio::time::sleep(SAMPLE_INTERVAL).await;
                         continue;
                     }
                 };
-                drop(meter);
                 // Get the threshold
                 let threshold = super::super::AUDIO_DEVICE_MANAGER
                     .lock()
@@ -347,7 +361,7 @@ impl AudioDevice {
                     },
                 )
                 .await;
-                tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+                tokio::time::sleep(SAMPLE_INTERVAL).await;
             }
         });
     }


### PR DESCRIPTION
Closes OYASUMIVR-39 (PERF-009).

`AudioDevice::enable_metering` spawns a loop that samples the capture device's peak level at 50 Hz. The single `sleep(20ms)` sat at the bottom of the loop, after the success path. The error arm of the `GetPeakValue` match ran `continue` before it, so a failing meter retried with no delay.

I rebuilt the loop in a standalone binary with a fake always-failing meter, the same `tokio::sync::Mutex` locks, and a 4-worker runtime:

```
current code, meter succeeds: 4 GetPeakValue calls in 100 ms
current code, meter errors : 1430784 GetPeakValue calls in 100 ms
fixed code,   meter succeeds: 4 GetPeakValue calls in 100 ms
fixed code,   meter errors : 4 GetPeakValue calls in 100 ms
```

One CPU core at 100% for as long as the device keeps failing. Disabling metering still stopped the task in both versions, so task shutdown was never affected.

Three changes in `enable_metering`:

- The error arm sleeps `SAMPLE_INTERVAL` before `continue`, so every iteration pays the 20 ms.
- `GetPeakValue` runs and the meter guard drops before the match, so no lock is held across a sleep.
- A `meter_error_logged` flag logs the first error of a failure run and resets on the next success. Without it a broken device would write 50 log lines a second.

The `20` now lives in one `const SAMPLE_INTERVAL` used by both sleeps.

Check whether logging once per failure run is the behaviour you want. The other option is to disable metering after a persistent failure and surface the device state to the UI. The ticket left that open.

I left out exponential backoff. At 20 ms the error path costs what the normal path already costs, so it buys nothing unless real devices fail for minutes at a time.

I ran `cargo check --no-default-features`. It passes with no warnings. The repro binary lives in `%TEMP%` and is not part of this branch. I never forced a real audio endpoint into the failing state.
