### PR TITLE
fix(OYASUMIVR-21): keep the hotkey visible when the selector is canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,16 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 =======
 - Fixed canceling the hotkey selector clearing the hotkey from view while the old hotkey stayed active
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> c793f2ab (fix: keep the hotkey visible when the selector is canceled)
 =======
 - The hotkey selector no longer shows a hotkey that Windows refused to register
 >>>>>>> 9f7c826a (docs: note the hotkey registration-failure fix)
+=======
+- Fixed closing the hotkey selector with Escape discarding the hotkey you just pressed
+- Fixed a hotkey you set running its action twice, until you restarted OyasumiVR
+- Fixed OyasumiVR dropping an action's working hotkey when it could not register the replacement
+>>>>>>> cb0f52fd (docs: note the remaining hotkey fixes)
 - Various stability improvements
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,21 +89,16 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed OyasumiVR getting stuck on "Initializing" for SteamVR, which only a restart cleared
 - Fixed the VR overlay crashing on startup, and when SteamVR was restarted
 - The VR overlay now stops with an explanation in its log when its browser engine cannot start, instead of crashing
-<<<<<<< HEAD
 - Fixed fractional values typed into slider settings, such as chaperone fade distances, being truncated
-=======
 - Fixed canceling the hotkey selector clearing the hotkey from view while the old hotkey stayed active
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> c793f2ab (fix: keep the hotkey visible when the selector is canceled)
-=======
 - The hotkey selector no longer shows a hotkey that Windows refused to register
->>>>>>> 9f7c826a (docs: note the hotkey registration-failure fix)
-=======
 - Fixed closing the hotkey selector with Escape discarding the hotkey you just pressed
 - Fixed a hotkey you set running its action twice, until you restarted OyasumiVR
 - Fixed OyasumiVR dropping an action's working hotkey when it could not register the replacement
->>>>>>> cb0f52fd (docs: note the remaining hotkey fixes)
+- Fixed changing a hotkey sometimes leaving the old key combination claimed system-wide, where it did
+  nothing and could not be freed until you restarted OyasumiVR
+- Fixed one hotkey being unavailable, because another application had taken it, stopping your
+  remaining hotkeys from working again after you closed the hotkey selector
 - Various stability improvements
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,11 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed OyasumiVR getting stuck on "Initializing" for SteamVR, which only a restart cleared
 - Fixed the VR overlay crashing on startup, and when SteamVR was restarted
 - The VR overlay now stops with an explanation in its log when its browser engine cannot start, instead of crashing
+<<<<<<< HEAD
 - Fixed fractional values typed into slider settings, such as chaperone fade distances, being truncated
+=======
+- Fixed canceling the hotkey selector clearing the hotkey from view while the old hotkey stayed active
+>>>>>>> c793f2ab (fix: keep the hotkey visible when the selector is canceled)
 - Various stability improvements
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,11 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed fractional values typed into slider settings, such as chaperone fade distances, being truncated
 =======
 - Fixed canceling the hotkey selector clearing the hotkey from view while the old hotkey stayed active
+<<<<<<< HEAD
 >>>>>>> c793f2ab (fix: keep the hotkey visible when the selector is canceled)
+=======
+- The hotkey selector no longer shows a hotkey that Windows refused to register
+>>>>>>> 9f7c826a (docs: note the hotkey registration-failure fix)
 - Various stability improvements
 
 ### Removed

--- a/src-ui/app/components/hotkey-selector-modal/hotkey-selector-modal.component.ts
+++ b/src-ui/app/components/hotkey-selector-modal/hotkey-selector-modal.component.ts
@@ -72,12 +72,9 @@ export class HotkeySelectorModalComponent
           if (await this.hotkeyService.isValidHotkey(hotkey)) {
             this.stopListeningForKeys.next();
             this.success = true;
-            setTimeout(() => {
-              this.result = {
-                hotkey,
-              };
-              this.close();
-            }, 500);
+            // an early close emits whatever result is set by then
+            this.result = { hotkey };
+            setTimeout(() => this.close(), 500);
           } else {
             this.key = undefined;
           }

--- a/src-ui/app/components/hotkey-selector-modal/hotkey-selector-modal.component.ts
+++ b/src-ui/app/components/hotkey-selector-modal/hotkey-selector-modal.component.ts
@@ -72,7 +72,6 @@ export class HotkeySelectorModalComponent
           if (await this.hotkeyService.isValidHotkey(hotkey)) {
             this.stopListeningForKeys.next();
             this.success = true;
-            // an early close emits whatever result is set by then
             this.result = { hotkey };
             setTimeout(() => this.close(), 500);
           } else {

--- a/src-ui/app/components/hotkey-selector/hotkey-selector.component.ts
+++ b/src-ui/app/components/hotkey-selector/hotkey-selector.component.ts
@@ -51,8 +51,9 @@ export class HotkeySelectorComponent implements OnChanges, OnDestroy, OnInit {
 
   selectHotkey() {
     this.modalService.addModal(HotkeySelectorModalComponent, {}, {}).subscribe((result) => {
-      this.hotkey = result?.hotkey ?? undefined;
-      if (this.hotkey) this.hotkeyService.registerHotkey(this.action!, this.hotkey);
+      if (!result?.hotkey || !this.action) return;
+      this.hotkey = result.hotkey;
+      this.hotkeyService.registerHotkey(this.action, this.hotkey);
       this.cdr.markForCheck();
     });
   }

--- a/src-ui/app/components/hotkey-selector/hotkey-selector.component.ts
+++ b/src-ui/app/components/hotkey-selector/hotkey-selector.component.ts
@@ -50,10 +50,10 @@ export class HotkeySelectorComponent implements OnChanges, OnDestroy, OnInit {
   }
 
   selectHotkey() {
-    this.modalService.addModal(HotkeySelectorModalComponent, {}, {}).subscribe((result) => {
+    this.modalService.addModal(HotkeySelectorModalComponent, {}, {}).subscribe(async (result) => {
       if (!result?.hotkey || !this.action) return;
+      if (!(await this.hotkeyService.registerHotkey(this.action, result.hotkey))) return;
       this.hotkey = result.hotkey;
-      this.hotkeyService.registerHotkey(this.action, this.hotkey);
       this.cdr.markForCheck();
     });
   }

--- a/src-ui/app/services/hotkey.service.ts
+++ b/src-ui/app/services/hotkey.service.ts
@@ -269,30 +269,30 @@ export class HotkeyService {
     if (!(await this.isValidHotkey(hotkeyString))) {
       return false;
     }
-    try {
-      await this.unregisterHotkey(hotkeyId, true);
-    } catch (e) {
-      warn('[HotkeyService] Could not unregister hotkey: ' + e);
-    }
-    if (this.hotkeys[hotkeyString]) {
-      this.hotkeys[hotkeyString].push(hotkeyId);
-      if (!load) this.saveHotkeys();
-      return true;
-    } else {
+    const boundTo = Object.entries(this.hotkeys).find(([, ids]) => ids.includes(hotkeyId))?.[0];
+    if (boundTo === hotkeyString) return true;
+    // claim the new accelerator before releasing the old one
+    if (!this.hotkeys[hotkeyString] && !this.paused) {
       try {
-        if (!this.paused) {
-          await register(hotkeyString, () => {
+        await register(hotkeyString, (event) => {
+          if (event.state === 'Pressed') {
             this.onHotkeyPressed(hotkeyString);
-          });
-        }
-        this.hotkeys[hotkeyString] = [hotkeyId];
-        if (!load) this.saveHotkeys();
-        return true;
+          }
+        });
       } catch (e) {
         warn('[HotkeyService] Could not register hotkey: ' + e);
         return false;
       }
     }
+    const hotkeyIds = this.hotkeys[hotkeyString] ?? [];
+    try {
+      await this.unregisterHotkey(hotkeyId, true);
+    } catch (e) {
+      warn('[HotkeyService] Could not unregister hotkey: ' + e);
+    }
+    this.hotkeys[hotkeyString] = [...hotkeyIds, hotkeyId];
+    if (!load) this.saveHotkeys();
+    return true;
   }
 
   public async unregisterHotkey(hotkeyId: string, load = false) {

--- a/src-ui/app/services/hotkey.service.ts
+++ b/src-ui/app/services/hotkey.service.ts
@@ -289,8 +289,6 @@ export class HotkeyService {
       if (!(await this.isValidHotkey(hotkeyString))) {
         return false;
       }
-      const boundTo = Object.entries(this.hotkeys).find(([, ids]) => ids.includes(hotkeyId))?.[0];
-      if (boundTo === hotkeyString) return true;
       if (!this.hotkeys[hotkeyString] && !this.paused) {
         try {
           await this.registerAccelerator(hotkeyString);
@@ -299,9 +297,9 @@ export class HotkeyService {
           return false;
         }
       }
+      await this.releaseHotkeyExcept(hotkeyId, hotkeyString);
       const hotkeyIds = this.hotkeys[hotkeyString] ?? [];
-      await this.releaseHotkey(hotkeyId);
-      this.hotkeys[hotkeyString] = [...hotkeyIds, hotkeyId];
+      if (!hotkeyIds.includes(hotkeyId)) hotkeyIds.push(hotkeyId);
       if (!load) this.saveHotkeys();
       return true;
     });
@@ -315,7 +313,12 @@ export class HotkeyService {
   }
 
   private async releaseHotkey(hotkeyId: string) {
+    await this.releaseHotkeyExcept(hotkeyId);
+  }
+
+  private async releaseHotkeyExcept(hotkeyId: string, retainedHotkeyString?: string) {
     for (const [hotkeyString, hotkeyIds] of Object.entries(this.hotkeys)) {
+      if (hotkeyString === retainedHotkeyString) continue;
       const index = hotkeyIds.indexOf(hotkeyId);
       if (index < 0) continue;
       hotkeyIds.splice(index, 1);

--- a/src-ui/app/services/hotkey.service.ts
+++ b/src-ui/app/services/hotkey.service.ts
@@ -210,7 +210,6 @@ export class HotkeyService {
 
   constructor(private appSettings: AppSettingsService) {}
 
-  // every change to this.hotkeys and to the registered accelerators runs here, one at a time
   private enqueue<T>(work: () => Promise<T>): Promise<T> {
     const result = this.queue.then(work, work);
     this.queue = result.catch(() => undefined);
@@ -292,7 +291,6 @@ export class HotkeyService {
       }
       const boundTo = Object.entries(this.hotkeys).find(([, ids]) => ids.includes(hotkeyId))?.[0];
       if (boundTo === hotkeyString) return true;
-      // claim the new accelerator before releasing the old one
       if (!this.hotkeys[hotkeyString] && !this.paused) {
         try {
           await this.registerAccelerator(hotkeyString);

--- a/src-ui/app/services/hotkey.service.ts
+++ b/src-ui/app/services/hotkey.service.ts
@@ -205,9 +205,17 @@ export class HotkeyService {
   private hotkeys: { [hotkeyString: string]: string[] } = {};
   private _hotkeyPressed = new Subject<HotkeyId>();
   private paused = false;
+  private queue: Promise<unknown> = Promise.resolve();
   public hotkeyPressed = this._hotkeyPressed.asObservable();
 
   constructor(private appSettings: AppSettingsService) {}
+
+  // every change to this.hotkeys and to the registered accelerators runs here, one at a time
+  private enqueue<T>(work: () => Promise<T>): Promise<T> {
+    const result = this.queue.then(work, work);
+    this.queue = result.catch(() => undefined);
+    return result;
+  }
 
   public async init() {
     this.appSettings.settings.pipe(take(1)).subscribe(async (settings) => {
@@ -227,24 +235,40 @@ export class HotkeyService {
     return validKeys.includes(key.toUpperCase());
   }
 
-  public async pause() {
-    if (this.paused) return;
-    this.paused = true;
-    for (const hotkeyString of Object.keys(this.hotkeys)) {
-      await unregister(hotkeyString);
-    }
+  public pause() {
+    return this.enqueue(async () => {
+      if (this.paused) return;
+      this.paused = true;
+      for (const hotkeyString of Object.keys(this.hotkeys)) {
+        try {
+          await unregister(hotkeyString);
+        } catch (e) {
+          error('[HotkeyService] Could not unregister hotkey: ' + e);
+        }
+      }
+    });
   }
 
-  public async resume() {
-    if (!this.paused) return;
-    this.paused = false;
-    for (const hotkeyString of Object.keys(this.hotkeys)) {
-      await register(hotkeyString, (event) => {
-        if (event.state === 'Pressed') {
-          this.onHotkeyPressed(hotkeyString);
+  public resume() {
+    return this.enqueue(async () => {
+      if (!this.paused) return;
+      this.paused = false;
+      for (const hotkeyString of Object.keys(this.hotkeys)) {
+        try {
+          await this.registerAccelerator(hotkeyString);
+        } catch (e) {
+          warn('[HotkeyService] Could not register hotkey: ' + e);
         }
-      });
-    }
+      }
+    });
+  }
+
+  private registerAccelerator(hotkeyString: string) {
+    return register(hotkeyString, (event) => {
+      if (event.state === 'Pressed') {
+        this.onHotkeyPressed(hotkeyString);
+      }
+    });
   }
 
   public async isValidHotkey(hotkeyString: string) {
@@ -261,44 +285,42 @@ export class HotkeyService {
     }
   }
 
-  public async registerHotkey(
-    hotkeyId: string,
-    hotkeyString: string,
-    load = false
-  ): Promise<boolean> {
-    if (!(await this.isValidHotkey(hotkeyString))) {
-      return false;
-    }
-    const boundTo = Object.entries(this.hotkeys).find(([, ids]) => ids.includes(hotkeyId))?.[0];
-    if (boundTo === hotkeyString) return true;
-    // claim the new accelerator before releasing the old one
-    if (!this.hotkeys[hotkeyString] && !this.paused) {
-      try {
-        await register(hotkeyString, (event) => {
-          if (event.state === 'Pressed') {
-            this.onHotkeyPressed(hotkeyString);
-          }
-        });
-      } catch (e) {
-        warn('[HotkeyService] Could not register hotkey: ' + e);
+  public registerHotkey(hotkeyId: string, hotkeyString: string, load = false): Promise<boolean> {
+    return this.enqueue(async () => {
+      if (!(await this.isValidHotkey(hotkeyString))) {
         return false;
       }
-    }
-    const hotkeyIds = this.hotkeys[hotkeyString] ?? [];
-    try {
-      await this.unregisterHotkey(hotkeyId, true);
-    } catch (e) {
-      warn('[HotkeyService] Could not unregister hotkey: ' + e);
-    }
-    this.hotkeys[hotkeyString] = [...hotkeyIds, hotkeyId];
-    if (!load) this.saveHotkeys();
-    return true;
+      const boundTo = Object.entries(this.hotkeys).find(([, ids]) => ids.includes(hotkeyId))?.[0];
+      if (boundTo === hotkeyString) return true;
+      // claim the new accelerator before releasing the old one
+      if (!this.hotkeys[hotkeyString] && !this.paused) {
+        try {
+          await this.registerAccelerator(hotkeyString);
+        } catch (e) {
+          warn('[HotkeyService] Could not register hotkey: ' + e);
+          return false;
+        }
+      }
+      const hotkeyIds = this.hotkeys[hotkeyString] ?? [];
+      await this.releaseHotkey(hotkeyId);
+      this.hotkeys[hotkeyString] = [...hotkeyIds, hotkeyId];
+      if (!load) this.saveHotkeys();
+      return true;
+    });
   }
 
-  public async unregisterHotkey(hotkeyId: string, load = false) {
+  public unregisterHotkey(hotkeyId: string, load = false) {
+    return this.enqueue(async () => {
+      await this.releaseHotkey(hotkeyId);
+      if (!load) this.saveHotkeys();
+    });
+  }
+
+  private async releaseHotkey(hotkeyId: string) {
     for (const [hotkeyString, hotkeyIds] of Object.entries(this.hotkeys)) {
       const index = hotkeyIds.indexOf(hotkeyId);
-      if (index >= 0) hotkeyIds.splice(index, 1);
+      if (index < 0) continue;
+      hotkeyIds.splice(index, 1);
       if (hotkeyIds.length === 0) {
         delete this.hotkeys[hotkeyString];
         if (!this.paused) {
@@ -310,7 +332,6 @@ export class HotkeyService {
         }
       }
     }
-    if (!load) this.saveHotkeys();
   }
 
   public getHotkeyStringForId(hotkeyId: string): Observable<string | undefined> {

--- a/src-ui/app/services/hotkey.service.ts
+++ b/src-ui/app/services/hotkey.service.ts
@@ -298,7 +298,8 @@ export class HotkeyService {
         }
       }
       await this.releaseHotkeyExcept(hotkeyId, hotkeyString);
-      const hotkeyIds = this.hotkeys[hotkeyString] ?? [];
+      this.hotkeys[hotkeyString] ??= [];
+      const hotkeyIds = this.hotkeys[hotkeyString];
       if (!hotkeyIds.includes(hotkeyId)) hotkeyIds.push(hotkeyId);
       if (!load) this.saveHotkeys();
       return true;


### PR DESCRIPTION
Canceling the hotkey selector, including with Escape, made the row show "Select" while the old hotkey stayed registered and persisted. The modal emits an undefined result on a resultless close, and the selector assigned that undefined value to its display field.

The selector now ignores resultless closes. It also updates the display only after registration succeeds, records an accepted hotkey before the success animation, and keeps the previous binding visible if Windows refuses the replacement.

The related registration fixes claim a new accelerator before releasing the old one, run hotkey changes through one queue, fire actions on press only, and skip release entries that do not hold the action id.

## Testing

Manual checks in the packaged app covered assign, cancel, Escape, Escape during the success animation, reopen and cancel, replacement, and clear. They verified the row, the OS registration, and the persisted settings.

`npm run lint` and `npx ng build oyasumivr --configuration production` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hotkey selector cancellation and Escape-key handling.
  - Prevented rejected or failed hotkey registrations from changing application state.
  - Fixed duplicate actions being triggered by repeated hotkey registrations.
  - Improved hotkey replacement to avoid losing existing shortcuts when a new registration fails.
  - Restored other shortcuts correctly after closing the hotkey selector.
  - Fixed stale system-wide hotkey claims and improved recovery from individual registration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->