### PR TITLE
fix(OYASUMIVR-3): request an orderly SteamVR quit before forcing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   nothing and could not be freed until you restarted OyasumiVR
 - Fixed one hotkey being unavailable, because another application had taken it, stopping your
   remaining hotkeys from working again after you closed the hotkey selector
+- Fixed the shutdown sequence force-quitting SteamVR right away. It now asks SteamVR to close first,
+  and only forces it after five seconds
 - Various stability improvements
 
 ### Removed

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -3,12 +3,15 @@ use serde::Serialize;
 use std::{
     ffi::OsStr,
     os::raw::c_char,
+    os::windows::process::CommandExt,
+    process::Command,
     sync::LazyLock,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use sysinfo::{ProcessesToUpdate, Signal, System};
+use sysinfo::{Pid, ProcessesToUpdate, System};
 use tauri::Emitter;
 use tokio::sync::Mutex;
+use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
 
 use crate::globals::{TAURI_APP_HANDLE, TAURI_CLI_MATCHES};
 
@@ -42,19 +45,29 @@ pub async fn is_process_active(process_name: &str, refresh_processes: bool) -> b
     processes.count() > 0
 }
 
+/// Without `kill`, this only requests a close: the target may ignore it, so the caller must escalate.
 pub async fn stop_process(process_name: &str, kill: bool) {
     let mut sysinfo_guard = SYSINFO.lock().await;
     let sysinfo = &mut *sysinfo_guard;
     sysinfo.refresh_processes(ProcessesToUpdate::All, true);
-    let processes = sysinfo.processes_by_exact_name(OsStr::new(process_name));
-    for process in processes {
-        if kill
-            || (process.kill_with(Signal::Term).is_none()
-                && process.kill_with(Signal::Quit).is_none())
+    for process in sysinfo.processes_by_exact_name(OsStr::new(process_name)) {
+        let pid = process.pid();
+        if let Err(e) = Command::new("taskkill.exe")
+            .args(taskkill_args(pid, kill))
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
         {
-            let _ = process.kill_with(Signal::Kill);
+            error!("[Core] Failed to stop process {process_name} ({pid}): {e}");
         }
     }
+}
+
+fn taskkill_args(pid: Pid, kill: bool) -> Vec<String> {
+    let mut args = vec![String::from("/PID"), pid.to_string()];
+    if kill {
+        args.push(String::from("/F"));
+    }
+    args
 }
 
 pub fn get_time() -> u128 {
@@ -123,4 +136,18 @@ pub fn convert_char_array_to_string(slice: &[c_char]) -> Option<String> {
         .collect();
 
     String::from_utf8(trimmed_array).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graceful_stop_never_forces() {
+        assert_eq!(taskkill_args(Pid::from_u32(1234), false), ["/PID", "1234"]);
+        assert_eq!(
+            taskkill_args(Pid::from_u32(1234), true),
+            ["/PID", "1234", "/F"]
+        );
+    }
 }

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -52,12 +52,21 @@ pub async fn stop_process(process_name: &str, kill: bool) {
     sysinfo.refresh_processes(ProcessesToUpdate::All, true);
     for process in sysinfo.processes_by_exact_name(OsStr::new(process_name)) {
         let pid = process.pid();
-        if let Err(e) = Command::new("taskkill.exe")
+        match Command::new("taskkill.exe")
             .args(taskkill_args(pid, kill))
             .creation_flags(CREATE_NO_WINDOW)
             .output()
         {
-            error!("[Core] Failed to stop process {process_name} ({pid}): {e}");
+            Ok(output) if !output.status.success() => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                error!(
+                    "[Core] Failed to stop process {process_name} ({pid}): {} {}",
+                    output.status,
+                    stderr.trim()
+                );
+            }
+            Err(e) => error!("[Core] Failed to stop process {process_name} ({pid}): {e}"),
+            Ok(_) => {}
         }
     }
 }


### PR DESCRIPTION
The shutdown sequence force-killed `vrmonitor.exe` on its first call. The UI asks for a graceful quit, waits, and escalates to a forced kill only after five seconds, so that window never applied.

`stop_process` tried `Signal::Term` and `Signal::Quit` before falling back to `Signal::Kill`. The pinned sysinfo 0.39.6 Windows backend supports only `Signal::Kill`, so both calls returned `None` without touching the process and the fallback ran right away. sysinfo's `kill_with` also hardcodes `/F`, so it cannot express a close request at all.

`stop_process` now spawns `taskkill.exe` itself. Without `kill` it passes `/PID` alone; with `kill` it adds `/F`, which is what sysinfo did. The signature is unchanged, so `quit_steamvr` and the frontend stay as they are. `stop_process` has one caller, `quit_steamvr`.

## Scope audit

Original intent: OYASUMIVR-3 (CORE-BUG-001). The first `quit_steamvr` call must request an orderly SteamVR shutdown. A forced kill may happen only after the existing five-second timeout. The ticket limits the change to `stop_process`, keeps the signature, forbids `/T`, and asks for a pure-function regression test.

Current scope: one file, `src-core/src/utils/mod.rs`, 43 insertions and 7 deletions across two commits.

Accepted growth: commit `b1b5d15a` logs a non-zero `taskkill.exe` exit status, raised by CodeRabbit. I count this in scope. The change replaced `let _ = kill_with(...)` with a spawned command, so handling that command's failure completes the code this PR introduced.

Follow-ups: a SteamVR quit that vrmonitor actually honors needs a different mechanism and its own ticket. See "What I left out".

To revert or split: nothing.

## What a reviewer should check

The unit test covers the argument list only. I also ran the real sequence end to end: a debug build of the app, a live SteamVR session, and the Run Sequence button, with Power down Windows off. A WMI watcher recorded the spawned commands.

```
00:50:11.815  "taskkill.exe" /PID 29152
00:50:17.477  "taskkill.exe" /PID 29152 /F
00:50:18.869  EXIT vrmonitor:29152
```

The first call carries no `/F` and the forced call lands 5.7 seconds later, matching the frontend timeout. SteamVR then shut down in order: vrmonitor, the vrwebhelpers, vrcompositor, vrdashboard, and vrserver last.

## What I left out

`vrmonitor.exe` ignores the close request. I ran `taskkill /PID` against it by hand and it was still alive after 63 seconds, with vrserver still up. So SteamVR still exits by force, five seconds later than before. The ticket's fallback suggestion, `PostMessageW` with `WM_CLOSE`, posts the message `taskkill` already posts, so it will not do better. If a genuinely graceful SteamVR quit is worth having, it needs a different mechanism and its own ticket.

I did not add `/T`, per the ticket.


## Review verdict

Round 1, recover mode. Verdict: merge-ready with follow-ups. Reviewed HEAD `b1b5d15a`. Reviewers: Claude (opus-5), Codex (gpt-5.6-sol), GLM (glm-5-3). 2026-08-29.

All three returned no blockers. Checks at that HEAD: `cargo test --bin oyasumivr` 5 passed, `cargo clippy --bin oyasumivr --all-targets` 0 warnings, `cargo fmt --check` does not flag the changed file.

CodeRabbit raised one point on `9a01e467`: `Command::output()` returns `Ok` on a non-zero child exit, so a failed `taskkill` logged nothing. Fixed in `b1b5d15a`.

Claude added three notes, all accepted as follow-ups rather than blockers:

- `taskkill /PID` without `/F` exits 0 and prints `SUCCESS: Sent termination signal` even when the target ignores the close. So the new success check catches only exit 128 and access denied, never "the target ignored us". The frontend five-second timeout stays the real detector.
- The `kill: true` path can log a false error if the target exits between `refresh_processes` and the spawn. Race window is milliseconds, log noise only. `develop` discarded this result entirely.
- The net user-visible effect is a five-second delay before the same forced kill. The contract accepts this.

Follow-up filed: OYASUMIVR-55, "Find a SteamVR quit that vrmonitor.exe actually honors". It carries the first and third notes, so nobody repeats the taskkill exit-code measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process termination on Windows.
  * Graceful stops now allow processes to exit normally, while forced stops terminate them immediately.
  * Suppressed unnecessary command windows during termination.
  * Added error logging when termination commands fail.
  * Updated shutdown behavior to request SteamVR to close gracefully before force-quitting it after five seconds if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

