### PR TITLE
perf(OYASUMIVR-36): share the startup solar-time lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   OyasumiVR's local connection
 - Fixed OyasumiVR using up an entire CPU core when Windows stopped reporting the microphone level
   for the capture device used by the system microphone automations
+- Fixed OyasumiVR looking up your sunrise and sunset times up to three times when it started
 - The VR overlay now writes the reason for an unexpected shutdown to its log file, instead of stopping without a trace
 - Changing the VR overlay's GPU acceleration setting now restarts it right away, instead of waiting out the retry delay
   of up to five minutes

--- a/src-ui/app/services/brightness-cct-automation.service.ts
+++ b/src-ui/app/services/brightness-cct-automation.service.ts
@@ -59,6 +59,7 @@ export class BrightnessCctAutomationService {
   } | null>(null);
   private autoSunsetTime?: string;
   private autoSunriseTime?: string;
+  private sunriseSunsetLookup?: Promise<[string, string]>;
   private sleepMode: boolean = false;
 
   public readonly anyBrightnessTransitionActive = this.lastActivatedBrightnessTransition.pipe(
@@ -149,7 +150,6 @@ export class BrightnessCctAutomationService {
     await listen<void>('CRON_MINUTE_START', () => this.onMinuteTick());
 
     // Update sunrise/sunset times on startup and every 12 hours
-    this.updateSunriseSunsetTimes();
     interval(1000 * 60 * 60 * 12) // Every 12 hours
       .pipe(startWith(0))
       .subscribe(() => this.updateSunriseSunsetTimes());
@@ -169,9 +169,7 @@ export class BrightnessCctAutomationService {
         // Fetch the sunset/sunrise times if needed
         if (!this.autoSunsetTime || !this.autoSunriseTime) {
           try {
-            const [sunrise, sunset] = await invoke<[string, string]>('get_sunrise_sunset_time');
-            this.autoSunriseTime = sunrise;
-            this.autoSunsetTime = sunset;
+            await this.fetchSunriseSunsetTimes();
           } catch (e) {
             error('[BrightnessCctAutomationService] Failed to fetch sunrise/sunset times: ' + e);
             return;
@@ -605,12 +603,20 @@ export class BrightnessCctAutomationService {
     }
   }
 
+  // shared while a lookup is in flight, refetches once it settles
+  private fetchSunriseSunsetTimes(): Promise<[string, string]> {
+    return (this.sunriseSunsetLookup ??= invoke<[string, string]>('get_sunrise_sunset_time')
+      .then((times) => {
+        [this.autoSunriseTime, this.autoSunsetTime] = times;
+        return times;
+      })
+      .finally(() => (this.sunriseSunsetLookup = undefined)));
+  }
+
   private async updateSunriseSunsetTimes() {
     try {
       // Get the latest sunrise/sunset times
-      const [sunrise, sunset] = await invoke<[string, string]>('get_sunrise_sunset_time');
-      this.autoSunriseTime = sunrise;
-      this.autoSunsetTime = sunset;
+      const [sunrise, sunset] = await this.fetchSunriseSunsetTimes();
 
       // Update configurations with auto update enabled
       const configs = await firstValueFrom(this.automationConfigService.configs);

--- a/src-ui/app/services/brightness-cct-automation.service.ts
+++ b/src-ui/app/services/brightness-cct-automation.service.ts
@@ -9,6 +9,7 @@ import {
   distinctUntilChanged,
   filter,
   firstValueFrom,
+  from,
   interval,
   map,
   merge,
@@ -20,6 +21,7 @@ import {
   switchMap,
   take,
   tap,
+  timeout,
 } from 'rxjs';
 import { CancellableTask } from '../utils/cancellable-task';
 import { EventLogService } from './event-log.service';
@@ -163,11 +165,15 @@ export class BrightnessCctAutomationService {
       )
       .subscribe(async (configs) => {
         // Check if the sunset/sunrise times are already configured
-        const config = configs.BRIGHTNESS_AUTOMATIONS;
-        if (config.AT_SUNRISE.activationTime !== null && config.AT_SUNSET.activationTime !== null)
+        if (
+          configs.BRIGHTNESS_AUTOMATIONS.AT_SUNRISE.activationTime !== null &&
+          configs.BRIGHTNESS_AUTOMATIONS.AT_SUNSET.activationTime !== null
+        )
           return;
         // Fetch the sunset/sunrise times if needed
         if (!this.autoSunsetTime || !this.autoSunriseTime) {
+          // leave a running lookup to the scheduled refresh, and try again on the next tick
+          if (this.sunriseSunsetLookup) return;
           try {
             await this.fetchSunriseSunsetTimes();
           } catch (e) {
@@ -175,7 +181,9 @@ export class BrightnessCctAutomationService {
             return;
           }
         }
-        // Update the config if needed
+        // Update the config if needed, reading it again since the lookup may have written to it
+        const config = (await firstValueFrom(this.automationConfigService.configs))
+          .BRIGHTNESS_AUTOMATIONS;
         const patch: Partial<BrightnessAutomationsConfig> = {};
         if (config.AT_SUNRISE.activationTime === null) {
           patch.AT_SUNRISE = {
@@ -189,6 +197,7 @@ export class BrightnessCctAutomationService {
             activationTime: this.autoSunsetTime ?? null,
           };
         }
+        if (!patch.AT_SUNRISE && !patch.AT_SUNSET) return;
         await this.automationConfigService.updateAutomationConfig<BrightnessAutomationsConfig>(
           'BRIGHTNESS_AUTOMATIONS',
           patch
@@ -603,9 +612,11 @@ export class BrightnessCctAutomationService {
     }
   }
 
-  // shared while a lookup is in flight, refetches once it settles
+  // callers share one in-flight request; the next call after it settles starts a new one
   private fetchSunriseSunsetTimes(): Promise<[string, string]> {
-    return (this.sunriseSunsetLookup ??= invoke<[string, string]>('get_sunrise_sunset_time')
+    return (this.sunriseSunsetLookup ??= firstValueFrom(
+      from(invoke<[string, string]>('get_sunrise_sunset_time')).pipe(timeout(30000))
+    )
       .then((times) => {
         [this.autoSunriseTime, this.autoSunsetTime] = times;
         return times;


### PR DESCRIPTION
At startup OyasumiVR ran the sunrise and sunset lookup up to three times, each
doing its own public-IP lookup, geolocation lookup, and solar calculation in
`src-core/src/commands/time.rs`. Two calls raced at once, and the fallback
added a third two seconds later.

`init` called `updateSunriseSunsetTimes` directly while the 12-hour interval
fired the same method through `startWith(0)` in the same tick. The fallback
checked for empty results rather than for a request already in flight.

`fetchSunriseSunsetTimes` now owns the request. It keeps the pending promise
in a field and clears it once the request settles, so the scheduled refresh
and the fallback share one lookup. A 30-second rxjs timeout rejects a stalled
request instead of parking later retries on it. The fallback defers to a
running lookup, reads the config again after its own lookup, and skips config
writes that have nothing to patch.

Facts for later: recovery of a missing activation time can now take one extra
fallback tick. The 30 seconds is a choice, not a measurement. The timeout
cancels the wait, not the Tauri command behind it, so a stalled command can
overlap the retry. `brightness-automation-details.component.ts` still calls
the command directly, because its button should fetch a fresh value. The
two-second fallback stays; removing it is a product call.
