### PR TITLE
fix(OYASUMIVR-45): skip port retry delay after success

### DIFF
--- a/src-ui/app/services/font-loader.service.ts
+++ b/src-ui/app/services/font-loader.service.ts
@@ -18,7 +18,7 @@ export class FontLoaderService {
     // Fetch http server port until it's available
     while (!this._httpServerPort) {
       this._httpServerPort = (await invoke<number>('get_http_server_port')) || 0;
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      if (!this._httpServerPort) await new Promise((resolve) => setTimeout(resolve, 50));
     }
     // Initialize font loader
     fontLoader.init(this._httpServerPort, this.translate.getActiveLang()!).then(() => {

--- a/src-ui/app/services/font-loader.service.ts
+++ b/src-ui/app/services/font-loader.service.ts
@@ -15,12 +15,10 @@ export class FontLoaderService {
   constructor(private translate: TranslocoService) {}
 
   async init() {
-    // Fetch http server port until it's available
     while (!this._httpServerPort) {
       this._httpServerPort = (await invoke<number>('get_http_server_port')) || 0;
       if (!this._httpServerPort) await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    // Initialize font loader
     fontLoader.init(this._httpServerPort, this.translate.getActiveLang()!).then(() => {
       // Load fonts for new locale
       this.translate.langChanges$.subscribe(async (lang) => {

--- a/src-ui/app/services/image-cache.service.ts
+++ b/src-ui/app/services/image-cache.service.ts
@@ -15,7 +15,7 @@ export class ImageCacheService {
     while (!this.httpServerPort.value) {
       const port = (await invoke<number>('get_http_server_port')) || null;
       if (port) this.httpServerPort.next(port);
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      else await new Promise((resolve) => setTimeout(resolve, 50));
     }
   }
 

--- a/src-ui/app/services/image-cache.service.ts
+++ b/src-ui/app/services/image-cache.service.ts
@@ -11,7 +11,6 @@ export class ImageCacheService {
   constructor() {}
 
   async init() {
-    // Fetch http server port until it's available
     while (!this.httpServerPort.value) {
       const port = (await invoke<number>('get_http_server_port')) || null;
       if (port) this.httpServerPort.next(port);


### PR DESCRIPTION
Both main-UI port polling loops waited 50 ms after the core had already returned a valid HTTP port, so the image cache finished init late and font loading started later than needed.

The retry delay belongs to unavailable or failed attempts. A valid port means the loop is done, but the sleep ran unconditionally before the loop condition was rechecked.

The loops now delay only when the port is still missing. The overlay sidecar wait loop already returned on success since commit 32ffa722, so it needed no change here.

Verified with ESLint on both changed files, Prettier, and a full `ng build oyasumivr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced startup delays when loading fonts and images.
  * Resource loading now proceeds immediately once the local server is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->