### PR TITLE
fix(OYASUMIVR-41): unsubscribe destroyed editor and modal subscriptions

### DIFF
--- a/src-ui/app/components/device-manager-config-modal/device-manager-config-modal.component.ts
+++ b/src-ui/app/components/device-manager-config-modal/device-manager-config-modal.component.ts
@@ -67,7 +67,7 @@ export class DeviceManagerConfigModalComponent
   }
 
   private loadTags() {
-    this.deviceManager.tags.subscribe((tags) => {
+    this.deviceManager.tags.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((tags) => {
       this.availableTags = tags;
       this.cdr.markForCheck();
     });

--- a/src-ui/app/components/osc-script-simple-editor/osc-script-simple-editor.component.ts
+++ b/src-ui/app/components/osc-script-simple-editor/osc-script-simple-editor.component.ts
@@ -137,13 +137,15 @@ export class OscScriptSimpleEditorComponent implements OnInit {
         this.cdr.markForCheck();
       });
 
-    combineLatest([this.avatarContextService.avatarContext]).subscribe(([avatarContext]) => {
-      this.currentAvatarContext = avatarContext;
-      this.knownOscAddresses = [...(avatarContext?.parameters ?? []).map((p) => p.address)].sort();
-      this.cdr.markForCheck();
-
-      // Check if we should show the VRChat autocomplete info dialog
-    });
+    combineLatest([this.avatarContextService.avatarContext])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([avatarContext]) => {
+        this.currentAvatarContext = avatarContext;
+        this.knownOscAddresses = [
+          ...(avatarContext?.parameters ?? []).map((p) => p.address),
+        ].sort();
+        this.cdr.markForCheck();
+      });
 
     setTimeout(() => {
       this.checkShowVRChatAutocompleteInfo();


### PR DESCRIPTION
﻿Closing the OSC script modal or the Device Manager configuration modal left its subscriptions attached to root-lifetime streams. Reopening a modal, or switching between the simple and script tabs, added another stale callback, so later avatar-context and device-tag changes kept touching destroyed components.

Both components already use takeUntilDestroyed for neighboring streams. These two subscriptions were plain subscribe calls, and nothing removed them when the component was destroyed.

Both subscriptions now run through takeUntilDestroyed(this.destroyRef) and end with their component. The editor also loses a comment that had drifted away from the code it described.

ESLint passes on both files and `npx ng build oyasumivr` succeeds. The repo has no configured test runner, so there is no spec to run; the observer-count regression test from the work item needs that infrastructure first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component cleanup to prevent lingering subscriptions when device manager and OSC script editor views are closed.
  * Enhanced application stability and resource usage during repeated navigation and component refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->