### PR TITLE
fix(OYASUMIVR-20): preserve fractional slider input

### DIFF
--- a/src-ui/app/components/slider-setting/slider-setting.component.html
+++ b/src-ui/app/components/slider-setting/slider-setting.component.html
@@ -26,6 +26,9 @@
   <input
     type="number"
     class="small"
+    [min]="min"
+    [max]="max"
+    [step]="step"
     [value]="value"
     (input)="input$.next(inputValue.value)"
     (blur)="onInputBlur()"

--- a/src-ui/app/components/slider-setting/slider-setting.component.ts
+++ b/src-ui/app/components/slider-setting/slider-setting.component.ts
@@ -69,8 +69,12 @@ export class SliderSettingComponent implements OnInit, OnChanges {
       .subscribe((strValue) => {
         let value = parseFloat(strValue);
         if (!Number.isFinite(value)) return;
+        const precision = floatPrecision(this.step);
         value = clamp(
-          ensurePrecision(Math.round(value / this.step) * this.step, floatPrecision(this.step)),
+          ensurePrecision(
+            Math.round(ensurePrecision(value / this.step, precision)) * this.step,
+            precision
+          ),
           this.min,
           this.max
         );

--- a/src-ui/app/components/slider-setting/slider-setting.component.ts
+++ b/src-ui/app/components/slider-setting/slider-setting.component.ts
@@ -70,11 +70,10 @@ export class SliderSettingComponent implements OnInit, OnChanges {
         let value = parseFloat(strValue);
         if (!Number.isFinite(value)) return;
         const precision = floatPrecision(this.step);
+        const quotient = value / this.step;
+        const epsilon = Number.EPSILON * 4 * Math.max(1, Math.abs(quotient));
         value = clamp(
-          ensurePrecision(
-            Math.round(ensurePrecision(value / this.step, precision)) * this.step,
-            precision
-          ),
+          ensurePrecision(Math.round(quotient + epsilon) * this.step, precision),
           this.min,
           this.max
         );

--- a/src-ui/app/components/slider-setting/slider-setting.component.ts
+++ b/src-ui/app/components/slider-setting/slider-setting.component.ts
@@ -66,8 +66,8 @@ export class SliderSettingComponent implements OnInit, OnChanges {
     this.input$
       .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
       .subscribe((strValue) => {
-        let value = parseInt(strValue, 10);
-        if (isNaN(value)) return;
+        let value = parseFloat(strValue);
+        if (!Number.isFinite(value)) return;
         value = Math.max(this.min, Math.min(this.max, value));
         if (value === this.value) return;
         this.value = value;

--- a/src-ui/app/components/slider-setting/slider-setting.component.ts
+++ b/src-ui/app/components/slider-setting/slider-setting.component.ts
@@ -69,11 +69,11 @@ export class SliderSettingComponent implements OnInit, OnChanges {
       .subscribe((strValue) => {
         let value = parseFloat(strValue);
         if (!Number.isFinite(value)) return;
-        const precision = floatPrecision(this.step);
-        const quotient = value / this.step;
+        const precision = Math.max(floatPrecision(this.min), floatPrecision(this.step));
+        const quotient = (value - this.min) / this.step;
         const epsilon = Number.EPSILON * 4 * Math.max(1, Math.abs(quotient));
         value = clamp(
-          ensurePrecision(Math.round(quotient + epsilon) * this.step, precision),
+          ensurePrecision(Math.round(quotient + epsilon) * this.step + this.min, precision),
           this.min,
           this.max
         );

--- a/src-ui/app/components/slider-setting/slider-setting.component.ts
+++ b/src-ui/app/components/slider-setting/slider-setting.component.ts
@@ -16,6 +16,7 @@ import { fade } from '../../utils/animations';
 import { debounceTime, Subject } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SliderComponent, SliderStyle } from '../slider/slider.component';
+import { clamp, ensurePrecision, floatPrecision } from '../../utils/number-utils';
 
 @Component({
   selector: 'app-slider-setting',
@@ -68,7 +69,11 @@ export class SliderSettingComponent implements OnInit, OnChanges {
       .subscribe((strValue) => {
         let value = parseFloat(strValue);
         if (!Number.isFinite(value)) return;
-        value = Math.max(this.min, Math.min(this.max, value));
+        value = clamp(
+          ensurePrecision(Math.round(value / this.step) * this.step, floatPrecision(this.step)),
+          this.min,
+          this.max
+        );
         if (value === this.value) return;
         this.value = value;
         this.valueChange.emit(value);


### PR DESCRIPTION
Typing a fractional chaperone fade distance silently stored a truncated integer. For example, `0.75` became `0`, and `1.4` became `1`.

The shared slider input parsed typed text with `parseInt`, which discards decimals. Every later layer already accepts fractional numbers.

The input now parses decimals, snaps them to the configured step relative to the configured minimum, handles floating-point ties with an epsilon, and clamps the result.

Validated with temporary component checks for chaperone values, integer and decimal steps, halfway and boundary values, non-zero minimums, clamping, empty input, and invalid input. Also passed Prettier, project ESLint, and the development UI build. The repository has no test builder or existing specs, so the component checks were temporary and are not committed.