### PR TITLE
fix(OYASUMIVR-46): handle bluetooth radio cycle failures

### DIFF
--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -104,6 +104,7 @@ windows = { version = "0.62.2", features = [
   "Win32_UI_WindowsAndMessaging",
   "Win32_System_LibraryLoader",
   "Win32_Graphics_Gdi",
+  "Devices_Enumeration",
   "Devices_Radios",
 ], default-features = false }
 windows-sys = { version = "0.61.2", features = [

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -642,7 +642,8 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
     let _guard = RADIO_RECOVERY_LOCK.lock().await;
     request_radio_access().await?;
     let radios = list_bluetooth_radios().await?;
-    let pending_ids = read_persisted_pending_restores();
+    let pending_ids = read_persisted_pending_restores()
+        .ok_or_else(|| String::from("failed to read pending bluetooth radio restores"))?;
     let mut cycle_results = Vec::new();
     for radio in &radios {
         cycle_results.push(cycle_radio(radio, &pending_ids).await);
@@ -783,11 +784,11 @@ async fn cycle_radio(radio: &BluetoothRadio, pending_ids: &[String]) -> RadioCyc
             persist_pending_restore(id);
             return cycle_error(Some(format!("the '{name}' radio {err}")));
         }
-        return RadioCycleResult {
-            id: Some(id.clone()),
-            error: None,
-            restored: true,
-        };
+        if !clear_persisted_pending_restore(id) {
+            return cycle_error(Some(format!(
+                "failed to clear the pending restore of the '{name}' radio"
+            )));
+        }
     }
     match radio.State() {
         Ok(RadioState::On) => {}
@@ -872,22 +873,38 @@ fn normalized_pending_restore_names(names: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn read_persisted_pending_restores_from(path: &std::path::Path) -> Vec<String> {
+fn read_persisted_pending_restores_from(path: &std::path::Path) -> std::io::Result<Vec<String>> {
     let contents = match std::fs::read_to_string(path) {
         Ok(contents) => contents,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
-        Err(err) => {
-            warn!("[Core] Failed to read pending bluetooth radio restores: {err}");
-            return Vec::new();
-        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
     };
-    match serde_json::from_str::<Vec<String>>(&contents) {
-        Ok(ids) => normalized_pending_restore_names(ids),
-        Err(err) => {
-            warn!("[Core] Failed to parse pending bluetooth radio restores: {err}");
-            Vec::new()
-        }
+    let ids = serde_json::from_str::<Vec<String>>(&contents)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    Ok(normalized_pending_restore_names(ids))
+}
+
+fn persist_pending_restore_from(path: &std::path::Path, id: &str) -> bool {
+    let Ok(mut ids) = read_persisted_pending_restores_from(path) else {
+        return false;
+    };
+    if ids.iter().any(|pending| pending == id) {
+        return true;
     }
+    ids.push(id.to_string());
+    write_persisted_pending_restores_to(path, &ids)
+}
+
+fn clear_persisted_pending_restore_from(path: &std::path::Path, id: &str) -> bool {
+    let Ok(mut ids) = read_persisted_pending_restores_from(path) else {
+        return false;
+    };
+    let before = ids.len();
+    ids.retain(|pending| pending != id);
+    if ids.len() == before {
+        return true;
+    }
+    write_persisted_pending_restores_to(path, &ids)
 }
 
 fn write_persisted_pending_restores_to(path: &std::path::Path, names: &[String]) -> bool {
@@ -911,12 +928,16 @@ fn write_persisted_pending_restores_to(path: &std::path::Path, names: &[String])
     file.persist(path).is_ok()
 }
 
-fn read_persisted_pending_restores() -> Vec<String> {
-    let Some(path) = pending_restore_path() else {
-        return Vec::new();
-    };
+fn read_persisted_pending_restores() -> Option<Vec<String>> {
+    let path = pending_restore_path()?;
     let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
-    read_persisted_pending_restores_from(&path)
+    match read_persisted_pending_restores_from(&path) {
+        Ok(ids) => Some(ids),
+        Err(err) => {
+            warn!("[Core] Failed to read pending bluetooth radio restores: {err}");
+            None
+        }
+    }
 }
 
 fn persist_pending_restore(name: &str) -> bool {
@@ -925,15 +946,7 @@ fn persist_pending_restore(name: &str) -> bool {
         return false;
     };
     let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
-    let mut names = read_persisted_pending_restores_from(&path);
-    if !names.iter().any(|pending| pending == name) {
-        names.push(name.to_string());
-        if !write_persisted_pending_restores_to(&path, &names) {
-            warn!("[Core] Failed to record a pending bluetooth radio restore");
-            return false;
-        }
-    }
-    true
+    persist_pending_restore_from(&path, name)
 }
 
 fn clear_persisted_pending_restore(id: &str) -> bool {
@@ -942,18 +955,7 @@ fn clear_persisted_pending_restore(id: &str) -> bool {
         return false;
     };
     let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
-    let mut ids = read_persisted_pending_restores_from(&path);
-    let before = ids.len();
-    ids.retain(|pending| pending != id);
-    if ids.len() == before {
-        return true;
-    }
-    if write_persisted_pending_restores_to(&path, &ids) {
-        true
-    } else {
-        warn!("[Core] Failed to clear a pending bluetooth radio restore");
-        false
-    }
+    clear_persisted_pending_restore_from(&path, id)
 }
 
 fn retain_persisted_pending_restores_from(
@@ -961,7 +963,9 @@ fn retain_persisted_pending_restores_from(
     snapshot: &[String],
     restored_ids: &[String],
 ) -> bool {
-    let current_ids = read_persisted_pending_restores_from(path);
+    let Ok(current_ids) = read_persisted_pending_restores_from(path) else {
+        return false;
+    };
     let ids = current_ids
         .into_iter()
         .filter(|id| {
@@ -984,7 +988,9 @@ fn retain_persisted_pending_restores(snapshot: &[String], restored_ids: &[String
 
 async fn restore_pending_radios() {
     let _guard = RADIO_RECOVERY_LOCK.lock().await;
-    let pending_ids = read_persisted_pending_restores();
+    let Some(pending_ids) = read_persisted_pending_restores() else {
+        return;
+    };
     if pending_ids.is_empty() {
         return;
     }
@@ -999,20 +1005,33 @@ async fn restore_pending_radios() {
             return;
         }
     };
+    let restore_results = join_all(
+        radios
+            .into_iter()
+            .filter(|radio| pending_ids.contains(&radio.id))
+            .map(|radio| async move {
+                let id = radio.id.clone();
+                let name = radio.name.clone();
+                warn!("[Core] Turning the '{name}' radio back on after a restart");
+                let restore =
+                    match timeout(RADIO_RESTORE_TIMEOUT, restore_radio_on(&radio.radio)).await {
+                        Ok(restore) => restore,
+                        Err(_) => Err(String::from("timed out")),
+                    };
+                (id, name, restore)
+            }),
+    )
+    .await;
     let mut seen_ids = Vec::new();
     let mut failed_ids = Vec::new();
-    for radio in radios {
-        if !pending_ids.contains(&radio.id) {
-            continue;
-        }
-        let name = radio.name.clone();
-        warn!("[Core] Turning the '{name}' radio back on after a restart");
-        if let Err(err) = restore_radio_on(&radio.radio).await {
-            failed_ids.push(radio.id.clone());
-            persist_pending_restore(&radio.id);
-            warn!("[Core] Failed to turn the '{name}' radio back on after a restart: {err}");
-        } else {
-            seen_ids.push(radio.id.clone());
+    for (id, name, restore) in restore_results {
+        match restore {
+            Ok(()) => seen_ids.push(id),
+            Err(err) => {
+                failed_ids.push(id.clone());
+                persist_pending_restore(&id);
+                warn!("[Core] Failed to turn the '{name}' radio back on after a restart: {err}");
+            }
         }
     }
     let restored_ids = seen_ids
@@ -1183,7 +1202,7 @@ mod tests {
 
         assert!(write_persisted_pending_restores_to(&path, &names));
         assert_eq!(
-            read_persisted_pending_restores_from(&path),
+            read_persisted_pending_restores_from(&path).unwrap(),
             vec![
                 String::from("radio"),
                 String::from("new\nline name"),
@@ -1196,12 +1215,39 @@ mod tests {
             &[String::new(), String::from("kept")]
         ));
         assert_eq!(
-            read_persisted_pending_restores_from(&path),
+            read_persisted_pending_restores_from(&path).unwrap(),
             vec![String::from("kept")]
         );
 
         assert!(write_persisted_pending_restores_to(&path, &[]));
-        assert!(read_persisted_pending_restores_from(&path).is_empty());
+        assert!(read_persisted_pending_restores_from(&path)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn pending_restore_helpers_change_only_existing_ids() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("pending-radio-restores");
+
+        assert!(persist_pending_restore_from(&path, "first"));
+        assert!(persist_pending_restore_from(&path, "first"));
+        assert!(persist_pending_restore_from(&path, "second"));
+        assert_eq!(
+            read_persisted_pending_restores_from(&path).unwrap(),
+            vec![String::from("first"), String::from("second")]
+        );
+
+        assert!(clear_persisted_pending_restore_from(&path, "missing"));
+        assert_eq!(
+            read_persisted_pending_restores_from(&path).unwrap(),
+            vec![String::from("first"), String::from("second")]
+        );
+        assert!(clear_persisted_pending_restore_from(&path, "first"));
+        assert_eq!(
+            read_persisted_pending_restores_from(&path).unwrap(),
+            vec![String::from("second")]
+        );
     }
 
     #[test]
@@ -1223,12 +1269,29 @@ mod tests {
             &[String::from("restored")]
         ));
         assert_eq!(
-            read_persisted_pending_restores_from(&path),
+            read_persisted_pending_restores_from(&path).unwrap(),
             vec![
                 String::from("missing"),
                 String::from("added-after-snapshot")
             ]
         );
+    }
+
+    #[test]
+    fn corrupt_pending_restore_file_is_never_replaced() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("pending-radio-restores");
+        std::fs::write(&path, "not json").unwrap();
+
+        assert!(read_persisted_pending_restores_from(&path).is_err());
+        assert!(!persist_pending_restore_from(&path, "radio"));
+        assert!(!clear_persisted_pending_restore_from(&path, "radio"));
+        assert!(!retain_persisted_pending_restores_from(
+            &path,
+            &[String::from("radio")],
+            &[String::from("radio")]
+        ));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "not json");
     }
 
     #[test]

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -65,6 +65,7 @@ static CONNECT_FAILURE_STREAK: AtomicU32 = AtomicU32::new(0);
 static LAST_RADIO_RECOVERY: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mutex::new(None));
 static PENDING_RESTORE_FILE_LOCK: LazyLock<std::sync::Mutex<()>> =
     LazyLock::new(|| std::sync::Mutex::new(()));
+static RADIO_RECOVERY_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const CONNECT_RETRY_COOLDOWN: Duration = Duration::from_secs(10);
@@ -75,17 +76,7 @@ const RADIO_RECOVERY_COOLDOWN: Duration = Duration::from_secs(300);
 const RADIO_ON_ATTEMPTS: u32 = 3;
 
 pub async fn init() {
-    // A crashed run may have left a radio turned off
-    tokio::task::spawn_blocking(|| {
-        let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        else {
-            warn!("[Core] Failed to start a runtime to restore pending bluetooth radios");
-            return;
-        };
-        runtime.block_on(restore_pending_radios());
-    });
+    restore_pending_radios().await;
     // Initialize adapter
     let manager = match Manager::new().await {
         Ok(manager) => manager,
@@ -639,41 +630,28 @@ async fn register_connect_failure(device_id: &PeripheralId) {
 }
 
 async fn cycle_bluetooth_radio() -> Result<(), String> {
-    use windows::Devices::Radios::{Radio, RadioAccessStatus};
-
-    let access = Radio::RequestAccessAsync()
-        .map_err(|e| e.to_string())?
-        .await
-        .map_err(|e| e.to_string())?;
-    if access != RadioAccessStatus::Allowed {
-        return Err(format!(
-            "radio access was refused before cycling ({access:?})"
-        ));
-    }
-
-    let radios = Radio::GetRadiosAsync()
-        .map_err(|e| e.to_string())?
-        .await
-        .map_err(|e| e.to_string())?;
-    let pending_names = read_persisted_pending_restores();
+    let _guard = RADIO_RECOVERY_LOCK.lock().await;
+    request_radio_access().await?;
+    let radios = list_bluetooth_radios().await?;
+    let pending_ids = read_persisted_pending_restores();
     let mut cycle_results = Vec::new();
-    for radio in radios {
-        cycle_results.push(cycle_radio(&radio, &pending_names).await);
+    for radio in &radios {
+        cycle_results.push(cycle_radio(radio, &pending_ids).await);
     }
     for result in &cycle_results {
-        let Some(name) = result.name.as_deref() else {
+        let Some(id) = result.id.as_deref() else {
             continue;
         };
         if !cycle_results
             .iter()
-            .any(|result| result.name.as_deref() == Some(name) && result.restored)
+            .any(|result| result.id.as_deref() == Some(id) && result.restored)
             || cycle_results
                 .iter()
-                .any(|result| result.name.as_deref() == Some(name) && result.error.is_some())
+                .any(|result| result.id.as_deref() == Some(id) && result.error.is_some())
         {
             continue;
         }
-        clear_persisted_pending_restore(name);
+        clear_persisted_pending_restore(id);
     }
     let failures = cycle_results
         .into_iter()
@@ -687,49 +665,78 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
 }
 
 struct RadioCycleResult {
-    name: Option<String>,
+    id: Option<String>,
     error: Option<String>,
     restored: bool,
 }
 
-async fn cycle_radio(
-    radio: &windows::Devices::Radios::Radio,
-    pending_names: &[String],
-) -> RadioCycleResult {
-    use windows::Devices::Radios::{RadioAccessStatus, RadioKind, RadioState};
+struct BluetoothRadio {
+    id: String,
+    name: String,
+    radio: windows::Devices::Radios::Radio,
+}
 
-    let kind = match radio.Kind() {
-        Ok(kind) => kind,
-        Err(err) => {
-            warn!("[Core] Failed to inspect a radio, skipping it: {err}");
-            return RadioCycleResult {
-                name: None,
-                error: None,
-                restored: false,
-            };
-        }
-    };
-    if kind != RadioKind::Bluetooth {
-        return RadioCycleResult {
-            name: None,
-            error: None,
-            restored: false,
-        };
+async fn request_radio_access() -> Result<(), String> {
+    use windows::Devices::Radios::{Radio, RadioAccessStatus};
+
+    let access = Radio::RequestAccessAsync()
+        .map_err(|e| e.to_string())?
+        .await
+        .map_err(|e| e.to_string())?;
+    if access == RadioAccessStatus::Allowed {
+        Ok(())
+    } else {
+        Err(format!("radio access was refused ({access:?})"))
     }
-    let name = radio_name(radio);
+}
+
+async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
+    use windows::Devices::Enumeration::DeviceInformation;
+    use windows::Devices::Radios::{Radio, RadioKind};
+
+    let selector = Radio::GetDeviceSelector().map_err(|e| e.to_string())?;
+    let devices = DeviceInformation::FindAllAsyncAqsFilter(&selector)
+        .map_err(|e| e.to_string())?
+        .await
+        .map_err(|e| e.to_string())?;
+    let count = devices.Size().map_err(|e| e.to_string())?;
+    let mut radios = Vec::new();
+    for index in 0..count {
+        let device = devices.GetAt(index).map_err(|e| e.to_string())?;
+        let id = device.Id().map_err(|e| e.to_string())?;
+        let radio = Radio::FromIdAsync(&id)
+            .map_err(|e| e.to_string())?
+            .await
+            .map_err(|e| e.to_string())?;
+        if radio.Kind().map_err(|e| e.to_string())? != RadioKind::Bluetooth {
+            continue;
+        }
+        radios.push(BluetoothRadio {
+            id: id.to_string(),
+            name: radio_name(&radio),
+            radio,
+        });
+    }
+    Ok(radios)
+}
+
+async fn cycle_radio(radio: &BluetoothRadio, pending_ids: &[String]) -> RadioCycleResult {
+    use windows::Devices::Radios::{RadioAccessStatus, RadioState};
+
+    let BluetoothRadio { id, name, radio } = radio;
     let cycle_error = |error: Option<String>| RadioCycleResult {
-        name: Some(name.clone()),
+        id: Some(id.clone()),
         error,
         restored: false,
     };
-    if pending_names.contains(&name) {
+    if pending_ids.contains(id) {
         warn!("[Core] Turning the '{name}' radio back on after a failed recovery");
         if let Err(err) = restore_radio_on(radio).await {
-            persist_pending_restore(&name);
+            persist_pending_restore(id);
             return cycle_error(Some(format!("the '{name}' radio {err}")));
         }
         return RadioCycleResult {
-            name: Some(name),
+            id: Some(id.clone()),
             error: None,
             restored: true,
         };
@@ -756,7 +763,7 @@ async fn cycle_radio(
             "turning the '{name}' radio back on was refused before cycling ({probe:?})"
         )));
     }
-    if !persist_pending_restore(&name) {
+    if !persist_pending_restore(id) {
         return cycle_error(Some(format!(
             "failed to record the pending restore of the '{name}' radio"
         )));
@@ -788,7 +795,7 @@ async fn cycle_radio(
         return cycle_error(Some(format!("the '{name}' radio {err}")));
     }
     RadioCycleResult {
-        name: Some(name),
+        id: Some(id.clone()),
         error: None,
         restored: true,
     }
@@ -886,68 +893,70 @@ fn clear_persisted_pending_restore(name: &str) {
     }
 }
 
-fn retain_persisted_pending_restores(snapshot: &[String], failed_names: &[String]) {
+fn retain_persisted_pending_restores_from(
+    path: &std::path::Path,
+    snapshot: &[String],
+    restored_ids: &[String],
+) -> bool {
+    let current_ids = read_persisted_pending_restores_from(path);
+    let ids = current_ids
+        .into_iter()
+        .filter(|id| {
+            !snapshot.iter().any(|pending| pending == id)
+                || !restored_ids.iter().any(|restored| restored == id)
+        })
+        .collect::<Vec<_>>();
+    write_persisted_pending_restores_to(path, &ids)
+}
+
+fn retain_persisted_pending_restores(snapshot: &[String], restored_ids: &[String]) {
     let Some(path) = pending_restore_path() else {
         return;
     };
     let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
-    let current_names = read_persisted_pending_restores_from(&path);
-    let names = current_names
-        .into_iter()
-        .filter(|name| {
-            !snapshot.iter().any(|pending| pending == name)
-                || failed_names.iter().any(|pending| pending == name)
-        })
-        .collect::<Vec<_>>();
-    if !write_persisted_pending_restores_to(&path, &names) {
+    if !retain_persisted_pending_restores_from(&path, snapshot, restored_ids) {
         warn!("[Core] Failed to update pending bluetooth radio restores");
     }
 }
 
 async fn restore_pending_radios() {
-    use windows::Devices::Radios::{Radio, RadioKind};
-    let names = read_persisted_pending_restores();
-    if names.is_empty() {
+    let _guard = RADIO_RECOVERY_LOCK.lock().await;
+    let pending_ids = read_persisted_pending_restores();
+    if pending_ids.is_empty() {
         return;
     }
-    let radios = match Radio::GetRadiosAsync() {
-        Ok(operation) => {
-            match operation.await {
-                Ok(radios) => radios,
-                Err(err) => {
-                    warn!("[Core] Failed to list radios to restore pending bluetooth recoveries: {err}");
-                    return;
-                }
-            }
-        }
+    if let Err(err) = request_radio_access().await {
+        warn!("[Core] Failed to get radio access for pending bluetooth recoveries: {err}");
+        return;
+    }
+    let radios = match list_bluetooth_radios().await {
+        Ok(radios) => radios,
         Err(err) => {
-            warn!(
-                "[Core] Failed to request the radio list for pending bluetooth recoveries: {err}"
-            );
+            warn!("[Core] Failed to list radios for pending bluetooth recoveries: {err}");
             return;
         }
     };
-    let mut failed_names = Vec::new();
+    let mut seen_ids = Vec::new();
+    let mut failed_ids = Vec::new();
     for radio in radios {
-        let kind = match radio.Kind() {
-            Ok(kind) => kind,
-            Err(_) => continue,
-        };
-        if kind != RadioKind::Bluetooth {
+        if !pending_ids.contains(&radio.id) {
             continue;
         }
-        let name = radio_name(&radio);
-        if !names.contains(&name) {
-            continue;
-        }
+        let name = radio.name.clone();
         warn!("[Core] Turning the '{name}' radio back on after a restart");
-        if let Err(err) = restore_radio_on(&radio).await {
-            failed_names.push(name.clone());
-            persist_pending_restore(&name);
+        if let Err(err) = restore_radio_on(&radio.radio).await {
+            failed_ids.push(radio.id.clone());
+            persist_pending_restore(&radio.id);
             warn!("[Core] Failed to turn the '{name}' radio back on after a restart: {err}");
+        } else {
+            seen_ids.push(radio.id.clone());
         }
     }
-    retain_persisted_pending_restores(&names, &failed_names);
+    let restored_ids = seen_ids
+        .into_iter()
+        .filter(|id| !failed_ids.contains(id))
+        .collect::<Vec<_>>();
+    retain_persisted_pending_restores(&pending_ids, &restored_ids);
 }
 
 async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
@@ -1098,7 +1107,6 @@ async fn reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn pending_restore_persistence_round_trips_names() {
         let directory = tempfile::tempdir().unwrap();
@@ -1122,15 +1130,42 @@ mod tests {
 
         assert!(write_persisted_pending_restores_to(
             &path,
-            &[String::from("empty names are dropped")]
+            &[String::new(), String::from("kept")]
         ));
         assert_eq!(
             read_persisted_pending_restores_from(&path),
-            vec![String::from("empty names are dropped")]
+            vec![String::from("kept")]
         );
 
         assert!(write_persisted_pending_restores_to(&path, &[]));
         assert!(read_persisted_pending_restores_from(&path).is_empty());
+    }
+
+    #[test]
+    fn pending_restore_retention_preserves_unrestored_ids() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("pending-radio-restores");
+        write_persisted_pending_restores_to(
+            &path,
+            &[
+                String::from("restored"),
+                String::from("missing"),
+                String::from("added-after-snapshot"),
+            ],
+        );
+
+        assert!(retain_persisted_pending_restores_from(
+            &path,
+            &[String::from("restored"), String::from("missing"),],
+            &[String::from("restored")]
+        ));
+        assert_eq!(
+            read_persisted_pending_restores_from(&path),
+            vec![
+                String::from("missing"),
+                String::from("added-after-snapshot")
+            ]
+        );
     }
 
     #[test]

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -63,8 +63,8 @@ static CONNECT_BACKOFFS: LazyLock<std::sync::Mutex<HashMap<PeripheralId, (u32, I
     LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 static CONNECT_FAILURE_STREAK: AtomicU32 = AtomicU32::new(0);
 static LAST_RADIO_RECOVERY: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mutex::new(None));
-static PENDING_RADIO_RESTORES: LazyLock<Mutex<Vec<windows::Devices::Radios::Radio>>> =
-    LazyLock::new(|| Mutex::new(Vec::new()));
+static PENDING_RESTORE_FILE_LOCK: LazyLock<std::sync::Mutex<()>> =
+    LazyLock::new(|| std::sync::Mutex::new(()));
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const CONNECT_RETRY_COOLDOWN: Duration = Duration::from_secs(10);
@@ -75,6 +75,17 @@ const RADIO_RECOVERY_COOLDOWN: Duration = Duration::from_secs(300);
 const RADIO_ON_ATTEMPTS: u32 = 3;
 
 pub async fn init() {
+    // A crashed run may have left a radio turned off
+    tokio::task::spawn_blocking(|| {
+        let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            warn!("[Core] Failed to start a runtime to restore pending bluetooth radios");
+            return;
+        };
+        runtime.block_on(restore_pending_radios());
+    });
     // Initialize adapter
     let manager = match Manager::new().await {
         Ok(manager) => manager,
@@ -100,17 +111,6 @@ pub async fn init() {
     }
     *MANAGER.lock().await = Some(manager);
     set_lighthouse_status(LighthouseStatus::Ready).await;
-    // A crashed run may have left a radio turned off
-    tokio::task::spawn_blocking(|| {
-        let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        else {
-            warn!("[Core] Failed to start a runtime to restore pending bluetooth radios");
-            return;
-        };
-        runtime.block_on(restore_pending_radios());
-    });
     // Poll the status of connected lighthouses every few seconds in a separate task
     tokio::spawn(async move {
         loop {
@@ -655,12 +655,30 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
         .map_err(|e| e.to_string())?
         .await
         .map_err(|e| e.to_string())?;
-    let mut failures = Vec::new();
+    let pending_names = read_persisted_pending_restores();
+    let mut cycle_results = Vec::new();
     for radio in radios {
-        if let Err(err) = cycle_radio(&radio).await {
-            failures.push(err);
-        }
+        cycle_results.push(cycle_radio(&radio, &pending_names).await);
     }
+    for result in &cycle_results {
+        let Some(name) = result.name.as_deref() else {
+            continue;
+        };
+        if !cycle_results
+            .iter()
+            .any(|result| result.name.as_deref() == Some(name) && result.restored)
+            || cycle_results
+                .iter()
+                .any(|result| result.name.as_deref() == Some(name) && result.error.is_some())
+        {
+            continue;
+        }
+        clear_persisted_pending_restore(name);
+    }
+    let failures = cycle_results
+        .into_iter()
+        .filter_map(|result| result.error)
+        .collect::<Vec<_>>();
     if failures.is_empty() {
         Ok(())
     } else {
@@ -668,61 +686,93 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
     }
 }
 
-async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
+struct RadioCycleResult {
+    name: Option<String>,
+    error: Option<String>,
+    restored: bool,
+}
+
+async fn cycle_radio(
+    radio: &windows::Devices::Radios::Radio,
+    pending_names: &[String],
+) -> RadioCycleResult {
     use windows::Devices::Radios::{RadioAccessStatus, RadioKind, RadioState};
 
     let kind = match radio.Kind() {
         Ok(kind) => kind,
         Err(err) => {
             warn!("[Core] Failed to inspect a radio, skipping it: {err}");
-            return Ok(());
+            return RadioCycleResult {
+                name: None,
+                error: None,
+                restored: false,
+            };
         }
     };
     if kind != RadioKind::Bluetooth {
-        return Ok(());
+        return RadioCycleResult {
+            name: None,
+            error: None,
+            restored: false,
+        };
     }
-    let name = radio
-        .Name()
-        .map(|name| name.to_string())
-        .unwrap_or_else(|_| String::from("bluetooth radio"));
-    if drain_pending_restore(radio).await {
+    let name = radio_name(radio);
+    let cycle_error = |error: Option<String>| RadioCycleResult {
+        name: Some(name.clone()),
+        error,
+        restored: false,
+    };
+    if pending_names.contains(&name) {
         warn!("[Core] Turning the '{name}' radio back on after a failed recovery");
         if let Err(err) = restore_radio_on(radio).await {
-            record_pending_restore(radio, &name).await;
-            return Err(format!("the '{name}' radio {err}"));
+            persist_pending_restore(&name);
+            return cycle_error(Some(format!("the '{name}' radio {err}")));
         }
-        clear_persisted_pending_restore(&name);
+        return RadioCycleResult {
+            name: Some(name),
+            error: None,
+            restored: true,
+        };
     }
     match radio.State() {
         Ok(RadioState::On) => {}
-        Ok(_) => return Ok(()),
+        Ok(_) => return cycle_error(None),
         Err(err) => {
-            return Err(format!(
+            return cycle_error(Some(format!(
                 "failed to read the state of the '{name}' radio: {err}"
-            ))
+            )));
         }
     }
-    let probe = radio
-        .SetStateAsync(RadioState::On)
-        .map_err(|e| e.to_string())?
-        .await
-        .map_err(|e| e.to_string())?;
+    let probe = match radio.SetStateAsync(RadioState::On) {
+        Ok(operation) => operation.await.map_err(|e| e.to_string()),
+        Err(err) => Err(err.to_string()),
+    };
+    let probe = match probe {
+        Ok(probe) => probe,
+        Err(err) => return cycle_error(Some(err)),
+    };
     if probe != RadioAccessStatus::Allowed {
-        return Err(format!(
+        return cycle_error(Some(format!(
             "turning the '{name}' radio back on was refused before cycling ({probe:?})"
-        ));
+        )));
     }
-    persist_pending_restore(&name);
-    let status = radio
-        .SetStateAsync(RadioState::Off)
-        .map_err(|e| e.to_string())?
-        .await
-        .map_err(|e| e.to_string())?;
+    if !persist_pending_restore(&name) {
+        return cycle_error(Some(format!(
+            "failed to record the pending restore of the '{name}' radio"
+        )));
+    }
+    let status = match radio.SetStateAsync(RadioState::Off) {
+        Ok(operation) => operation.await.map_err(|e| e.to_string()),
+        Err(err) => Err(err.to_string()),
+    };
+    let status = match status {
+        Ok(status) => status,
+        Err(err) => return cycle_error(Some(err)),
+    };
     if status != RadioAccessStatus::Allowed {
-        clear_persisted_pending_restore(&name);
-        return Err(format!(
+        return cycle_error(Some(format!(
             "turning the '{name}' radio off was refused ({status:?})"
-        ));
+        )));
     }
     sleep(Duration::from_secs(3)).await;
     match radio.State() {
@@ -735,73 +785,122 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
         }
     }
     if let Err(err) = restore_radio_on(radio).await {
-        record_pending_restore(radio, &name).await;
-        return Err(format!("the '{name}' radio {err}"));
+        return cycle_error(Some(format!("the '{name}' radio {err}")));
     }
-    clear_persisted_pending_restore(&name);
-    Ok(())
+    RadioCycleResult {
+        name: Some(name),
+        error: None,
+        restored: true,
+    }
 }
 
-async fn drain_pending_restore(radio: &windows::Devices::Radios::Radio) -> bool {
-    let mut pending = PENDING_RADIO_RESTORES.lock().await;
-    let Some(index) = pending.iter().position(|pending| pending == radio) else {
-        return false;
-    };
-    pending.remove(index);
-    true
-}
-
-async fn record_pending_restore(radio: &windows::Devices::Radios::Radio, name: &str) {
-    PENDING_RADIO_RESTORES.lock().await.push(radio.clone());
-    persist_pending_restore(name);
+fn radio_name(radio: &windows::Devices::Radios::Radio) -> String {
+    radio
+        .Name()
+        .ok()
+        .and_then(|name| {
+            let name = name.to_string();
+            (!name.is_empty()).then_some(name)
+        })
+        .unwrap_or_else(|| String::from("bluetooth radio"))
 }
 
 fn pending_restore_path() -> Option<PathBuf> {
     dirs::data_dir().map(|dir| dir.join("co.raphii.oyasumi").join("pending-radio-restores"))
 }
 
+fn normalized_pending_restore_names(names: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    names
+        .into_iter()
+        .filter(|name| !name.is_empty() && seen.insert(name.clone()))
+        .collect()
+}
+
+fn read_persisted_pending_restores_from(path: &std::path::Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<Vec<String>>(&contents).ok())
+        .map(normalized_pending_restore_names)
+        .unwrap_or_default()
+}
+
+fn write_persisted_pending_restores_to(path: &std::path::Path, names: &[String]) -> bool {
+    use std::io::Write;
+
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return false;
+    }
+    let Ok(contents) = serde_json::to_vec(&normalized_pending_restore_names(names.to_vec())) else {
+        return false;
+    };
+    let Ok(mut file) = tempfile::NamedTempFile::new_in(parent) else {
+        return false;
+    };
+    if file.write_all(&contents).is_err() || file.as_file().sync_all().is_err() {
+        return false;
+    }
+    file.persist(path).is_ok()
+}
+
 fn read_persisted_pending_restores() -> Vec<String> {
     let Some(path) = pending_restore_path() else {
         return Vec::new();
     };
-    std::fs::read_to_string(path)
-        .map(|content| {
-            content
-                .lines()
-                .map(str::to_string)
-                .filter(|name| !name.is_empty())
-                .collect()
-        })
-        .unwrap_or_default()
+    let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
+    read_persisted_pending_restores_from(&path)
 }
 
-fn write_persisted_pending_restores(names: &[String]) {
+fn persist_pending_restore(name: &str) -> bool {
     let Some(path) = pending_restore_path() else {
-        return;
+        warn!("[Core] Failed to locate the pending bluetooth radio restore file");
+        return false;
     };
-    let Some(parent) = path.parent() else {
-        return;
-    };
-    if std::fs::create_dir_all(parent).is_err() {
-        return;
-    }
-    let _ = std::fs::write(&path, names.join("\n"));
-}
-
-fn persist_pending_restore(name: &str) {
-    let mut names = read_persisted_pending_restores();
+    let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
+    let mut names = read_persisted_pending_restores_from(&path);
     if !names.iter().any(|pending| pending == name) {
         names.push(name.to_string());
-        write_persisted_pending_restores(&names);
+        if !write_persisted_pending_restores_to(&path, &names) {
+            warn!("[Core] Failed to record a pending bluetooth radio restore");
+            return false;
+        }
     }
+    true
 }
 
 fn clear_persisted_pending_restore(name: &str) {
-    let mut names = read_persisted_pending_restores();
+    let Some(path) = pending_restore_path() else {
+        return;
+    };
+    let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
+    let mut names = read_persisted_pending_restores_from(&path);
     let before = names.len();
     names.retain(|pending| pending != name);
     if names.len() != before {
-        write_persisted_pending_restores(&names);
+        if !write_persisted_pending_restores_to(&path, &names) {
+            warn!("[Core] Failed to clear a pending bluetooth radio restore");
+        }
+    }
+}
+
+fn retain_persisted_pending_restores(snapshot: &[String], failed_names: &[String]) {
+    let Some(path) = pending_restore_path() else {
+        return;
+    };
+    let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
+    let current_names = read_persisted_pending_restores_from(&path);
+    let names = current_names
+        .into_iter()
+        .filter(|name| {
+            !snapshot.iter().any(|pending| pending == name)
+                || failed_names.iter().any(|pending| pending == name)
+        })
+        .collect::<Vec<_>>();
+    if !write_persisted_pending_restores_to(&path, &names) {
+        warn!("[Core] Failed to update pending bluetooth radio restores");
     }
 }
 
@@ -828,6 +927,7 @@ async fn restore_pending_radios() {
             return;
         }
     };
+    let mut failed_names = Vec::new();
     for radio in radios {
         let kind = match radio.Kind() {
             Ok(kind) => kind,
@@ -836,21 +936,18 @@ async fn restore_pending_radios() {
         if kind != RadioKind::Bluetooth {
             continue;
         }
-        let name = radio
-            .Name()
-            .map(|name| name.to_string())
-            .unwrap_or_else(|_| String::from("bluetooth radio"));
+        let name = radio_name(&radio);
         if !names.contains(&name) {
             continue;
         }
         warn!("[Core] Turning the '{name}' radio back on after a restart");
         if let Err(err) = restore_radio_on(&radio).await {
-            record_pending_restore(&radio, &name).await;
+            failed_names.push(name.clone());
+            persist_pending_restore(&name);
             warn!("[Core] Failed to turn the '{name}' radio back on after a restart: {err}");
-        } else {
-            clear_persisted_pending_restore(&name);
         }
     }
+    retain_persisted_pending_restores(&names, &failed_names);
 }
 
 async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
@@ -1001,6 +1098,40 @@ async fn reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pending_restore_persistence_round_trips_names() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("pending-radio-restores");
+        let names = vec![
+            String::from("radio"),
+            String::from("radio"),
+            String::from("new\nline name"),
+            String::from(" spaced name "),
+        ];
+
+        assert!(write_persisted_pending_restores_to(&path, &names));
+        assert_eq!(
+            read_persisted_pending_restores_from(&path),
+            vec![
+                String::from("radio"),
+                String::from("new\nline name"),
+                String::from(" spaced name ")
+            ]
+        );
+
+        assert!(write_persisted_pending_restores_to(
+            &path,
+            &[String::from("empty names are dropped")]
+        ));
+        assert_eq!(
+            read_persisted_pending_restores_from(&path),
+            vec![String::from("empty names are dropped")]
+        );
+
+        assert!(write_persisted_pending_restores_to(&path, &[]));
+        assert!(read_persisted_pending_restores_from(&path).is_empty());
+    }
 
     #[test]
     fn connect_backoff_grows_and_caps() {

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -666,7 +666,15 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
     }
     let name = radio
         .Name()
-        .map_err(|e| format!("failed to name a bluetooth radio: {e}"))?;
+        .map(|name| name.to_string())
+        .unwrap_or_else(|_| String::from("bluetooth radio"));
+    match radio.State() {
+        Ok(RadioState::Off) | Ok(RadioState::Disabled) => return Ok(()),
+        Ok(_) => {}
+        Err(err) => {
+            warn!("[Core] Failed to read the bluetooth radio state before cycling it: {err}");
+        }
+    }
     let probe = radio
         .SetStateAsync(RadioState::On)
         .map_err(|e| e.to_string())?
@@ -683,7 +691,9 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
         .await
         .map_err(|e| e.to_string())?;
     if status != RadioAccessStatus::Allowed {
-        return Err(format!("turning the '{name}' radio off was refused ({status:?})"));
+        return Err(format!(
+            "turning the '{name}' radio off was refused ({status:?})"
+        ));
     }
     sleep(Duration::from_secs(3)).await;
     restore_radio_on(radio)
@@ -698,11 +708,20 @@ async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(),
         if attempt > 1 {
             sleep(Duration::from_secs(3)).await;
         }
-        let status = radio
-            .SetStateAsync(RadioState::On)
-            .map_err(|e| e.to_string())?
-            .await
-            .map_err(|e| e.to_string())?;
+        let operation = match radio.SetStateAsync(RadioState::On) {
+            Ok(operation) => operation,
+            Err(err) => {
+                warn!("[Core] Failed to request turning the bluetooth radio back on (attempt {attempt}/{RADIO_ON_ATTEMPTS}): {err}");
+                continue;
+            }
+        };
+        let status = match operation.await {
+            Ok(status) => status,
+            Err(err) => {
+                warn!("[Core] Turning the bluetooth radio back on failed (attempt {attempt}/{RADIO_ON_ATTEMPTS}): {err}");
+                continue;
+            }
+        };
         if status != RadioAccessStatus::Allowed {
             warn!("[Core] Turning the bluetooth radio back on was refused (attempt {attempt}/{RADIO_ON_ATTEMPTS}): {status:?}");
             continue;

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -641,27 +641,20 @@ async fn register_connect_failure(device_id: &PeripheralId) {
 async fn cycle_bluetooth_radio() -> Result<(), String> {
     let _guard = RADIO_RECOVERY_LOCK.lock().await;
     request_radio_access().await?;
-    let radios = list_bluetooth_radios().await?;
+    let listing = list_bluetooth_radios().await?;
+    let radios = listing.radios;
     let pending_ids = read_persisted_pending_restores()
         .ok_or_else(|| String::from("failed to read pending bluetooth radio restores"))?;
     let mut cycle_results = Vec::new();
     for radio in &radios {
         cycle_results.push(cycle_radio(radio, &pending_ids).await);
     }
-    let failed_ids = cycle_results
-        .iter()
-        .filter(|result| result.error.is_some())
-        .filter_map(|result| result.id.clone())
-        .collect::<HashSet<_>>();
     let restored_ids = cycle_results
         .iter()
         .filter(|result| result.restored)
         .filter_map(|result| result.id.clone())
         .collect::<Vec<_>>();
     for id in restored_ids {
-        if failed_ids.contains(&id) {
-            continue;
-        }
         if !clear_persisted_pending_restore(&id) {
             if let Some(result) = cycle_results
                 .iter_mut()
@@ -690,6 +683,11 @@ struct RadioCycleResult {
     restored: bool,
 }
 
+struct BluetoothRadioListing {
+    radios: Vec<BluetoothRadio>,
+    complete: bool,
+}
+
 struct BluetoothRadio {
     id: String,
     name: String,
@@ -710,7 +708,7 @@ async fn request_radio_access() -> Result<(), String> {
     }
 }
 
-async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
+async fn list_bluetooth_radios() -> Result<BluetoothRadioListing, String> {
     use windows::Devices::Enumeration::DeviceInformation;
     use windows::Devices::Radios::{Radio, RadioKind};
 
@@ -721,11 +719,13 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
         .map_err(|e| e.to_string())?;
     let count = devices.Size().map_err(|e| e.to_string())?;
     let mut radios = Vec::new();
+    let mut complete = true;
     for index in 0..count {
         let device = match devices.GetAt(index) {
             Ok(device) => device,
             Err(err) => {
                 warn!("[Core] Failed to inspect a radio while listing bluetooth radios: {err}");
+                complete = false;
                 continue;
             }
         };
@@ -733,6 +733,7 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
             Ok(id) => id,
             Err(err) => {
                 warn!("[Core] Failed to read a radio device id: {err}");
+                complete = false;
                 continue;
             }
         };
@@ -740,6 +741,7 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
             Ok(operation) => operation,
             Err(err) => {
                 warn!("[Core] Failed to open a radio by device id: {err}");
+                complete = false;
                 continue;
             }
         };
@@ -747,6 +749,7 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
             Ok(radio) => radio,
             Err(err) => {
                 warn!("[Core] Failed to open a radio by device id: {err}");
+                complete = false;
                 continue;
             }
         };
@@ -754,6 +757,7 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
             Ok(kind) => kind,
             Err(err) => {
                 warn!("[Core] Failed to inspect an opened radio: {err}");
+                complete = false;
                 continue;
             }
         };
@@ -766,7 +770,7 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
             radio,
         });
     }
-    Ok(radios)
+    Ok(BluetoothRadioListing { radios, complete })
 }
 
 async fn cycle_radio(radio: &BluetoothRadio, pending_ids: &[String]) -> RadioCycleResult {
@@ -783,11 +787,6 @@ async fn cycle_radio(radio: &BluetoothRadio, pending_ids: &[String]) -> RadioCyc
         if let Err(err) = restore_radio_on(radio).await {
             persist_pending_restore(id);
             return cycle_error(Some(format!("the '{name}' radio {err}")));
-        }
-        if !clear_persisted_pending_restore(id) {
-            return cycle_error(Some(format!(
-                "failed to clear the pending restore of the '{name}' radio"
-            )));
         }
     }
     match radio.State() {
@@ -879,9 +878,13 @@ fn read_persisted_pending_restores_from(path: &std::path::Path) -> std::io::Resu
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
     };
-    let ids = serde_json::from_str::<Vec<String>>(&contents)
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    Ok(normalized_pending_restore_names(ids))
+    match serde_json::from_str::<Vec<String>>(&contents) {
+        Ok(ids) => Ok(normalized_pending_restore_names(ids)),
+        Err(err) => {
+            warn!("[Core] Failed to parse pending bluetooth radio restores: {err}");
+            Ok(Vec::new())
+        }
+    }
 }
 
 fn persist_pending_restore_from(path: &std::path::Path, id: &str) -> bool {
@@ -998,47 +1001,68 @@ async fn restore_pending_radios() {
         warn!("[Core] Failed to get radio access for pending bluetooth recoveries: {err}");
         return;
     }
-    let radios = match list_bluetooth_radios().await {
-        Ok(radios) => radios,
+    let listing = match list_bluetooth_radios().await {
+        Ok(listing) => listing,
         Err(err) => {
             warn!("[Core] Failed to list radios for pending bluetooth recoveries: {err}");
             return;
         }
     };
+    let enumeration_complete = listing.complete;
+    let available_ids = listing
+        .radios
+        .iter()
+        .map(|radio| radio.id.clone())
+        .collect::<HashSet<_>>();
     let restore_results = join_all(
-        radios
+        listing
+            .radios
             .into_iter()
             .filter(|radio| pending_ids.contains(&radio.id))
             .map(|radio| async move {
                 let id = radio.id.clone();
                 let name = radio.name.clone();
                 warn!("[Core] Turning the '{name}' radio back on after a restart");
-                let restore =
-                    match timeout(RADIO_RESTORE_TIMEOUT, restore_radio_on(&radio.radio)).await {
-                        Ok(restore) => restore,
-                        Err(_) => Err(String::from("timed out")),
-                    };
+                let restore = restore_radio_on(&radio.radio).await;
                 (id, name, restore)
             }),
     )
     .await;
     let mut seen_ids = Vec::new();
-    let mut failed_ids = Vec::new();
     for (id, name, restore) in restore_results {
         match restore {
             Ok(()) => seen_ids.push(id),
             Err(err) => {
-                failed_ids.push(id.clone());
                 persist_pending_restore(&id);
                 warn!("[Core] Failed to turn the '{name}' radio back on after a restart: {err}");
             }
         }
     }
-    let restored_ids = seen_ids
-        .into_iter()
-        .filter(|id| !failed_ids.contains(id))
-        .collect::<Vec<_>>();
+    let restored_ids = pending_restore_clear_ids(
+        &pending_ids,
+        &seen_ids,
+        &available_ids,
+        enumeration_complete,
+    );
     retain_persisted_pending_restores(&pending_ids, &restored_ids);
+}
+
+fn pending_restore_clear_ids(
+    pending_ids: &[String],
+    restored_ids: &[String],
+    available_ids: &HashSet<String>,
+    enumeration_complete: bool,
+) -> Vec<String> {
+    let mut ids = restored_ids.to_vec();
+    if enumeration_complete {
+        ids.extend(
+            pending_ids
+                .iter()
+                .filter(|id| !available_ids.contains(*id))
+                .cloned(),
+        );
+    }
+    ids
 }
 
 async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
@@ -1278,20 +1302,35 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_pending_restore_file_is_never_replaced() {
+    fn corrupt_pending_restore_file_repairs_on_write() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("pending-radio-restores");
         std::fs::write(&path, "not json").unwrap();
 
-        assert!(read_persisted_pending_restores_from(&path).is_err());
-        assert!(!persist_pending_restore_from(&path, "radio"));
-        assert!(!clear_persisted_pending_restore_from(&path, "radio"));
-        assert!(!retain_persisted_pending_restores_from(
-            &path,
-            &[String::from("radio")],
-            &[String::from("radio")]
-        ));
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "not json");
+        assert!(read_persisted_pending_restores_from(&path)
+            .unwrap()
+            .is_empty());
+        assert!(persist_pending_restore_from(&path, "radio"));
+        assert!(clear_persisted_pending_restore_from(&path, "radio"));
+        assert!(read_persisted_pending_restores_from(&path)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn stale_pending_restores_clear_only_after_complete_enumeration() {
+        let pending_ids = vec![String::from("present"), String::from("stale")];
+        let restored_ids = vec![String::from("present")];
+        let available_ids = HashSet::from([String::from("present")]);
+
+        assert_eq!(
+            pending_restore_clear_ids(&pending_ids, &restored_ids, &available_ids, true),
+            vec![String::from("present"), String::from("stale")]
+        );
+        assert_eq!(
+            pending_restore_clear_ids(&pending_ids, &restored_ids, &available_ids, false),
+            vec![String::from("present")]
+        );
     }
 
     #[test]

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -69,6 +69,7 @@ const CONNECT_BACKOFF_MAX: Duration = Duration::from_secs(300);
 // Failing connects to every device at once is the signature of a wedged stack
 const RADIO_RECOVERY_THRESHOLD: u32 = 6;
 const RADIO_RECOVERY_COOLDOWN: Duration = Duration::from_secs(300);
+const RADIO_ON_ATTEMPTS: u32 = 3;
 
 pub async fn init() {
     // Initialize adapter
@@ -624,29 +625,96 @@ async fn register_connect_failure(device_id: &PeripheralId) {
 }
 
 async fn cycle_bluetooth_radio() -> Result<(), String> {
-    use windows::Devices::Radios::{Radio, RadioKind, RadioState};
+    use windows::Devices::Radios::{Radio, RadioAccessStatus};
+
+    let access = Radio::RequestAccessAsync()
+        .map_err(|e| e.to_string())?
+        .await
+        .map_err(|e| e.to_string())?;
+    if access != RadioAccessStatus::Allowed {
+        return Err(format!(
+            "radio access was refused before cycling ({access:?})"
+        ));
+    }
+
     let radios = Radio::GetRadiosAsync()
         .map_err(|e| e.to_string())?
         .await
         .map_err(|e| e.to_string())?;
+    let mut failures = Vec::new();
     for radio in radios {
-        if radio.Kind().map_err(|e| e.to_string())? != RadioKind::Bluetooth {
-            continue;
+        if let Err(err) = cycle_radio(&radio).await {
+            failures.push(err);
         }
-        radio
-            .SetStateAsync(RadioState::Off)
-            .map_err(|e| e.to_string())?
-            .await
-            .map_err(|e| e.to_string())?;
-        sleep(Duration::from_secs(3)).await;
-        radio
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
+    }
+}
+
+async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
+    use windows::Devices::Radios::{RadioAccessStatus, RadioKind, RadioState};
+
+    if radio
+        .Kind()
+        .map_err(|e| format!("failed to inspect a bluetooth radio: {e}"))?
+        != RadioKind::Bluetooth
+    {
+        return Ok(());
+    }
+    let name = radio
+        .Name()
+        .map_err(|e| format!("failed to name a bluetooth radio: {e}"))?;
+    let probe = radio
+        .SetStateAsync(RadioState::On)
+        .map_err(|e| e.to_string())?
+        .await
+        .map_err(|e| e.to_string())?;
+    if probe != RadioAccessStatus::Allowed {
+        return Err(format!(
+            "turning the '{name}' radio back on was refused before cycling ({probe:?})"
+        ));
+    }
+    let status = radio
+        .SetStateAsync(RadioState::Off)
+        .map_err(|e| e.to_string())?
+        .await
+        .map_err(|e| e.to_string())?;
+    if status != RadioAccessStatus::Allowed {
+        return Err(format!("turning the '{name}' radio off was refused ({status:?})"));
+    }
+    sleep(Duration::from_secs(3)).await;
+    restore_radio_on(radio)
+        .await
+        .map_err(|err| format!("the '{name}' radio {err}"))
+}
+
+async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
+    use windows::Devices::Radios::{RadioAccessStatus, RadioState};
+
+    for attempt in 1..=RADIO_ON_ATTEMPTS {
+        if attempt > 1 {
+            sleep(Duration::from_secs(3)).await;
+        }
+        let status = radio
             .SetStateAsync(RadioState::On)
             .map_err(|e| e.to_string())?
             .await
             .map_err(|e| e.to_string())?;
+        if status != RadioAccessStatus::Allowed {
+            warn!("[Core] Turning the bluetooth radio back on was refused (attempt {attempt}/{RADIO_ON_ATTEMPTS}): {status:?}");
+            continue;
+        }
         sleep(Duration::from_secs(5)).await;
+        match radio.State() {
+            Ok(RadioState::On) => return Ok(()),
+            Ok(state) => warn!("[Core] The bluetooth radio still reports {state:?} after being turned back on (attempt {attempt}/{RADIO_ON_ATTEMPTS})"),
+            Err(err) => warn!("[Core] Failed to read the bluetooth radio state after re-enabling it (attempt {attempt}/{RADIO_ON_ATTEMPTS}): {err}"),
+        }
     }
-    Ok(())
+    Err("could not be turned back on".to_string())
 }
 
 async fn get_power_characteristic(

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -21,7 +21,10 @@ use btleplug::{
 use futures_util::{future::join_all, StreamExt};
 use log::{debug, error, info, trace, warn};
 use models::LighthouseDevice;
-use tokio::{sync::Mutex, time::sleep};
+use tokio::{
+    sync::Mutex,
+    time::{sleep, timeout},
+};
 use uuid::Uuid;
 
 use crate::utils::send_event;
@@ -74,9 +77,15 @@ const CONNECT_BACKOFF_MAX: Duration = Duration::from_secs(300);
 const RADIO_RECOVERY_THRESHOLD: u32 = 6;
 const RADIO_RECOVERY_COOLDOWN: Duration = Duration::from_secs(300);
 const RADIO_ON_ATTEMPTS: u32 = 3;
+const RADIO_RESTORE_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub async fn init() {
-    restore_pending_radios().await;
+    if timeout(RADIO_RESTORE_TIMEOUT, restore_pending_radios())
+        .await
+        .is_err()
+    {
+        warn!("[Core] Timed out restoring pending bluetooth radios");
+    }
     // Initialize adapter
     let manager = match Manager::new().await {
         Ok(manager) => manager,
@@ -638,20 +647,30 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
     for radio in &radios {
         cycle_results.push(cycle_radio(radio, &pending_ids).await);
     }
-    for result in &cycle_results {
-        let Some(id) = result.id.as_deref() else {
-            continue;
-        };
-        if !cycle_results
-            .iter()
-            .any(|result| result.id.as_deref() == Some(id) && result.restored)
-            || cycle_results
-                .iter()
-                .any(|result| result.id.as_deref() == Some(id) && result.error.is_some())
-        {
+    let failed_ids = cycle_results
+        .iter()
+        .filter(|result| result.error.is_some())
+        .filter_map(|result| result.id.clone())
+        .collect::<HashSet<_>>();
+    let restored_ids = cycle_results
+        .iter()
+        .filter(|result| result.restored)
+        .filter_map(|result| result.id.clone())
+        .collect::<Vec<_>>();
+    for id in restored_ids {
+        if failed_ids.contains(&id) {
             continue;
         }
-        clear_persisted_pending_restore(id);
+        if !clear_persisted_pending_restore(&id) {
+            if let Some(result) = cycle_results
+                .iter_mut()
+                .find(|result| result.id.as_deref() == Some(id.as_str()))
+            {
+                result.error = Some(format!(
+                    "failed to clear the pending restore of the '{id}' radio"
+                ));
+            }
+        }
     }
     let failures = cycle_results
         .into_iter()
@@ -702,13 +721,42 @@ async fn list_bluetooth_radios() -> Result<Vec<BluetoothRadio>, String> {
     let count = devices.Size().map_err(|e| e.to_string())?;
     let mut radios = Vec::new();
     for index in 0..count {
-        let device = devices.GetAt(index).map_err(|e| e.to_string())?;
-        let id = device.Id().map_err(|e| e.to_string())?;
-        let radio = Radio::FromIdAsync(&id)
-            .map_err(|e| e.to_string())?
-            .await
-            .map_err(|e| e.to_string())?;
-        if radio.Kind().map_err(|e| e.to_string())? != RadioKind::Bluetooth {
+        let device = match devices.GetAt(index) {
+            Ok(device) => device,
+            Err(err) => {
+                warn!("[Core] Failed to inspect a radio while listing bluetooth radios: {err}");
+                continue;
+            }
+        };
+        let id = match device.Id() {
+            Ok(id) => id,
+            Err(err) => {
+                warn!("[Core] Failed to read a radio device id: {err}");
+                continue;
+            }
+        };
+        let operation = match Radio::FromIdAsync(&id) {
+            Ok(operation) => operation,
+            Err(err) => {
+                warn!("[Core] Failed to open a radio by device id: {err}");
+                continue;
+            }
+        };
+        let radio = match operation.await {
+            Ok(radio) => radio,
+            Err(err) => {
+                warn!("[Core] Failed to open a radio by device id: {err}");
+                continue;
+            }
+        };
+        let kind = match radio.Kind() {
+            Ok(kind) => kind,
+            Err(err) => {
+                warn!("[Core] Failed to inspect an opened radio: {err}");
+                continue;
+            }
+        };
+        if kind != RadioKind::Bluetooth {
             continue;
         }
         radios.push(BluetoothRadio {
@@ -825,11 +873,21 @@ fn normalized_pending_restore_names(names: Vec<String>) -> Vec<String> {
 }
 
 fn read_persisted_pending_restores_from(path: &std::path::Path) -> Vec<String> {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|contents| serde_json::from_str::<Vec<String>>(&contents).ok())
-        .map(normalized_pending_restore_names)
-        .unwrap_or_default()
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(err) => {
+            warn!("[Core] Failed to read pending bluetooth radio restores: {err}");
+            return Vec::new();
+        }
+    };
+    match serde_json::from_str::<Vec<String>>(&contents) {
+        Ok(ids) => normalized_pending_restore_names(ids),
+        Err(err) => {
+            warn!("[Core] Failed to parse pending bluetooth radio restores: {err}");
+            Vec::new()
+        }
+    }
 }
 
 fn write_persisted_pending_restores_to(path: &std::path::Path, names: &[String]) -> bool {
@@ -878,18 +936,23 @@ fn persist_pending_restore(name: &str) -> bool {
     true
 }
 
-fn clear_persisted_pending_restore(name: &str) {
+fn clear_persisted_pending_restore(id: &str) -> bool {
     let Some(path) = pending_restore_path() else {
-        return;
+        warn!("[Core] Failed to locate the pending bluetooth radio restore file");
+        return false;
     };
     let _guard = PENDING_RESTORE_FILE_LOCK.lock().unwrap();
-    let mut names = read_persisted_pending_restores_from(&path);
-    let before = names.len();
-    names.retain(|pending| pending != name);
-    if names.len() != before {
-        if !write_persisted_pending_restores_to(&path, &names) {
-            warn!("[Core] Failed to clear a pending bluetooth radio restore");
-        }
+    let mut ids = read_persisted_pending_restores_from(&path);
+    let before = ids.len();
+    ids.retain(|pending| pending != id);
+    if ids.len() == before {
+        return true;
+    }
+    if write_persisted_pending_restores_to(&path, &ids) {
+        true
+    } else {
+        warn!("[Core] Failed to clear a pending bluetooth radio restore");
+        false
     }
 }
 

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -62,6 +62,8 @@ static CONNECT_BACKOFFS: LazyLock<std::sync::Mutex<HashMap<PeripheralId, (u32, I
     LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 static CONNECT_FAILURE_STREAK: AtomicU32 = AtomicU32::new(0);
 static LAST_RADIO_RECOVERY: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mutex::new(None));
+static PENDING_RADIO_RESTORES: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const CONNECT_RETRY_COOLDOWN: Duration = Duration::from_secs(10);
@@ -657,22 +659,32 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
 async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
     use windows::Devices::Radios::{RadioAccessStatus, RadioKind, RadioState};
 
-    if radio
-        .Kind()
-        .map_err(|e| format!("failed to inspect a bluetooth radio: {e}"))?
-        != RadioKind::Bluetooth
-    {
+    let kind = match radio.Kind() {
+        Ok(kind) => kind,
+        Err(_) => return Ok(()),
+    };
+    if kind != RadioKind::Bluetooth {
         return Ok(());
     }
     let name = radio
         .Name()
         .map(|name| name.to_string())
         .unwrap_or_else(|_| String::from("bluetooth radio"));
+    if PENDING_RADIO_RESTORES.lock().await.remove(&name) {
+        warn!("[Core] Turning the '{name}' radio back on after a failed recovery");
+        if let Err(err) = restore_radio_on(radio).await {
+            PENDING_RADIO_RESTORES.lock().await.insert(name.clone());
+            return Err(format!("the '{name}' radio {err}"));
+        }
+        return Ok(());
+    }
     match radio.State() {
-        Ok(RadioState::Off) | Ok(RadioState::Disabled) => return Ok(()),
-        Ok(_) => {}
+        Ok(RadioState::On) => {}
+        Ok(_) => return Ok(()),
         Err(err) => {
-            warn!("[Core] Failed to read the bluetooth radio state before cycling it: {err}");
+            return Err(format!(
+                "failed to read the state of the '{name}' radio: {err}"
+            ))
         }
     }
     let probe = radio
@@ -696,9 +708,22 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
         ));
     }
     sleep(Duration::from_secs(3)).await;
-    restore_radio_on(radio)
-        .await
-        .map_err(|err| format!("the '{name}' radio {err}"))
+    match radio.State() {
+        Ok(RadioState::Off) => {}
+        Ok(state) => {
+            return Err(format!(
+                "the '{name}' radio still reports {state:?} after being turned off"
+            ))
+        }
+        Err(err) => {
+            warn!("[Core] Failed to read the '{name}' radio state after turning it off: {err}")
+        }
+    }
+    if let Err(err) = restore_radio_on(radio).await {
+        PENDING_RADIO_RESTORES.lock().await.insert(name.clone());
+        return Err(format!("the '{name}' radio {err}"));
+    }
+    Ok(())
 }
 
 async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -96,13 +96,13 @@ pub async fn init() {
         let manager = match Manager::new().await {
             Ok(manager) => manager,
             Err(err) => {
+                set_lighthouse_status(LighthouseStatus::AdapterError).await;
                 if pending_restores_remain() {
                     warn!("[Core] Failed to initialize the bluetooth manager while restores remain: {err}");
                     sleep(RADIO_ADAPTER_RETRY_COOLDOWN).await;
                     continue;
                 }
                 error!("[Core] Failed to initialize the bluetooth manager: {err}");
-                set_lighthouse_status(LighthouseStatus::AdapterError).await;
                 return;
             }
         };
@@ -129,16 +129,17 @@ pub async fn init() {
                 return;
             }
             Ok(_) => {
+                set_lighthouse_status(LighthouseStatus::NoAdapter).await;
                 if pending_restores_remain() {
                     warn!("[Core] No bluetooth adapter was found while restores remain");
                     sleep(RADIO_ADAPTER_RETRY_COOLDOWN).await;
                     continue;
                 }
-                set_lighthouse_status(LighthouseStatus::NoAdapter).await;
                 warn!("[Core] No bluetooth adapter was found. Disabling lighthouse module.");
                 return;
             }
             Err(err) => {
+                set_lighthouse_status(LighthouseStatus::AdapterError).await;
                 if pending_restores_remain() {
                     error!(
                         "[Core] Failed to list the bluetooth adapters while restores remain: {err}"
@@ -147,7 +148,6 @@ pub async fn init() {
                     continue;
                 }
                 error!("[Core] Failed to list the bluetooth adapters: {err}");
-                set_lighthouse_status(LighthouseStatus::AdapterError).await;
                 return;
             }
         }

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -642,6 +642,7 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
     let _guard = RADIO_RECOVERY_LOCK.lock().await;
     request_radio_access().await?;
     let listing = list_bluetooth_radios().await?;
+    let enumeration_complete = listing.complete;
     let radios = listing.radios;
     let pending_ids = read_persisted_pending_restores()
         .ok_or_else(|| String::from("failed to read pending bluetooth radio restores"))?;
@@ -666,10 +667,13 @@ async fn cycle_bluetooth_radio() -> Result<(), String> {
             }
         }
     }
-    let failures = cycle_results
+    let mut failures = cycle_results
         .into_iter()
         .filter_map(|result| result.error)
         .collect::<Vec<_>>();
+    if !enumeration_complete {
+        failures.push(String::from("bluetooth radio enumeration was incomplete"));
+    }
     if failures.is_empty() {
         Ok(())
     } else {
@@ -1054,7 +1058,7 @@ fn pending_restore_clear_ids(
     enumeration_complete: bool,
 ) -> Vec<String> {
     let mut ids = restored_ids.to_vec();
-    if enumeration_complete {
+    if enumeration_complete && !available_ids.is_empty() {
         ids.extend(
             pending_ids
                 .iter()
@@ -1330,6 +1334,10 @@ mod tests {
         assert_eq!(
             pending_restore_clear_ids(&pending_ids, &restored_ids, &available_ids, false),
             vec![String::from("present")]
+        );
+        assert!(
+            pending_restore_clear_ids(&[String::from("present")], &[], &HashSet::new(), true)
+                .is_empty()
         );
     }
 

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -3,6 +3,7 @@ pub mod models;
 
 use std::{
     collections::{HashMap, HashSet},
+    path::PathBuf,
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, LazyLock,
@@ -62,8 +63,8 @@ static CONNECT_BACKOFFS: LazyLock<std::sync::Mutex<HashMap<PeripheralId, (u32, I
     LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 static CONNECT_FAILURE_STREAK: AtomicU32 = AtomicU32::new(0);
 static LAST_RADIO_RECOVERY: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mutex::new(None));
-static PENDING_RADIO_RESTORES: LazyLock<Mutex<HashSet<String>>> =
-    LazyLock::new(|| Mutex::new(HashSet::new()));
+static PENDING_RADIO_RESTORES: LazyLock<Mutex<Vec<windows::Devices::Radios::Radio>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const CONNECT_RETRY_COOLDOWN: Duration = Duration::from_secs(10);
@@ -99,6 +100,17 @@ pub async fn init() {
     }
     *MANAGER.lock().await = Some(manager);
     set_lighthouse_status(LighthouseStatus::Ready).await;
+    // A crashed run may have left a radio turned off
+    tokio::task::spawn_blocking(|| {
+        let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            warn!("[Core] Failed to start a runtime to restore pending bluetooth radios");
+            return;
+        };
+        runtime.block_on(restore_pending_radios());
+    });
     // Poll the status of connected lighthouses every few seconds in a separate task
     tokio::spawn(async move {
         loop {
@@ -661,7 +673,10 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
 
     let kind = match radio.Kind() {
         Ok(kind) => kind,
-        Err(_) => return Ok(()),
+        Err(err) => {
+            warn!("[Core] Failed to inspect a radio, skipping it: {err}");
+            return Ok(());
+        }
     };
     if kind != RadioKind::Bluetooth {
         return Ok(());
@@ -670,13 +685,13 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
         .Name()
         .map(|name| name.to_string())
         .unwrap_or_else(|_| String::from("bluetooth radio"));
-    if PENDING_RADIO_RESTORES.lock().await.remove(&name) {
+    if drain_pending_restore(radio).await {
         warn!("[Core] Turning the '{name}' radio back on after a failed recovery");
         if let Err(err) = restore_radio_on(radio).await {
-            PENDING_RADIO_RESTORES.lock().await.insert(name.clone());
+            record_pending_restore(radio, &name).await;
             return Err(format!("the '{name}' radio {err}"));
         }
-        return Ok(());
+        clear_persisted_pending_restore(&name);
     }
     match radio.State() {
         Ok(RadioState::On) => {}
@@ -697,12 +712,14 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
             "turning the '{name}' radio back on was refused before cycling ({probe:?})"
         ));
     }
+    persist_pending_restore(&name);
     let status = radio
         .SetStateAsync(RadioState::Off)
         .map_err(|e| e.to_string())?
         .await
         .map_err(|e| e.to_string())?;
     if status != RadioAccessStatus::Allowed {
+        clear_persisted_pending_restore(&name);
         return Err(format!(
             "turning the '{name}' radio off was refused ({status:?})"
         ));
@@ -710,20 +727,130 @@ async fn cycle_radio(radio: &windows::Devices::Radios::Radio) -> Result<(), Stri
     sleep(Duration::from_secs(3)).await;
     match radio.State() {
         Ok(RadioState::Off) => {}
-        Ok(state) => {
-            return Err(format!(
-                "the '{name}' radio still reports {state:?} after being turned off"
-            ))
-        }
+        Ok(state) => warn!(
+            "[Core] The '{name}' radio still reports {state:?} after being turned off, restoring it"
+        ),
         Err(err) => {
             warn!("[Core] Failed to read the '{name}' radio state after turning it off: {err}")
         }
     }
     if let Err(err) = restore_radio_on(radio).await {
-        PENDING_RADIO_RESTORES.lock().await.insert(name.clone());
+        record_pending_restore(radio, &name).await;
         return Err(format!("the '{name}' radio {err}"));
     }
+    clear_persisted_pending_restore(&name);
     Ok(())
+}
+
+async fn drain_pending_restore(radio: &windows::Devices::Radios::Radio) -> bool {
+    let mut pending = PENDING_RADIO_RESTORES.lock().await;
+    let Some(index) = pending.iter().position(|pending| pending == radio) else {
+        return false;
+    };
+    pending.remove(index);
+    true
+}
+
+async fn record_pending_restore(radio: &windows::Devices::Radios::Radio, name: &str) {
+    PENDING_RADIO_RESTORES.lock().await.push(radio.clone());
+    persist_pending_restore(name);
+}
+
+fn pending_restore_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|dir| dir.join("co.raphii.oyasumi").join("pending-radio-restores"))
+}
+
+fn read_persisted_pending_restores() -> Vec<String> {
+    let Some(path) = pending_restore_path() else {
+        return Vec::new();
+    };
+    std::fs::read_to_string(path)
+        .map(|content| {
+            content
+                .lines()
+                .map(str::to_string)
+                .filter(|name| !name.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn write_persisted_pending_restores(names: &[String]) {
+    let Some(path) = pending_restore_path() else {
+        return;
+    };
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let _ = std::fs::write(&path, names.join("\n"));
+}
+
+fn persist_pending_restore(name: &str) {
+    let mut names = read_persisted_pending_restores();
+    if !names.iter().any(|pending| pending == name) {
+        names.push(name.to_string());
+        write_persisted_pending_restores(&names);
+    }
+}
+
+fn clear_persisted_pending_restore(name: &str) {
+    let mut names = read_persisted_pending_restores();
+    let before = names.len();
+    names.retain(|pending| pending != name);
+    if names.len() != before {
+        write_persisted_pending_restores(&names);
+    }
+}
+
+async fn restore_pending_radios() {
+    use windows::Devices::Radios::{Radio, RadioKind};
+    let names = read_persisted_pending_restores();
+    if names.is_empty() {
+        return;
+    }
+    let radios = match Radio::GetRadiosAsync() {
+        Ok(operation) => {
+            match operation.await {
+                Ok(radios) => radios,
+                Err(err) => {
+                    warn!("[Core] Failed to list radios to restore pending bluetooth recoveries: {err}");
+                    return;
+                }
+            }
+        }
+        Err(err) => {
+            warn!(
+                "[Core] Failed to request the radio list for pending bluetooth recoveries: {err}"
+            );
+            return;
+        }
+    };
+    for radio in radios {
+        let kind = match radio.Kind() {
+            Ok(kind) => kind,
+            Err(_) => continue,
+        };
+        if kind != RadioKind::Bluetooth {
+            continue;
+        }
+        let name = radio
+            .Name()
+            .map(|name| name.to_string())
+            .unwrap_or_else(|_| String::from("bluetooth radio"));
+        if !names.contains(&name) {
+            continue;
+        }
+        warn!("[Core] Turning the '{name}' radio back on after a restart");
+        if let Err(err) = restore_radio_on(&radio).await {
+            record_pending_restore(&radio, &name).await;
+            warn!("[Core] Failed to turn the '{name}' radio back on after a restart: {err}");
+        } else {
+            clear_persisted_pending_restore(&name);
+        }
+    }
 }
 
 async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {

--- a/src-core/src/lighthouse/mod.rs
+++ b/src-core/src/lighthouse/mod.rs
@@ -77,7 +77,9 @@ const CONNECT_BACKOFF_MAX: Duration = Duration::from_secs(300);
 const RADIO_RECOVERY_THRESHOLD: u32 = 6;
 const RADIO_RECOVERY_COOLDOWN: Duration = Duration::from_secs(300);
 const RADIO_ON_ATTEMPTS: u32 = 3;
-const RADIO_RESTORE_TIMEOUT: Duration = Duration::from_secs(30);
+const RADIO_RESTORE_TIMEOUT: Duration = Duration::from_secs(60);
+const RADIO_RESTORE_RETRY_COOLDOWN: Duration = Duration::from_secs(30);
+const RADIO_ADAPTER_RETRY_COOLDOWN: Duration = Duration::from_secs(5);
 
 pub async fn init() {
     if timeout(RADIO_RESTORE_TIMEOUT, restore_pending_radios())
@@ -86,47 +88,92 @@ pub async fn init() {
     {
         warn!("[Core] Timed out restoring pending bluetooth radios");
     }
+    if pending_restores_remain() {
+        tokio::spawn(retry_pending_radio_restores());
+    }
     // Initialize adapter
-    let manager = match Manager::new().await {
-        Ok(manager) => manager,
-        Err(err) => {
-            error!("[Core] Failed to initialize the bluetooth manager: {err}");
-            set_lighthouse_status(LighthouseStatus::AdapterError).await;
-            return;
-        }
-    };
-    match manager.adapters().await {
-        Ok(adapters) => {
-            if adapters.is_empty() {
+    loop {
+        let manager = match Manager::new().await {
+            Ok(manager) => manager,
+            Err(err) => {
+                if pending_restores_remain() {
+                    warn!("[Core] Failed to initialize the bluetooth manager while restores remain: {err}");
+                    sleep(RADIO_ADAPTER_RETRY_COOLDOWN).await;
+                    continue;
+                }
+                error!("[Core] Failed to initialize the bluetooth manager: {err}");
+                set_lighthouse_status(LighthouseStatus::AdapterError).await;
+                return;
+            }
+        };
+        match manager.adapters().await {
+            Ok(adapters) if !adapters.is_empty() => {
+                *MANAGER.lock().await = Some(manager);
+                set_lighthouse_status(LighthouseStatus::Ready).await;
+                // Poll the status of connected lighthouses every few seconds in a separate task
+                tokio::spawn(async move {
+                    loop {
+                        sleep(Duration::from_secs(2)).await;
+                        let devices_guard = LIGHTHOUSE_DEVICES.lock().await;
+                        let devices = devices_guard.clone();
+                        drop(devices_guard);
+                        // Polled together, so an unreachable device cannot hold up the others
+                        join_all(
+                            devices
+                                .iter()
+                                .map(|d| get_device_power_state(d.id.to_string())),
+                        )
+                        .await;
+                    }
+                });
+                return;
+            }
+            Ok(_) => {
+                if pending_restores_remain() {
+                    warn!("[Core] No bluetooth adapter was found while restores remain");
+                    sleep(RADIO_ADAPTER_RETRY_COOLDOWN).await;
+                    continue;
+                }
                 set_lighthouse_status(LighthouseStatus::NoAdapter).await;
                 warn!("[Core] No bluetooth adapter was found. Disabling lighthouse module.");
                 return;
             }
+            Err(err) => {
+                if pending_restores_remain() {
+                    error!(
+                        "[Core] Failed to list the bluetooth adapters while restores remain: {err}"
+                    );
+                    sleep(RADIO_ADAPTER_RETRY_COOLDOWN).await;
+                    continue;
+                }
+                error!("[Core] Failed to list the bluetooth adapters: {err}");
+                set_lighthouse_status(LighthouseStatus::AdapterError).await;
+                return;
+            }
         }
-        Err(err) => {
-            error!("[Core] Failed to list the bluetooth adapters: {err}");
-            set_lighthouse_status(LighthouseStatus::AdapterError).await;
+    }
+}
+
+fn pending_restores_remain() -> bool {
+    !matches!(
+        read_persisted_pending_restores(),
+        Some(pending_ids) if pending_ids.is_empty()
+    )
+}
+
+async fn retry_pending_radio_restores() {
+    loop {
+        sleep(RADIO_RESTORE_RETRY_COOLDOWN).await;
+        if timeout(RADIO_RESTORE_TIMEOUT, restore_pending_radios())
+            .await
+            .is_err()
+        {
+            warn!("[Core] Timed out restoring pending bluetooth radios");
+        }
+        if !pending_restores_remain() {
             return;
         }
     }
-    *MANAGER.lock().await = Some(manager);
-    set_lighthouse_status(LighthouseStatus::Ready).await;
-    // Poll the status of connected lighthouses every few seconds in a separate task
-    tokio::spawn(async move {
-        loop {
-            sleep(Duration::from_secs(2)).await;
-            let devices_guard = LIGHTHOUSE_DEVICES.lock().await;
-            let devices = devices_guard.clone();
-            drop(devices_guard);
-            // Polled together, so an unreachable device cannot hold up the others
-            join_all(
-                devices
-                    .iter()
-                    .map(|d| get_device_power_state(d.id.to_string())),
-            )
-            .await;
-        }
-    });
 }
 
 /// Every scan needs its own adapter: btleplug registers an advertisement handler per `start_scan`
@@ -795,7 +842,13 @@ async fn cycle_radio(radio: &BluetoothRadio, pending_ids: &[String]) -> RadioCyc
     }
     match radio.State() {
         Ok(RadioState::On) => {}
-        Ok(_) => return cycle_error(None),
+        Ok(RadioState::Off | RadioState::Disabled) => return cycle_error(None),
+        Ok(RadioState::Unknown) => {
+            warn!("[Core] The '{name}' radio reports an unknown state, cycling it")
+        }
+        Ok(state) => {
+            warn!("[Core] The '{name}' radio reports an unrecognized state ({state:?}), cycling it")
+        }
         Err(err) => {
             return cycle_error(Some(format!(
                 "failed to read the state of the '{name}' radio: {err}"
@@ -1012,12 +1065,6 @@ async fn restore_pending_radios() {
             return;
         }
     };
-    let enumeration_complete = listing.complete;
-    let available_ids = listing
-        .radios
-        .iter()
-        .map(|radio| radio.id.clone())
-        .collect::<HashSet<_>>();
     let restore_results = join_all(
         listing
             .radios
@@ -1042,31 +1089,8 @@ async fn restore_pending_radios() {
             }
         }
     }
-    let restored_ids = pending_restore_clear_ids(
-        &pending_ids,
-        &seen_ids,
-        &available_ids,
-        enumeration_complete,
-    );
+    let restored_ids = seen_ids;
     retain_persisted_pending_restores(&pending_ids, &restored_ids);
-}
-
-fn pending_restore_clear_ids(
-    pending_ids: &[String],
-    restored_ids: &[String],
-    available_ids: &HashSet<String>,
-    enumeration_complete: bool,
-) -> Vec<String> {
-    let mut ids = restored_ids.to_vec();
-    if enumeration_complete && !available_ids.is_empty() {
-        ids.extend(
-            pending_ids
-                .iter()
-                .filter(|id| !available_ids.contains(*id))
-                .cloned(),
-        );
-    }
-    ids
 }
 
 async fn restore_radio_on(radio: &windows::Devices::Radios::Radio) -> Result<(), String> {
@@ -1319,26 +1343,6 @@ mod tests {
         assert!(read_persisted_pending_restores_from(&path)
             .unwrap()
             .is_empty());
-    }
-
-    #[test]
-    fn stale_pending_restores_clear_only_after_complete_enumeration() {
-        let pending_ids = vec![String::from("present"), String::from("stale")];
-        let restored_ids = vec![String::from("present")];
-        let available_ids = HashSet::from([String::from("present")]);
-
-        assert_eq!(
-            pending_restore_clear_ids(&pending_ids, &restored_ids, &available_ids, true),
-            vec![String::from("present"), String::from("stale")]
-        );
-        assert_eq!(
-            pending_restore_clear_ids(&pending_ids, &restored_ids, &available_ids, false),
-            vec![String::from("present")]
-        );
-        assert!(
-            pending_restore_clear_ids(&[String::from("present")], &[], &HashSet::new(), true)
-                .is_empty()
-        );
     }
 
     #[test]

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -289,8 +289,8 @@ async fn app_setup(app_handle: tauri::AppHandle) {
     os::init_sound_playback().await;
     // Initialize audio device manager
     os::init_audio_device_manager().await;
-    // Initialize Lighthouse Bluetooth
-    lighthouse::init().await;
+    // Initialize Lighthouse Bluetooth without delaying startup
+    drop(tokio::spawn(lighthouse::init()));
     // Initialize Hardware modules
     hardware::init().await;
     // Initialize log commands


### PR DESCRIPTION
Closes #251

The Bluetooth recovery path runs after six consecutive connect failures. It turned every Bluetooth radio off and back on, but discarded the `RadioAccessStatus` from both `SetStateAsync` calls. Only `Allowed` means the request was accepted. A refused `on` request looked like success, the radio stayed off, and nothing reached the logs. The cycle also never called `RequestAccessAsync`, which the WinRT docs require before changing radio state.

The cycle now:

- aborts unless `RequestAccessAsync` returns `Allowed`, before touching any radio
- requires `Allowed` from the off request and reports the returned status otherwise
- retries the on request up to three times when it is refused or the radio does not come back
- verifies the radio actually reports `On` after the request is accepted, since `Allowed` only means accepted
- logs every refusal, failed read, and failed verification with the returned status

The refusal path is fixed per the WinRT contract. I did not reproduce a refusal on a live machine, and I did not deliberately disable Bluetooth to force one. `cargo check` and `cargo test` pass from `src-core`. The remaining `cargo fmt --check` diffs are pre-existing in files this PR does not touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth recovery reliability on Windows.
  * Failed radio restorations are now saved and retried during later application starts and recovery cycles.
  * Recovery verifies radio states before and after restoration attempts.
  * Radios that cannot be restored remain tracked for future attempts, with retries limited to prevent repeated failures.
  * Improved reporting for radio state and transition issues.
  * Recovery continues restoring available radios when one encounters an issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Scope audit

Original intent: fix issue #251 without replying on GitHub. A failed Bluetooth restore must not look like success or leave the radio silently off.

Current scope: request radio access before state changes, use stable radio IDs, probe and verify states, retry restoration, record durable pending restores, restore them at startup and during later recovery cycles, and initialize the lighthouse module without blocking app startup.

Accepted growth: durable marker persistence, stable device IDs, startup and in-session retries, incomplete radio-listing detection, aggregate per-radio failures, and background lighthouse initialization. Each piece closes a path where the app could otherwise lose track of a radio it turned off.

Follow-ups: share app-data path resolution with Tauri instead of hardcoding the identifier, add more tests around cycle and retry seams if those seams are introduced, and narrow enumeration completeness to errors that can hide a Bluetooth radio.

Revert or split: nothing. The growth is larger than the first patch, but it follows directly from the accepted contract that the app must not forget a radio it turned off.

## Review verdict

Round: 1, recover mode.
Verdict: merge-ready with follow-ups.
Reviewed HEAD: a3f29893a951a9a3f0d42fb5d80357e9c874a4ab.
Reviewers: Claude, Codex, and GLM.
Date: 2026-08-29.

Claude found one blocker. Retained restore retries did not publish the Bluetooth adapter status, so the devices panel stayed blank. Commit a3f29893 fixes it by publishing `NoAdapter` or `AdapterError` before each retry. Codex and GLM found no blockers in the frozen scope.

`cargo test`, strict Clippy, `git diff --check`, and the live Bluetooth cycle passed. The final-head cycle rediscovered `LHB-0C142B16`, `LHB-2DA3D6C1`, and `LHB-60E16879` before and after the radio transition.

App-level verification launched the reviewed executable with its matching frontend. The real WebView2 UI was driven from Overview to Device Manager, through Hardware Automations and Power Automations, and back to Device Manager. Device Manager showed all three current lighthouses as on, and the app stayed responsive without new recovery errors.

The accepted maintenance notes are tracked in Plane as OYASUMIVR-56.
