### PR TITLE
fix(OYASUMIVR-2): make settings migrations recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed the Windows notification provider not showing any notifications
 - Fixed the VR overlay failing to start when system-wide ad blockers or proxies intercepted
   OyasumiVR's local connection
+- Fixed settings being reset when upgrading from very old versions of OyasumiVR, or when switching
+  between release and beta builds
 - Fixed OyasumiVR using up an entire CPU core when Windows stopped reporting the microphone level
   for the capture device used by the system microphone automations
 - Fixed OyasumiVR looking up your sunrise and sunset times up to three times when it started

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:eslint": "eslint --no-error-on-unmatched-pattern --fix \"src-ui/**/*.ts\" \"src-overlay-ui/**/*.ts\" \"src-shared-ts/**/*.ts\" \"scripts/**/*.ts\"",
     "format:prettier": "prettier --write \"src-ui/**/*.{html,css,scss,js,ts}\" \"src-overlay-ui/**/*.{html,css,scss,js,ts}\" \"src-shared-ts/**/*.{html,css,scss,js,ts}\" \"scripts/**/*.{html,css,scss,js,ts}\"",
     "lint": "ng lint",
-    "test": "node --experimental-strip-types --test \"src-shared-ts/src/*.test.ts\"",
+    "test": "node --experimental-strip-types --test \"src-shared-ts/src/*.test.ts\" \"scripts/*.test.ts\"",
     "clean": "rimraf dist && rimraf src-overlay-sidecar/bin && rimraf src-overlay-sidecar/obj && rimraf src-overlay-ui/build && rimraf src-elevated-sidecar/target && rimraf src-core/target && rimraf src-shared-rust/target && rimraf src-core/resources/elevated-sidecar && rimraf src-core/resources/overlay-sidecar && rimraf src-core/resources/fonts",
     "tl": "node scripts/translation-utils.js",
     "tl:check-icu": "node scripts/check-icu.mjs",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:eslint": "eslint --no-error-on-unmatched-pattern --fix \"src-ui/**/*.ts\" \"src-overlay-ui/**/*.ts\" \"src-shared-ts/**/*.ts\" \"scripts/**/*.ts\"",
     "format:prettier": "prettier --write \"src-ui/**/*.{html,css,scss,js,ts}\" \"src-overlay-ui/**/*.{html,css,scss,js,ts}\" \"src-shared-ts/**/*.{html,css,scss,js,ts}\" \"scripts/**/*.{html,css,scss,js,ts}\"",
     "lint": "ng lint",
+    "test": "node --experimental-strip-types --test \"src-shared-ts/src/*.test.ts\"",
     "clean": "rimraf dist && rimraf src-overlay-sidecar/bin && rimraf src-overlay-sidecar/obj && rimraf src-overlay-ui/build && rimraf src-elevated-sidecar/target && rimraf src-core/target && rimraf src-shared-rust/target && rimraf src-core/resources/elevated-sidecar && rimraf src-core/resources/overlay-sidecar && rimraf src-core/resources/fonts",
     "tl": "node scripts/translation-utils.js",
     "tl:check-icu": "node scripts/check-icu.mjs",

--- a/scripts/migration-transforms.test.ts
+++ b/scripts/migration-transforms.test.ts
@@ -1,0 +1,471 @@
+// run from the repo root: node --test scripts/migration-transforms.test.ts
+import { registerHooks } from 'node:module';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Node's type stripping cannot tell type-only named imports from value imports,
+// so named imports in app sources become namespace imports plus destructuring.
+// The Tauri plugins and the one Angular service in the import chain load from stubs.
+const STUB_SOURCES: Record<string, string> = {
+  'stub:@tauri-apps/plugin-log':
+    'export const info = async () => {};\nexport const error = async () => {};\n',
+  'stub:@tauri-apps/plugin-dialog': 'export const message = async () => {};\n',
+  'stub:@tauri-apps/plugin-fs':
+    'export const BaseDirectory = { AppData: 18 };\nexport const writeTextFile = async () => {};\n',
+  'stub:app/frame-limiter.service':
+    "export const FrameLimiterPresets = [{ appId: 438100, appLabel: 'VRChat', appIcon: 'assets/img/vrc_icon.png' }];\n",
+};
+
+let importCounter = 0;
+
+registerHooks({
+  resolve(specifier: string, context: any, nextResolve: any) {
+    if (specifier.startsWith('@tauri-apps/')) {
+      return { url: 'stub:' + specifier, shortCircuit: true };
+    }
+    if (specifier.endsWith('frame-limiter.service')) {
+      return { url: 'stub:app/frame-limiter.service', shortCircuit: true };
+    }
+    try {
+      return nextResolve(specifier, context);
+    } catch (err) {
+      if (specifier.startsWith('.') && !/\.[cm]?[jt]s$/.test(specifier)) {
+        return nextResolve(specifier + '.ts', context);
+      }
+      throw err;
+    }
+  },
+  load(url: string, context: any, nextLoad: any) {
+    const stubSource = STUB_SOURCES[url];
+    if (stubSource !== undefined)
+      return { format: 'module', source: stubSource, shortCircuit: true };
+    const result = nextLoad(url, context);
+    if (!url.includes('/src-ui/') || !url.endsWith('.ts')) return result;
+    const source = String(result.source).replace(
+      /import\s*\{([^}]*)\}\s*from\s*(["'][^"']+["']);?/g,
+      (_m: string, bindings: string, quoted: string) => {
+        const ns = `__imp${importCounter}`;
+        importCounter++;
+        return `import * as ${ns} from ${quoted}; const { ${bindings.trim()} } = ${ns}.default ?? ${ns};`;
+      }
+    );
+    return { ...result, source };
+  },
+});
+
+const loadMigrations = () => import('../src-ui/app/migrations/automation-configs.migrations');
+
+const RIPPLE_SOUND = {
+  id: 'ripple',
+  type: 'BUILT_IN',
+  duration: 3.6,
+  name: 'Ripple',
+  userConfigurable: true,
+};
+const PULSE_SOUND = {
+  id: 'pulse',
+  type: 'BUILT_IN',
+  duration: 1.1,
+  name: 'Pulse',
+  userConfigurable: true,
+};
+
+test('v8: brightness construction separates enable and disable, shutdown renames nest', async () => {
+  const { migrateAutomationConfigs } = await loadMigrations();
+  const result = await migrateAutomationConfigs({
+    version: 8,
+    GPU_POWER_LIMITS: {
+      enabled: true,
+      selectedDeviceId: null,
+      onSleepEnable: { enabled: false, resetToDefault: false },
+      onSleepDisable: { enabled: false, resetToDefault: true },
+    },
+    TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE: { enabled: true, deviceClasses: ['HMD', 'Controller'] },
+    MSI_AFTERBURNER: {
+      enabled: true,
+      msiAfterburnerPath: 'C:\\Sentinel\\MSIAfterburner.exe',
+      onSleepEnableProfile: 2,
+      onSleepDisableProfile: 3,
+    },
+    DISPLAY_BRIGHTNESS_ON_SLEEP_MODE_ENABLE: {
+      enabled: true,
+      brightness: 37,
+      transition: false,
+      transitionTime: 4242,
+    },
+    IMAGE_BRIGHTNESS_ON_SLEEP_MODE_DISABLE: {
+      enabled: true,
+      brightness: 41,
+      transition: true,
+      transitionTime: 9000,
+    },
+    SHUTDOWN_AUTOMATIONS: {
+      enabled: true,
+      triggerOnSleep: false,
+      sleepDuration: 777000,
+      activationWindow: true,
+      activationWindowStart: [21, 42],
+      activationWindowEnd: [8, 15],
+      quitSteamVR: false,
+      turnOffControllers: true,
+      turnOffTrackers: false,
+      turnOffBaseStations: false,
+      shutdownWindows: true,
+    },
+    WINDOWS_POWER_POLICY_ON_SLEEP_MODE_ENABLE: { enabled: true, powerPolicy: 'BALANCED' },
+  });
+
+  assert.equal(result.version, 20);
+  assert.deepEqual(result.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE, {
+    enabled: true,
+    changeBrightness: true,
+    changeColorTemperature: false,
+    brightness: 37,
+    softwareBrightness: 100,
+    hardwareBrightness: 37,
+    transition: false,
+    transitionTime: 4242,
+    colorTemperature: 1800,
+  });
+  assert.deepEqual(result.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_DISABLE, {
+    enabled: true,
+    changeBrightness: true,
+    changeColorTemperature: false,
+    brightness: 41,
+    softwareBrightness: 41,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 9000,
+    colorTemperature: 6600,
+  });
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepDuration, 777000);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepActivationWindow, true);
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepActivationWindowStart, [21, 42]);
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepActivationWindowEnd, [8, 15]);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.powerDownWindows, true);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.powerDownWindowsMode, 'SHUTDOWN');
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.turnOffDevices.types, ['CONTROLLER']);
+  assert.equal(
+    result.WINDOWS_POWER_POLICY_ON_SLEEP_MODE_ENABLE.powerPolicy,
+    '381b4222-f694-41f0-9685-ff5bb260df2e'
+  );
+  assert.deepEqual(result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesOnSleepModeEnable.types, [
+    'HMD',
+    'CONTROLLER',
+  ]);
+  assert.equal(result.MSI_AFTERBURNER.enabled, true);
+});
+
+test('v14: shutdown trigger fields rename inside SHUTDOWN_AUTOMATIONS, sounds freeze at v18 defaults', async () => {
+  const { migrateAutomationConfigs } = await loadMigrations();
+  const result = await migrateAutomationConfigs({
+    version: 14,
+    BRIGHTNESS_CONTROL_ADVANCED_MODE: { enabled: false },
+    SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE: {
+      enabled: false,
+      brightness: 20,
+      softwareBrightness: 20,
+      hardwareBrightness: 100,
+      transition: true,
+      transitionTime: 300000,
+      applyOnStart: false,
+    },
+    SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE: {
+      enabled: false,
+      brightness: 100,
+      softwareBrightness: 100,
+      hardwareBrightness: 100,
+      transition: true,
+      transitionTime: 10000,
+      applyOnStart: false,
+    },
+    SET_BRIGHTNESS_ON_SLEEP_PREPARATION: {
+      enabled: false,
+      brightness: 50,
+      softwareBrightness: 50,
+      hardwareBrightness: 100,
+      transition: true,
+      transitionTime: 30000,
+    },
+    VRCHAT_MIC_MUTE_AUTOMATIONS: {
+      enabled: true,
+      onSleepModeEnable: 'MUTE',
+      onSleepModeDisable: 'NONE',
+      onSleepPreparation: 'NONE',
+    },
+    JOIN_NOTIFICATIONS: {
+      enabled: true,
+      playerIds: ['usr_1'],
+      onlyDuringSleepMode: false,
+      onlyWhenPreviouslyAlone: false,
+      onlyWhenLeftAlone: false,
+      joinNotification: 'WHITELIST',
+      leaveNotification: 'DISABLED',
+      joinSound: 'FRIEND',
+      leaveSound: 'BLACKLIST',
+      joinSoundVolume: 33,
+    },
+    NIGHTMARE_DETECTION: {
+      enabled: true,
+      heartRateThreshold: 130,
+      periodDuration: 60000,
+      disableSleepMode: false,
+      playSound: true,
+      soundVolume: 55,
+    },
+    TURN_OFF_DEVICES_ON_BATTERY_LEVEL: {
+      enabled: true,
+      turnOffControllers: true,
+      turnOffControllersAtLevel: 22,
+      turnOffControllersOnlyDuringSleepMode: true,
+      turnOffTrackers: true,
+      turnOffTrackersAtLevel: 33,
+      turnOffTrackersOnlyDuringSleepMode: false,
+    },
+    SHUTDOWN_AUTOMATIONS: {
+      enabled: true,
+      triggerOnSleep: false,
+      sleepDuration: 777000,
+      activationWindow: true,
+      activationWindowStart: [21, 42],
+      activationWindowEnd: [8, 15],
+      quitSteamVR: true,
+      turnOffControllers: false,
+      turnOffTrackers: false,
+      turnOffBaseStations: false,
+      powerDownWindows: false,
+      powerDownWindowsMode: 'REBOOT',
+    },
+  });
+
+  assert.equal(result.version, 20);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepDuration, 777000);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepActivationWindow, true);
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepActivationWindowStart, [21, 42]);
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.triggerOnSleepActivationWindowEnd, [8, 15]);
+  assert.equal('sleepDuration' in result.SHUTDOWN_AUTOMATIONS, false);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.powerDownWindowsMode, 'REBOOT');
+  assert.equal('mode' in result.VRCHAT_MIC_MUTE_AUTOMATIONS, false);
+  assert.equal(result.VRCHAT_MIC_MUTE_AUTOMATIONS.onSleepModeEnable, 'MUTE');
+  assert.equal(result.JOIN_NOTIFICATIONS.joinSoundMode, 'FRIEND');
+  assert.equal(result.JOIN_NOTIFICATIONS.leaveSoundMode, 'BLACKLIST');
+  assert.deepEqual(result.JOIN_NOTIFICATIONS.joinSound, {
+    sound: RIPPLE_SOUND,
+    volume: 100,
+    enabled: true,
+  });
+  assert.deepEqual(result.JOIN_NOTIFICATIONS.leaveSound, {
+    sound: PULSE_SOUND,
+    volume: 100,
+    enabled: true,
+  });
+  assert.deepEqual(result.NIGHTMARE_DETECTION.sound, {
+    sound: RIPPLE_SOUND,
+    volume: 55,
+    enabled: true,
+  });
+  assert.equal('playSound' in result.NIGHTMARE_DETECTION, false);
+  assert.deepEqual(result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesBelowBatteryLevel.types, [
+    'CONTROLLER',
+    'TRACKER',
+  ]);
+  assert.equal(result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesBelowBatteryLevel_threshold, 33);
+  assert.equal(
+    result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesBelowBatteryLevel_onlyWhileAsleep,
+    false
+  );
+});
+
+test('v16: brightness automations build from the frozen v17 defaults', async () => {
+  const { migrateAutomationConfigs } = await loadMigrations();
+  const result = await migrateAutomationConfigs({
+    version: 16,
+    BRIGHTNESS_CONTROL_ADVANCED_MODE: { enabled: false },
+    SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE: {
+      enabled: true,
+      brightness: 63,
+      softwareBrightness: 29,
+      hardwareBrightness: 61,
+      transition: true,
+      transitionTime: 9000,
+      applyOnStart: false,
+    },
+    SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE: {
+      enabled: false,
+      brightness: 100,
+      softwareBrightness: 100,
+      hardwareBrightness: 100,
+      transition: true,
+      transitionTime: 10000,
+      applyOnStart: false,
+    },
+    SET_BRIGHTNESS_ON_SLEEP_PREPARATION: {
+      enabled: true,
+      brightness: 51,
+      softwareBrightness: 52,
+      hardwareBrightness: 53,
+      transition: false,
+      transitionTime: 77000,
+    },
+  });
+
+  assert.equal(result.version, 20);
+  assert.equal(result.BRIGHTNESS_AUTOMATIONS.advancedMode, false);
+  assert.deepEqual(result.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE, {
+    enabled: true,
+    changeBrightness: true,
+    changeColorTemperature: false,
+    brightness: 63,
+    softwareBrightness: 29,
+    hardwareBrightness: 61,
+    transition: true,
+    transitionTime: 9000,
+    colorTemperature: 1800,
+  });
+  assert.deepEqual(result.BRIGHTNESS_AUTOMATIONS.SLEEP_PREPARATION, {
+    enabled: true,
+    changeBrightness: true,
+    changeColorTemperature: false,
+    brightness: 51,
+    softwareBrightness: 52,
+    hardwareBrightness: 53,
+    transition: false,
+    transitionTime: 77000,
+    colorTemperature: 3500,
+  });
+  assert.deepEqual(result.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_DISABLE, {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 100,
+    softwareBrightness: 100,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 10000,
+    colorTemperature: 6600,
+  });
+  assert.equal(result.BRIGHTNESS_AUTOMATIONS.AT_SUNSET.transitionTime, 300000);
+  assert.equal(result.BRIGHTNESS_AUTOMATIONS.AT_SUNSET.type, 'SUN');
+});
+
+test('v17: notification and device power automations freeze at v18 defaults', async () => {
+  const { migrateAutomationConfigs } = await loadMigrations();
+  const result = await migrateAutomationConfigs({
+    version: 17,
+    BRIGHTNESS_AUTOMATIONS: {
+      enabled: true,
+      advancedMode: true,
+      SLEEP_MODE_ENABLE: {
+        enabled: true,
+        changeBrightness: true,
+        changeColorTemperature: true,
+        brightness: 17,
+        softwareBrightness: 18,
+        hardwareBrightness: 19,
+        transition: true,
+        transitionTime: 31000,
+        colorTemperature: 1900,
+      },
+    },
+    JOIN_NOTIFICATIONS: {
+      enabled: true,
+      playerIds: [],
+      onlyDuringSleepMode: false,
+      onlyWhenPreviouslyAlone: false,
+      onlyWhenLeftAlone: false,
+      joinNotification: 'WHITELIST',
+      leaveNotification: 'DISABLED',
+      joinSound: 'FRIEND',
+      leaveSound: 'BLACKLIST',
+      joinSoundVolume: 100,
+    },
+    NIGHTMARE_DETECTION: {
+      enabled: true,
+      heartRateThreshold: 130,
+      periodDuration: 60000,
+      disableSleepMode: false,
+      playSound: true,
+      soundVolume: 55,
+    },
+    SHUTDOWN_AUTOMATIONS: {
+      enabled: true,
+      triggersEnabled: true,
+      triggerOnSleep: false,
+      triggerOnSleepDuration: 900000,
+      triggerOnSleepActivationWindow: false,
+      triggerOnSleepActivationWindowStart: [23, 0],
+      triggerOnSleepActivationWindowEnd: [7, 0],
+      triggerWhenAlone: true,
+      triggerWhenAloneDuration: 123000,
+      triggerWhenAloneOnlyWhenSleepModeActive: true,
+      triggerWhenAloneActivationWindow: false,
+      triggerWhenAloneActivationWindowStart: [23, 0],
+      triggerWhenAloneActivationWindowEnd: [7, 0],
+      quitSteamVR: true,
+      turnOffControllers: true,
+      turnOffTrackers: true,
+      turnOffBaseStations: false,
+      powerDownWindows: true,
+      powerDownWindowsMode: 'SHUTDOWN',
+    },
+    TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE: { enabled: true, deviceClasses: ['HMD'] },
+    TURN_OFF_DEVICES_WHEN_CHARGING: { enabled: false, deviceClasses: ['GenericTracker'] },
+  });
+
+  assert.equal(result.version, 20);
+  assert.equal(result.BRIGHTNESS_AUTOMATIONS.advancedMode, true);
+  assert.equal(result.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE.brightness, 17);
+  assert.equal(result.JOIN_NOTIFICATIONS.joinSoundMode, 'FRIEND');
+  assert.equal(result.JOIN_NOTIFICATIONS.leaveSoundMode, 'BLACKLIST');
+  assert.deepEqual(result.JOIN_NOTIFICATIONS.joinSound, {
+    sound: RIPPLE_SOUND,
+    volume: 100,
+    enabled: true,
+  });
+  assert.deepEqual(result.JOIN_NOTIFICATIONS.leaveSound, {
+    sound: PULSE_SOUND,
+    volume: 100,
+    enabled: true,
+  });
+  assert.deepEqual(result.NIGHTMARE_DETECTION.sound, {
+    sound: RIPPLE_SOUND,
+    volume: 55,
+    enabled: true,
+  });
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.turnOffDevices.types, ['CONTROLLER', 'TRACKER']);
+  assert.deepEqual(result.SHUTDOWN_AUTOMATIONS.turnOffDevices.devices, []);
+  assert.deepEqual(result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesOnSleepModeEnable.types, ['HMD']);
+  assert.deepEqual(result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesWhenCharging.types, []);
+  assert.equal(result.SHUTDOWN_AUTOMATIONS.triggerWhenAloneDuration, 123000);
+});
+
+test('v2: oldest automation schema migrates end to end through the frozen defaults', async () => {
+  const { migrateAutomationConfigs } = await loadMigrations();
+  const result = await migrateAutomationConfigs({
+    version: 2,
+    GPU_POWER_LIMITS: {
+      enabled: true,
+      selectedDeviceId: null,
+      onSleepEnable: { enabled: false, resetToDefault: false },
+      onSleepDisable: { enabled: false, resetToDefault: true },
+    },
+    SLEEP_MODE_ENABLE_AT_TIME: { enabled: true, time: '23:42' },
+    TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE: { enabled: true, deviceClasses: ['HMD'] },
+  });
+
+  assert.equal(result.version, 20);
+  assert.equal(result.SLEEP_MODE_ENABLE_AT_TIME.time, '23:42');
+  assert.deepEqual(result.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE, {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 20,
+    softwareBrightness: 20,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 300000,
+    colorTemperature: 1800,
+  });
+  assert.deepEqual(result.DEVICE_POWER_AUTOMATIONS.turnOffDevicesOnSleepModeEnable.types, ['HMD']);
+  assert.equal(result.MSI_AFTERBURNER.enabled, true);
+});

--- a/scripts/migration-transforms.test.ts
+++ b/scripts/migration-transforms.test.ts
@@ -20,6 +20,9 @@ let importCounter = 0;
 
 registerHooks({
   resolve(specifier: string, context: any, nextResolve: any) {
+    if (specifier.startsWith('src-shared-ts/')) {
+      return { url: new URL(`../${specifier}.ts`, import.meta.url).href, shortCircuit: true };
+    }
     if (specifier.startsWith('@tauri-apps/')) {
       return { url: 'stub:' + specifier, shortCircuit: true };
     }
@@ -53,7 +56,21 @@ registerHooks({
   },
 });
 
-const loadMigrations = () => import('../src-ui/app/migrations/automation-configs.migrations');
+const loadMigrations = async () => {
+  const [{ AUTOMATION_CONFIGS_MIGRATION }, { runMigrations }] = await Promise.all([
+    import('../src-ui/app/migrations/automation-configs.migrations'),
+    import('../src-shared-ts/src/migration-runner'),
+  ]);
+  return {
+    migrateAutomationConfigs: async (data: any) => {
+      const result = await runMigrations(data, AUTOMATION_CONFIGS_MIGRATION);
+      if (result.status !== 'migrated' && result.status !== 'unchanged') {
+        throw new Error(`Migration failed with status ${result.status}`);
+      }
+      return result.value;
+    },
+  };
+};
 
 const RIPPLE_SOUND = {
   id: 'ripple',
@@ -69,6 +86,11 @@ const PULSE_SOUND = {
   name: 'Pulse',
   userConfigurable: true,
 };
+
+test('current automation data with an invalid shape is rejected', async () => {
+  const { migrateAutomationConfigs } = await loadMigrations();
+  await assert.rejects(() => migrateAutomationConfigs({ version: 20, BRIGHTNESS_AUTOMATIONS: [] }));
+});
 
 test('v8: brightness construction separates enable and disable, shutdown renames nest', async () => {
   const { migrateAutomationConfigs } = await loadMigrations();

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -108,6 +108,7 @@ windows = { version = "0.62.2", features = [
 ], default-features = false }
 windows-sys = { version = "0.61.2", features = [
   "Win32_Foundation",
+  "Win32_Storage_FileSystem",
   "Win32_System_Threading",
 ] }
 winreg = "0.56.0"

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -18,6 +18,7 @@ mod os;
 mod osc;
 mod overlay_sidecar;
 mod steam;
+mod store_safety;
 mod system_tray;
 mod telemetry;
 mod utils;
@@ -424,6 +425,13 @@ fn configure_command_handlers() -> impl Fn(tauri::ipc::Invoke) -> bool {
         commands::time::get_sunrise_sunset_time,
         commands::secrets::protect_secret,
         commands::secrets::unprotect_secret,
+        store_safety::commands::store_safety_save_snapshot,
+        store_safety::commands::store_safety_restore_snapshot,
+        store_safety::commands::store_safety_create_checkpoint,
+        store_safety::commands::store_safety_list_checkpoints,
+        store_safety::commands::store_safety_read_checkpoint,
+        store_safety::commands::store_safety_quarantine_store,
+        store_safety::commands::store_safety_replace_store,
         grpc::commands::get_core_grpc_port,
         grpc::commands::get_core_grpc_web_port,
         telemetry::commands::set_telemetry_enabled,

--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -426,6 +426,7 @@ fn configure_command_handlers() -> impl Fn(tauri::ipc::Invoke) -> bool {
         commands::secrets::protect_secret,
         commands::secrets::unprotect_secret,
         store_safety::commands::store_safety_save_snapshot,
+        store_safety::commands::store_safety_read_snapshot,
         store_safety::commands::store_safety_restore_snapshot,
         store_safety::commands::store_safety_create_checkpoint,
         store_safety::commands::store_safety_list_checkpoints,

--- a/src-core/src/store_safety/commands.rs
+++ b/src-core/src/store_safety/commands.rs
@@ -1,0 +1,109 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use log::info;
+use tauri::{AppHandle, Manager};
+
+use super::{base_dir, store_file_path, CheckpointMetadata};
+
+fn app_data_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Could not resolve the app data directory: {e}"))
+}
+
+#[tauri::command]
+pub async fn store_safety_save_snapshot(
+    app_handle: AppHandle,
+    store_name: String,
+    contents: String,
+) -> Result<(), String> {
+    let base = base_dir(&app_data_dir(&app_handle)?);
+    super::save_snapshot(&base, &store_name, &contents)
+}
+
+#[tauri::command]
+pub async fn store_safety_restore_snapshot(
+    app_handle: AppHandle,
+    store_name: String,
+    store_file_name: String,
+) -> Result<bool, String> {
+    let data_dir = app_data_dir(&app_handle)?;
+    let base = base_dir(&data_dir);
+    let live = store_file_path(&data_dir, &store_file_name)?;
+    super::restore_snapshot(&base, &store_name, &live)
+}
+
+#[tauri::command]
+pub async fn store_safety_create_checkpoint(
+    app_handle: AppHandle,
+    store_name: String,
+    contents: String,
+    reason: String,
+    app_version: String,
+    schema_versions: BTreeMap<String, u32>,
+) -> Result<CheckpointMetadata, String> {
+    let base = base_dir(&app_data_dir(&app_handle)?);
+    let metadata = super::create_checkpoint(
+        &base,
+        &store_name,
+        &contents,
+        &reason,
+        &app_version,
+        schema_versions,
+    )?;
+    info!(
+        "[StoreSafety] Created checkpoint '{}' for store '{}' (reason '{}', {} bytes)",
+        metadata.id, metadata.store_name, metadata.reason, metadata.content_size_bytes
+    );
+    Ok(metadata)
+}
+
+#[tauri::command]
+pub async fn store_safety_list_checkpoints(
+    app_handle: AppHandle,
+    store_name: String,
+) -> Result<Vec<CheckpointMetadata>, String> {
+    let base = base_dir(&app_data_dir(&app_handle)?);
+    super::list_checkpoints(&base, &store_name)
+}
+
+#[tauri::command]
+pub async fn store_safety_read_checkpoint(
+    app_handle: AppHandle,
+    store_name: String,
+    checkpoint_id: String,
+) -> Result<String, String> {
+    let base = base_dir(&app_data_dir(&app_handle)?);
+    super::read_checkpoint(&base, &store_name, &checkpoint_id)
+}
+
+#[tauri::command]
+pub async fn store_safety_quarantine_store(
+    app_handle: AppHandle,
+    store_name: String,
+    store_file_name: String,
+) -> Result<Option<String>, String> {
+    let data_dir = app_data_dir(&app_handle)?;
+    let base = base_dir(&data_dir);
+    let live = store_file_path(&data_dir, &store_file_name)?;
+    let quarantined = super::quarantine_store(&base, &store_name, &live)?;
+    if let Some(path) = &quarantined {
+        info!(
+            "[StoreSafety] Quarantined store file of '{}' to '{}'",
+            store_name, path
+        );
+    }
+    Ok(quarantined)
+}
+
+#[tauri::command]
+pub async fn store_safety_replace_store(
+    app_handle: AppHandle,
+    store_file_name: String,
+    contents: String,
+) -> Result<(), String> {
+    let data_dir = app_data_dir(&app_handle)?;
+    let live = store_file_path(&data_dir, &store_file_name)?;
+    super::replace_store(&live, &contents)
+}

--- a/src-core/src/store_safety/commands.rs
+++ b/src-core/src/store_safety/commands.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use log::info;
 use tauri::{AppHandle, Manager};
 
-use super::{base_dir, store_file_path, CheckpointMetadata};
+use super::{base_dir, store_file_path, CheckpointMetadata, SnapshotData};
 
 fn app_data_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
     app_handle
@@ -20,6 +20,15 @@ pub async fn store_safety_save_snapshot(
 ) -> Result<(), String> {
     let base = base_dir(&app_data_dir(&app_handle)?);
     super::save_snapshot(&base, &store_name, &contents)
+}
+
+#[tauri::command]
+pub async fn store_safety_read_snapshot(
+    app_handle: AppHandle,
+    store_name: String,
+) -> Result<Option<SnapshotData>, String> {
+    let base = base_dir(&app_data_dir(&app_handle)?);
+    super::read_snapshot(&base, &store_name)
 }
 
 #[tauri::command]

--- a/src-core/src/store_safety/mod.rs
+++ b/src-core/src/store_safety/mod.rs
@@ -1,0 +1,629 @@
+pub mod commands;
+
+use std::{collections::BTreeMap, fs, path::Path, path::PathBuf};
+
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const CHECKPOINT_FORMAT_VERSION: u32 = 1;
+
+const MAX_NAME_LENGTH: usize = 128;
+
+/// Checkpoint metadata, serialized camelCase for the frontend.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointMetadata {
+    pub format_version: u32,
+    pub id: String,
+    pub store_name: String,
+    pub app_version: String,
+    pub reason: String,
+    pub created_at: String,
+    pub created_at_millis: i64,
+    pub sequence: u64,
+    pub schema_versions: BTreeMap<String, u32>,
+    pub content_checksum: String,
+    pub content_size_bytes: u64,
+    pub content_file: String,
+    /// Derived from disk, never stored in the metadata file itself.
+    #[serde(skip)]
+    pub content_file_exists: bool,
+}
+
+pub fn base_dir(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("StoreProtector")
+}
+
+/// Resolve a store file name inside the app data dir.
+pub fn store_file_path(app_data_dir: &Path, store_file_name: &str) -> Result<PathBuf, String> {
+    validate_name(store_file_name, true)?;
+    Ok(app_data_dir.join(store_file_name))
+}
+
+fn snapshot_path(base: &Path, store_name: &str) -> PathBuf {
+    base.join(format!("{store_name}.dat"))
+}
+
+fn checkpoint_dir(base: &Path, store_name: &str) -> PathBuf {
+    base.join("checkpoints").join(store_name)
+}
+
+fn checkpoint_content_dir(base: &Path, store_name: &str) -> PathBuf {
+    checkpoint_dir(base, store_name).join("content")
+}
+
+fn quarantine_dir(base: &Path, store_name: &str) -> PathBuf {
+    base.join("quarantine").join(store_name)
+}
+
+fn validate_name(name: &str, allow_dot: bool) -> Result<(), String> {
+    let valid = !name.is_empty()
+        && name.len() <= MAX_NAME_LENGTH
+        && !name.starts_with('.')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || (allow_dot && c == '.'));
+    if valid {
+        Ok(())
+    } else {
+        Err(format!("Invalid name '{name}'"))
+    }
+}
+
+fn checksum(bytes: &[u8]) -> String {
+    format!("{:x}", md5::compute(bytes))
+}
+
+fn is_store_object(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .map(|value| value.is_object())
+        .unwrap_or(false)
+}
+
+/// Write via a temp file, fsync, verify the written bytes, then rename over
+/// the target, so a crash never leaves a half-written file under a final name.
+fn write_file_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| format!("'{}' has no parent directory", path.display()))?;
+    fs::create_dir_all(dir)
+        .map_err(|e| format!("Failed to create directory '{}': {e}", dir.display()))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| format!("'{}' has no file name", path.display()))?
+        .to_string_lossy();
+    let tmp_path = dir.join(format!("{file_name}.tmp-{}", uuid::Uuid::new_v4().simple()));
+    let result = (|| -> Result<(), String> {
+        fs::write(&tmp_path, contents)
+            .map_err(|e| format!("Failed to write '{}': {e}", tmp_path.display()))?;
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&tmp_path)
+            .map_err(|e| format!("Failed to open '{}': {e}", tmp_path.display()))?;
+        file.sync_all()
+            .map_err(|e| format!("Failed to flush '{}': {e}", tmp_path.display()))?;
+        let written = fs::read(&tmp_path)
+            .map_err(|e| format!("Failed to verify '{}': {e}", tmp_path.display()))?;
+        if written != contents {
+            return Err(format!(
+                "Verified bytes of '{}' do not match the expected contents",
+                tmp_path.display()
+            ));
+        }
+        drop(file);
+        rename_replacing(&tmp_path, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn rename_replacing(from: &Path, to: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+    let from_wide: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
+    let to_wide: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+    let moved = unsafe {
+        MoveFileExW(
+            from_wide.as_ptr(),
+            to_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved != 0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "Failed to move '{}' into place: {}",
+            from.display(),
+            std::io::Error::last_os_error()
+        ))
+    }
+}
+
+#[cfg(not(windows))]
+fn rename_replacing(from: &Path, to: &Path) -> Result<(), String> {
+    fs::rename(from, to).map_err(|e| format!("Failed to move '{}' into place: {e}", from.display()))
+}
+
+/// Overwrite the rolling latest-known-good snapshot for a store.
+pub fn save_snapshot(base: &Path, store_name: &str, contents: &str) -> Result<(), String> {
+    validate_name(store_name, false)?;
+    if !is_store_object(contents.as_bytes()) {
+        return Err(format!(
+            "Snapshot contents for store '{store_name}' are not a JSON object"
+        ));
+    }
+    write_file_atomic(&snapshot_path(base, store_name), contents.as_bytes())
+}
+
+/// Replace a corrupt live store file with the rolling snapshot. False means no
+/// viable snapshot; the live file is left untouched in that case.
+pub fn restore_snapshot(base: &Path, store_name: &str, live_path: &Path) -> Result<bool, String> {
+    validate_name(store_name, false)?;
+    let snapshot = snapshot_path(base, store_name);
+    if !snapshot.is_file() {
+        return Ok(false);
+    }
+    let bytes = fs::read(&snapshot)
+        .map_err(|e| format!("Failed to read snapshot of store '{store_name}': {e}"))?;
+    if !is_store_object(&bytes) {
+        return Ok(false);
+    }
+    write_file_atomic(live_path, &bytes)?;
+    Ok(true)
+}
+
+/// Create an immutable checkpoint; identical content returns the existing one.
+pub fn create_checkpoint(
+    base: &Path,
+    store_name: &str,
+    contents: &str,
+    reason: &str,
+    app_version: &str,
+    schema_versions: BTreeMap<String, u32>,
+) -> Result<CheckpointMetadata, String> {
+    validate_name(store_name, false)?;
+    if !is_store_object(contents.as_bytes()) {
+        return Err(format!(
+            "Checkpoint contents for store '{store_name}' are not a JSON object"
+        ));
+    }
+    let checksum = checksum(contents.as_bytes());
+    let existing = list_checkpoints(base, store_name)?;
+    if let Some(metadata) = existing.iter().find(|m| m.content_checksum == checksum) {
+        return Ok(metadata.clone());
+    }
+    let content_file = format!("{checksum}.dat");
+    let content_path = checkpoint_content_dir(base, store_name).join(&content_file);
+    if !content_path.is_file() {
+        write_file_atomic(&content_path, contents.as_bytes())?;
+    }
+    let now = Utc::now();
+    let sequence = existing.iter().map(|m| m.sequence).max().unwrap_or(0) + 1;
+    let id = format!(
+        "{}-{}-{}",
+        now.timestamp_millis(),
+        sequence,
+        uuid::Uuid::new_v4().simple()
+    );
+    let metadata = CheckpointMetadata {
+        format_version: CHECKPOINT_FORMAT_VERSION,
+        id: id.clone(),
+        store_name: store_name.to_string(),
+        app_version: app_version.to_string(),
+        reason: reason.to_string(),
+        created_at: now.to_rfc3339_opts(SecondsFormat::Millis, true),
+        created_at_millis: now.timestamp_millis(),
+        sequence,
+        schema_versions,
+        content_checksum: checksum,
+        content_size_bytes: contents.len() as u64,
+        content_file,
+        content_file_exists: true,
+    };
+    let metadata_path = checkpoint_dir(base, store_name).join(format!("{id}.json"));
+    let metadata_bytes = serde_json::to_vec_pretty(&metadata)
+        .map_err(|e| format!("Failed to serialize checkpoint metadata: {e}"))?;
+    write_file_atomic(&metadata_path, &metadata_bytes)?;
+    Ok(metadata)
+}
+
+/// List a store's checkpoints, newest first, skipping unreadable entries.
+pub fn list_checkpoints(base: &Path, store_name: &str) -> Result<Vec<CheckpointMetadata>, String> {
+    validate_name(store_name, false)?;
+    let mut checkpoints: Vec<CheckpointMetadata> = Vec::new();
+    let entries = match fs::read_dir(checkpoint_dir(base, store_name)) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(checkpoints),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = fs::read(&path) else { continue };
+        let Ok(mut metadata) = serde_json::from_slice::<CheckpointMetadata>(&bytes) else {
+            continue;
+        };
+        if metadata.store_name != store_name {
+            continue;
+        }
+        metadata.content_file_exists = checkpoint_content_dir(base, store_name)
+            .join(&metadata.content_file)
+            .is_file();
+        checkpoints.push(metadata);
+    }
+    checkpoints.sort_by_key(|m| std::cmp::Reverse((m.created_at_millis, m.sequence)));
+    Ok(checkpoints)
+}
+
+/// Read checkpoint contents, verifying the stored checksum first.
+pub fn read_checkpoint(
+    base: &Path,
+    store_name: &str,
+    checkpoint_id: &str,
+) -> Result<String, String> {
+    validate_name(store_name, false)?;
+    validate_name(checkpoint_id, false)?;
+    let metadata_path = checkpoint_dir(base, store_name).join(format!("{checkpoint_id}.json"));
+    let bytes = fs::read(&metadata_path)
+        .map_err(|_| format!("Checkpoint '{checkpoint_id}' was not found"))?;
+    let metadata: CheckpointMetadata = serde_json::from_slice(&bytes)
+        .map_err(|e| format!("Checkpoint '{checkpoint_id}' has unreadable metadata: {e}"))?;
+    if metadata.store_name != store_name {
+        return Err(format!(
+            "Checkpoint '{checkpoint_id}' does not belong to store '{store_name}'"
+        ));
+    }
+    let content_path = checkpoint_content_dir(base, store_name).join(&metadata.content_file);
+    let content = fs::read(&content_path)
+        .map_err(|_| format!("Checkpoint '{checkpoint_id}' is missing its content"))?;
+    if checksum(&content) != metadata.content_checksum {
+        return Err(format!(
+            "Checkpoint '{checkpoint_id}' failed checksum verification"
+        ));
+    }
+    String::from_utf8(content)
+        .map_err(|_| format!("Checkpoint '{checkpoint_id}' is not valid UTF-8"))
+}
+
+/// Move unusable live store bytes aside; None when there is no live file.
+pub fn quarantine_store(
+    base: &Path,
+    store_name: &str,
+    live_path: &Path,
+) -> Result<Option<String>, String> {
+    validate_name(store_name, false)?;
+    if !live_path.is_file() {
+        return Ok(None);
+    }
+    let dir = quarantine_dir(base, store_name);
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create quarantine directory: {e}"))?;
+    let id = format!(
+        "{}-{}",
+        Utc::now().timestamp_millis(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let destination = dir.join(format!("{id}.dat"));
+    fs::rename(live_path, &destination)
+        .map_err(|e| format!("Failed to quarantine store '{store_name}': {e}"))?;
+    Ok(Some(destination.to_string_lossy().into_owned()))
+}
+
+/// Crash-safely replace a physical store file with new contents.
+pub fn replace_store(live_path: &Path, contents: &str) -> Result<(), String> {
+    if !is_store_object(contents.as_bytes()) {
+        return Err(format!(
+            "Replacement contents for '{}' are not a JSON object",
+            live_path.display()
+        ));
+    }
+    write_file_atomic(live_path, contents.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, TempDir) {
+        (TempDir::new().unwrap(), TempDir::new().unwrap())
+    }
+
+    fn live_path(live_dir: &Path) -> PathBuf {
+        live_dir.join("settings.dat")
+    }
+
+    fn dir_entries(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn checkpoint_metadata_is_stable() {
+        let (base, _) = setup();
+        let mut schema_versions = BTreeMap::new();
+        schema_versions.insert("AUTOMATION_CONFIGS".to_string(), 8);
+        let contents = r#"{"AUTOMATION_CONFIGS":{"version":8}}"#;
+        let metadata = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "pre-migration",
+            "26.8.0-beta.6",
+            schema_versions.clone(),
+        )
+        .unwrap();
+        assert_eq!(metadata.format_version, CHECKPOINT_FORMAT_VERSION);
+        assert_eq!(metadata.store_name, "settings");
+        assert_eq!(metadata.app_version, "26.8.0-beta.6");
+        assert_eq!(metadata.reason, "pre-migration");
+        assert_eq!(metadata.schema_versions, schema_versions);
+        assert_eq!(metadata.content_checksum, checksum(contents.as_bytes()));
+        assert_eq!(metadata.content_size_bytes, contents.len() as u64);
+        assert!(metadata.content_file_exists);
+        assert!(chrono::DateTime::parse_from_rfc3339(&metadata.created_at).is_ok());
+        let stored: CheckpointMetadata = serde_json::from_str(
+            &fs::read_to_string(
+                checkpoint_dir(base.path(), "settings").join(format!("{}.json", metadata.id)),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(stored.id, metadata.id);
+        assert_eq!(stored.content_checksum, metadata.content_checksum);
+        assert_eq!(stored.schema_versions, metadata.schema_versions);
+    }
+
+    #[test]
+    fn checkpoints_deduplicate_by_content_hash() {
+        let (base, _) = setup();
+        let contents = r#"{"SLEEP_MODE":true}"#;
+        let first = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "pre-migration",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let second = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "manual",
+            "2.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        assert_eq!(first.id, second.id);
+        assert_eq!(
+            dir_entries(&checkpoint_dir(base.path(), "settings")),
+            vec![format!("{}.json", first.id), "content".to_string()]
+        );
+        assert_eq!(
+            dir_entries(&checkpoint_content_dir(base.path(), "settings")).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn checkpoints_list_newest_first() {
+        let (base, _) = setup();
+        let oldest = create_checkpoint(
+            base.path(),
+            "settings",
+            r#"{"step":1}"#,
+            "r1",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let middle = create_checkpoint(
+            base.path(),
+            "settings",
+            r#"{"step":2}"#,
+            "r2",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let newest = create_checkpoint(
+            base.path(),
+            "settings",
+            r#"{"step":3}"#,
+            "r3",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let list = list_checkpoints(base.path(), "settings").unwrap();
+        assert_eq!(
+            list.iter().map(|m| m.id.clone()).collect::<Vec<_>>(),
+            vec![newest.id.clone(), middle.id.clone(), oldest.id.clone()]
+        );
+        assert!(newest.sequence > middle.sequence && middle.sequence > oldest.sequence);
+        assert!(list.first().unwrap().content_file_exists);
+    }
+
+    #[test]
+    fn snapshot_write_leaves_no_temp_files() {
+        let (base, live_dir) = setup();
+        save_snapshot(base.path(), "settings", r#"{"a":1}"#).unwrap();
+        assert_eq!(dir_entries(base.path()), vec!["settings.dat".to_string()]);
+        replace_store(&live_path(live_dir.path()), r#"{"b":2}"#).unwrap();
+        assert_eq!(
+            dir_entries(live_dir.path()),
+            vec!["settings.dat".to_string()]
+        );
+        assert_eq!(
+            fs::read_to_string(live_path(live_dir.path())).unwrap(),
+            r#"{"b":2}"#
+        );
+    }
+
+    #[test]
+    fn snapshot_write_replaces_existing_snapshot() {
+        let (base, _) = setup();
+        save_snapshot(base.path(), "settings", r#"{"v":1}"#).unwrap();
+        save_snapshot(base.path(), "settings", r#"{"v":2}"#).unwrap();
+        assert_eq!(
+            fs::read_to_string(snapshot_path(base.path(), "settings")).unwrap(),
+            r#"{"v":2}"#
+        );
+    }
+
+    #[test]
+    fn replace_store_replaces_existing_file() {
+        let (_, live_dir) = setup();
+        let live = live_path(live_dir.path());
+        fs::write(&live, r#"{"old":true}"#).unwrap();
+        replace_store(&live, r#"{"new":true}"#).unwrap();
+        assert_eq!(fs::read_to_string(&live).unwrap(), r#"{"new":true}"#);
+    }
+
+    #[test]
+    fn snapshot_and_replacement_contents_must_be_json_objects() {
+        let (base, live_dir) = setup();
+        let live = live_path(live_dir.path());
+        for contents in ["", "not json", r#"["array"]"#, "3"] {
+            assert!(save_snapshot(base.path(), "settings", contents).is_err());
+            assert!(replace_store(&live, contents).is_err());
+        }
+        assert!(!snapshot_path(base.path(), "settings").exists());
+        assert!(!live.exists());
+    }
+
+    #[test]
+    fn restore_snapshot_recovers_corrupt_live_store() {
+        let (base, live_dir) = setup();
+        let live = live_path(live_dir.path());
+        for corrupt in ["", "{", r#"{"torn":"#] {
+            fs::write(&live, corrupt).unwrap();
+            save_snapshot(base.path(), "settings", r#"{"good":true}"#).unwrap();
+            assert!(restore_snapshot(base.path(), "settings", &live).unwrap());
+            assert_eq!(fs::read_to_string(&live).unwrap(), r#"{"good":true}"#);
+        }
+    }
+
+    #[test]
+    fn restore_snapshot_rejects_invalid_snapshot() {
+        let (base, live_dir) = setup();
+        let live = live_path(live_dir.path());
+        fs::write(&live, r#"{"original":true}"#).unwrap();
+        for snapshot_bytes in ["", "not json", r#"["array"]"#, r#"42"#] {
+            fs::write(snapshot_path(base.path(), "settings"), snapshot_bytes).unwrap();
+            assert!(!restore_snapshot(base.path(), "settings", &live).unwrap());
+            assert_eq!(fs::read_to_string(&live).unwrap(), r#"{"original":true}"#);
+        }
+    }
+
+    #[test]
+    fn restore_snapshot_without_snapshot_returns_false() {
+        let (base, live_dir) = setup();
+        assert!(!restore_snapshot(base.path(), "settings", &live_path(live_dir.path())).unwrap());
+    }
+
+    #[test]
+    fn read_checkpoint_detects_corruption() {
+        let (base, _) = setup();
+        let contents = r#"{"data":1}"#;
+        let metadata = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "pre-migration",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            read_checkpoint(base.path(), "settings", &metadata.id).unwrap(),
+            contents
+        );
+        let content_path =
+            checkpoint_content_dir(base.path(), "settings").join(&metadata.content_file);
+        fs::write(&content_path, r#"{"tampered":2}"#).unwrap();
+        assert!(read_checkpoint(base.path(), "settings", &metadata.id)
+            .unwrap_err()
+            .contains("checksum"));
+        fs::remove_file(&content_path).unwrap();
+        assert!(read_checkpoint(base.path(), "settings", &metadata.id)
+            .unwrap_err()
+            .contains("missing"));
+        let list = list_checkpoints(base.path(), "settings").unwrap();
+        assert_eq!(list.len(), 1);
+        assert!(!list[0].content_file_exists);
+    }
+
+    #[test]
+    fn quarantine_store_preserves_bytes() {
+        let (base, live_dir) = setup();
+        let live = live_path(live_dir.path());
+        assert_eq!(
+            quarantine_store(base.path(), "settings", &live).unwrap(),
+            None
+        );
+        fs::write(&live, r#"{"broken":"bytes"}"#).unwrap();
+        let quarantined = quarantine_store(base.path(), "settings", &live)
+            .unwrap()
+            .expect("live file should be quarantined");
+        assert!(!live.exists());
+        assert_eq!(
+            fs::read_to_string(&quarantined).unwrap(),
+            r#"{"broken":"bytes"}"#
+        );
+        assert!(quarantined.contains("quarantine"));
+        assert_eq!(
+            quarantine_store(base.path(), "settings", &live).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn names_are_validated() {
+        let (base, live_dir) = setup();
+        for name in ["", "..", "../evil", "a/b", "a\\b", ".hidden", "sp ace"] {
+            assert!(
+                validate_name(name, false).is_err(),
+                "{name} should be rejected"
+            );
+        }
+        assert!(save_snapshot(base.path(), "../evil", "{}").is_err());
+        assert!(create_checkpoint(base.path(), "a/b", "{}", "r", "1", BTreeMap::new()).is_err());
+        assert!(restore_snapshot(base.path(), "..", &live_path(live_dir.path())).is_err());
+        assert!(validate_name("settings", false).is_ok());
+        assert!(validate_name("event_log-1", false).is_ok());
+        assert!(validate_name("settings.dat", true).is_ok());
+        assert!(validate_name("..", true).is_err());
+    }
+
+    #[test]
+    fn checkpoint_contents_must_be_a_json_object() {
+        let (base, _) = setup();
+        for contents in ["", "not json", r#"[1,2]"#, r#"3"#] {
+            assert!(create_checkpoint(
+                base.path(),
+                "settings",
+                contents,
+                "pre-migration",
+                "1.0.0",
+                BTreeMap::new()
+            )
+            .is_err());
+        }
+    }
+}

--- a/src-core/src/store_safety/mod.rs
+++ b/src-core/src/store_safety/mod.rs
@@ -1,6 +1,6 @@
 pub mod commands;
 
-use std::{collections::BTreeMap, fs, path::Path, path::PathBuf};
+use std::{collections::BTreeMap, fs, path::Path, path::PathBuf, time::UNIX_EPOCH};
 
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
@@ -25,9 +25,15 @@ pub struct CheckpointMetadata {
     pub content_checksum: String,
     pub content_size_bytes: u64,
     pub content_file: String,
-    /// Derived from disk, never stored in the metadata file itself.
-    #[serde(skip)]
+    #[serde(default)]
     pub content_file_exists: bool,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotData {
+    pub contents: String,
+    pub modified_at_millis: u64,
 }
 
 pub fn base_dir(app_data_dir: &Path) -> PathBuf {
@@ -68,6 +74,26 @@ fn validate_name(name: &str, allow_dot: bool) -> Result<(), String> {
     } else {
         Err(format!("Invalid name '{name}'"))
     }
+}
+
+fn validate_checkpoint_metadata(
+    metadata: &CheckpointMetadata,
+    store_name: &str,
+    checkpoint_id: &str,
+) -> Result<(), String> {
+    if metadata.format_version != CHECKPOINT_FORMAT_VERSION {
+        return Err(format!(
+            "Checkpoint '{checkpoint_id}' uses unsupported metadata format {}",
+            metadata.format_version
+        ));
+    }
+    if metadata.store_name != store_name || metadata.id != checkpoint_id {
+        return Err(format!(
+            "Checkpoint '{checkpoint_id}' has mismatched metadata"
+        ));
+    }
+    validate_name(&metadata.content_file, true)
+        .map_err(|_| format!("Checkpoint '{checkpoint_id}' has an invalid content file"))
 }
 
 fn checksum(bytes: &[u8]) -> String {
@@ -163,6 +189,37 @@ pub fn save_snapshot(base: &Path, store_name: &str, contents: &str) -> Result<()
     write_file_atomic(&snapshot_path(base, store_name), contents.as_bytes())
 }
 
+/// Read the rolling snapshot without touching the live store. None means no
+/// viable snapshot exists.
+pub fn read_snapshot(base: &Path, store_name: &str) -> Result<Option<SnapshotData>, String> {
+    validate_name(store_name, false)?;
+    let snapshot = snapshot_path(base, store_name);
+    if !snapshot.is_file() {
+        return Ok(None);
+    }
+    let metadata = fs::metadata(&snapshot)
+        .map_err(|e| format!("Failed to read snapshot metadata for store '{store_name}': {e}"))?;
+    let bytes = fs::read(&snapshot)
+        .map_err(|e| format!("Failed to read snapshot of store '{store_name}': {e}"))?;
+    if !is_store_object(&bytes) {
+        return Err(format!(
+            "Snapshot of store '{store_name}' is not a JSON object"
+        ));
+    }
+    let contents = String::from_utf8(bytes)
+        .map_err(|e| format!("Snapshot of store '{store_name}' is not valid UTF-8: {e}"))?;
+    let modified_at_millis = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default();
+    Ok(Some(SnapshotData {
+        contents,
+        modified_at_millis,
+    }))
+}
+
 /// Replace a corrupt live store file with the rolling snapshot. False means no
 /// viable snapshot; the live file is left untouched in that case.
 pub fn restore_snapshot(base: &Path, store_name: &str, live_path: &Path) -> Result<bool, String> {
@@ -197,7 +254,10 @@ pub fn create_checkpoint(
     }
     let checksum = checksum(contents.as_bytes());
     let existing = list_checkpoints(base, store_name)?;
-    if let Some(metadata) = existing.iter().find(|m| m.content_checksum == checksum) {
+    if let Some(metadata) = existing
+        .iter()
+        .find(|m| m.content_checksum == checksum && m.content_file_exists)
+    {
         return Ok(metadata.clone());
     }
     let content_file = format!("{checksum}.dat");
@@ -241,7 +301,12 @@ pub fn list_checkpoints(base: &Path, store_name: &str) -> Result<Vec<CheckpointM
     let mut checkpoints: Vec<CheckpointMetadata> = Vec::new();
     let entries = match fs::read_dir(checkpoint_dir(base, store_name)) {
         Ok(entries) => entries,
-        Err(_) => return Ok(checkpoints),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(checkpoints),
+        Err(error) => {
+            return Err(format!(
+                "Failed to list checkpoints for store '{store_name}': {error}"
+            ));
+        }
     };
     for entry in entries.flatten() {
         let path = entry.path();
@@ -252,7 +317,10 @@ pub fn list_checkpoints(base: &Path, store_name: &str) -> Result<Vec<CheckpointM
         let Ok(mut metadata) = serde_json::from_slice::<CheckpointMetadata>(&bytes) else {
             continue;
         };
-        if metadata.store_name != store_name {
+        let Some(checkpoint_id) = path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if validate_checkpoint_metadata(&metadata, store_name, checkpoint_id).is_err() {
             continue;
         }
         metadata.content_file_exists = checkpoint_content_dir(base, store_name)
@@ -277,14 +345,15 @@ pub fn read_checkpoint(
         .map_err(|_| format!("Checkpoint '{checkpoint_id}' was not found"))?;
     let metadata: CheckpointMetadata = serde_json::from_slice(&bytes)
         .map_err(|e| format!("Checkpoint '{checkpoint_id}' has unreadable metadata: {e}"))?;
-    if metadata.store_name != store_name {
-        return Err(format!(
-            "Checkpoint '{checkpoint_id}' does not belong to store '{store_name}'"
-        ));
-    }
+    validate_checkpoint_metadata(&metadata, store_name, checkpoint_id)?;
     let content_path = checkpoint_content_dir(base, store_name).join(&metadata.content_file);
     let content = fs::read(&content_path)
         .map_err(|_| format!("Checkpoint '{checkpoint_id}' is missing its content"))?;
+    if content.len() as u64 != metadata.content_size_bytes {
+        return Err(format!(
+            "Checkpoint '{checkpoint_id}' failed size verification"
+        ));
+    }
     if checksum(&content) != metadata.content_checksum {
         return Err(format!(
             "Checkpoint '{checkpoint_id}' failed checksum verification"
@@ -385,6 +454,7 @@ mod tests {
         assert_eq!(stored.id, metadata.id);
         assert_eq!(stored.content_checksum, metadata.content_checksum);
         assert_eq!(stored.schema_versions, metadata.schema_versions);
+        assert!(stored.content_file_exists);
     }
 
     #[test]
@@ -417,6 +487,37 @@ mod tests {
         assert_eq!(
             dir_entries(&checkpoint_content_dir(base.path(), "settings")).len(),
             1
+        );
+    }
+
+    #[test]
+    fn checkpoint_deduplication_recreates_missing_content() {
+        let (base, _) = setup();
+        let contents = r#"{"SLEEP_MODE":true}"#;
+        let first = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "pre-migration",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        fs::remove_file(checkpoint_content_dir(base.path(), "settings").join(first.content_file))
+            .unwrap();
+        let replacement = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "store-recovery",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        assert_ne!(replacement.id, first.id);
+        assert_eq!(
+            read_checkpoint(base.path(), "settings", &replacement.id).unwrap(),
+            contents
         );
     }
 
@@ -457,6 +558,10 @@ mod tests {
         );
         assert!(newest.sequence > middle.sequence && middle.sequence > oldest.sequence);
         assert!(list.first().unwrap().content_file_exists);
+        assert_eq!(
+            serde_json::to_value(list.first().unwrap()).unwrap()["contentFileExists"],
+            true
+        );
     }
 
     #[test]
@@ -538,6 +643,33 @@ mod tests {
     }
 
     #[test]
+    fn read_snapshot_returns_contents_without_touching_live() {
+        let (base, live_dir) = setup();
+        let live = live_path(live_dir.path());
+        fs::write(&live, r#"{"original":true}"#).unwrap();
+        save_snapshot(base.path(), "settings", r#"{"good":true}"#).unwrap();
+        assert_eq!(
+            read_snapshot(base.path(), "settings")
+                .unwrap()
+                .unwrap()
+                .contents,
+            r#"{"good":true}"#
+        );
+        assert_eq!(fs::read_to_string(&live).unwrap(), r#"{"original":true}"#);
+    }
+
+    #[test]
+    fn read_snapshot_returns_none_for_missing_snapshot_and_rejects_invalid_snapshot() {
+        let (base, _) = setup();
+        assert_eq!(read_snapshot(base.path(), "settings").unwrap(), None);
+        for snapshot_bytes in ["", "not json", r#"["array"]"#, r#"42"#] {
+            fs::write(snapshot_path(base.path(), "settings"), snapshot_bytes).unwrap();
+            assert!(read_snapshot(base.path(), "settings").is_err());
+        }
+        assert!(read_snapshot(base.path(), "../evil").is_err());
+    }
+
+    #[test]
     fn read_checkpoint_detects_corruption() {
         let (base, _) = setup();
         let contents = r#"{"data":1}"#;
@@ -556,10 +688,14 @@ mod tests {
         );
         let content_path =
             checkpoint_content_dir(base.path(), "settings").join(&metadata.content_file);
-        fs::write(&content_path, r#"{"tampered":2}"#).unwrap();
+        fs::write(&content_path, r#"{"data":2}"#).unwrap();
         assert!(read_checkpoint(base.path(), "settings", &metadata.id)
             .unwrap_err()
             .contains("checksum"));
+        fs::write(&content_path, r#"{"data":"too long"}"#).unwrap();
+        assert!(read_checkpoint(base.path(), "settings", &metadata.id)
+            .unwrap_err()
+            .contains("size"));
         fs::remove_file(&content_path).unwrap();
         assert!(read_checkpoint(base.path(), "settings", &metadata.id)
             .unwrap_err()
@@ -567,6 +703,32 @@ mod tests {
         let list = list_checkpoints(base.path(), "settings").unwrap();
         assert_eq!(list.len(), 1);
         assert!(!list[0].content_file_exists);
+    }
+
+    #[test]
+    fn checkpoint_metadata_must_match_its_file_name() {
+        let (base, _) = setup();
+        let metadata = create_checkpoint(
+            base.path(),
+            "settings",
+            r#"{"data":1}"#,
+            "pre-migration",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let metadata_path =
+            checkpoint_dir(base.path(), "settings").join(format!("{}.json", metadata.id));
+        let mut stored: CheckpointMetadata =
+            serde_json::from_str(&fs::read_to_string(&metadata_path).unwrap()).unwrap();
+        stored.id = "different".to_string();
+        fs::write(&metadata_path, serde_json::to_vec(&stored).unwrap()).unwrap();
+        assert!(list_checkpoints(base.path(), "settings")
+            .unwrap()
+            .is_empty());
+        assert!(read_checkpoint(base.path(), "settings", &metadata.id)
+            .unwrap_err()
+            .contains("mismatched"));
     }
 
     #[test]

--- a/src-core/src/store_safety/mod.rs
+++ b/src-core/src/store_safety/mod.rs
@@ -254,17 +254,15 @@ pub fn create_checkpoint(
     }
     let checksum = checksum(contents.as_bytes());
     let existing = list_checkpoints(base, store_name)?;
-    if let Some(metadata) = existing
-        .iter()
-        .find(|m| m.content_checksum == checksum && m.content_file_exists)
-    {
+    if let Some(metadata) = existing.iter().find(|metadata| {
+        metadata.content_checksum == checksum
+            && read_checkpoint(base, store_name, &metadata.id).as_deref() == Ok(contents)
+    }) {
         return Ok(metadata.clone());
     }
     let content_file = format!("{checksum}.dat");
     let content_path = checkpoint_content_dir(base, store_name).join(&content_file);
-    if !content_path.is_file() {
-        write_file_atomic(&content_path, contents.as_bytes())?;
-    }
+    write_file_atomic(&content_path, contents.as_bytes())?;
     let now = Utc::now();
     let sequence = existing.iter().map(|m| m.sequence).max().unwrap_or(0) + 1;
     let id = format!(
@@ -505,6 +503,40 @@ mod tests {
         .unwrap();
         fs::remove_file(checkpoint_content_dir(base.path(), "settings").join(first.content_file))
             .unwrap();
+        let replacement = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "store-recovery",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        assert_ne!(replacement.id, first.id);
+        assert_eq!(
+            read_checkpoint(base.path(), "settings", &replacement.id).unwrap(),
+            contents
+        );
+    }
+
+    #[test]
+    fn checkpoint_deduplication_replaces_corrupt_content() {
+        let (base, _) = setup();
+        let contents = r#"{"SLEEP_MODE":true}"#;
+        let first = create_checkpoint(
+            base.path(),
+            "settings",
+            contents,
+            "pre-migration",
+            "1.0.0",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        fs::write(
+            checkpoint_content_dir(base.path(), "settings").join(first.content_file),
+            "corrupt",
+        )
+        .unwrap();
         let replacement = create_checkpoint(
             base.path(),
             "settings",

--- a/src-shared-ts/src/migration-runner.test.ts
+++ b/src-shared-ts/src/migration-runner.test.ts
@@ -1,0 +1,317 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runMigrations } from './migration-runner.ts';
+import type { MigrationDefinition, Versioned } from './migration-runner.ts';
+
+interface Settings extends Versioned {
+  name?: string;
+  nested?: { items: number[] };
+  normalized?: boolean;
+}
+
+test('migrates through each step in order', async () => {
+  const calls: number[] = [];
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 3,
+    steps: {
+      0: (data) => {
+        calls.push(data.version);
+        return { ...data, version: 1, name: 'v1' };
+      },
+      1: (data) => {
+        calls.push(data.version);
+        return { ...data, version: 2, name: 'v2' };
+      },
+      2: (data) => {
+        calls.push(data.version);
+        return { ...data, version: 3, name: 'v3' };
+      },
+    },
+  };
+  const result = await runMigrations({ version: 0, name: 'v0' }, definition);
+  if (result.status !== 'migrated') assert.fail(`expected 'migrated', got '${result.status}'`);
+  assert.deepEqual(calls, [0, 1, 2]);
+  assert.deepEqual(result.value, { version: 3, name: 'v3' });
+});
+
+test('awaits async steps before running the next one', async () => {
+  const order: string[] = [];
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 2,
+    steps: {
+      0: async (data) => {
+        order.push('start0');
+        await Promise.resolve();
+        order.push('end0');
+        return { ...data, version: 1 };
+      },
+      1: (data) => {
+        order.push('step1');
+        return { ...data, version: 2 };
+      },
+    },
+  };
+  const result = await runMigrations({ version: 0 }, definition);
+  if (result.status !== 'migrated') assert.fail(`expected 'migrated', got '${result.status}'`);
+  assert.deepEqual(order, ['start0', 'end0', 'step1']);
+  assert.equal(result.value.version, 2);
+});
+
+test('returns unchanged at the target version without running steps', async () => {
+  const calls: string[] = [];
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 2,
+    steps: {
+      0: (data) => {
+        calls.push('step0');
+        return { ...data, version: 1 };
+      },
+      1: (data) => {
+        calls.push('step1');
+        return { ...data, version: 2 };
+      },
+    },
+    normalizeCurrentVersion: (data) => {
+      calls.push('normalize');
+      return { ...data, normalized: true };
+    },
+  };
+  const input: Settings = { version: 2, name: 'x' };
+  const result = await runMigrations(input, definition);
+  if (result.status !== 'unchanged') assert.fail(`expected 'unchanged', got '${result.status}'`);
+  assert.deepEqual(calls, ['normalize']);
+  assert.notEqual(result.value, input);
+  assert.deepEqual(result.value, { version: 2, name: 'x', normalized: true });
+});
+
+test('reports future when the input version is above the target', async () => {
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 2,
+    steps: { 1: (data) => ({ ...data, version: 2 }) },
+    normalizeCurrentVersion: (data) => ({ ...data, normalized: true }),
+  };
+  const input: Settings = { version: 5 };
+  const result = await runMigrations(input, definition);
+  if (result.status !== 'future') assert.fail(`expected 'future', got '${result.status}'`);
+  assert.notEqual(result.value, input);
+  assert.deepEqual(result.value, { version: 5 });
+});
+
+test('reports unsupported below the minimum supported version', async () => {
+  const calls: string[] = [];
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 3,
+    minimumSupportedVersion: 2,
+    steps: {
+      2: (data) => {
+        calls.push('step2');
+        return { ...data, version: 3 };
+      },
+    },
+    normalizeCurrentVersion: (data) => {
+      calls.push('normalize');
+      return data;
+    },
+  };
+  const result = await runMigrations({ version: 1 }, definition);
+  if (result.status !== 'unsupported')
+    assert.fail(`expected 'unsupported', got '${result.status}'`);
+  assert.equal(result.minimumSupportedVersion, 2);
+  assert.deepEqual(result.value, { version: 1 });
+  assert.deepEqual(calls, []);
+});
+
+test('runs the chain from exactly the minimum supported version', async () => {
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 3,
+    minimumSupportedVersion: 2,
+    steps: { 2: (data) => ({ ...data, version: 3, name: 'migrated' }) },
+  };
+  const result = await runMigrations({ version: 2 }, definition);
+  if (result.status !== 'migrated') assert.fail(`expected 'migrated', got '${result.status}'`);
+  assert.deepEqual(result.value, { version: 3, name: 'migrated' });
+});
+
+test('fails when the input has no integer version', async () => {
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 1,
+    steps: { 0: (data) => ({ ...data, version: 1 }) },
+  };
+  const badInputs: unknown[] = [
+    {},
+    { version: undefined },
+    { version: null },
+    { version: 1.5 },
+    { version: Number.NaN },
+    { version: '1' },
+  ];
+  for (const bad of badInputs) {
+    const result = await runMigrations(bad as Settings, definition);
+    if (result.status !== 'failed') assert.fail(`expected 'failed', got '${result.status}'`);
+    assert.equal(result.sourceVersion, null);
+    assert.equal(result.targetVersion, 1);
+    assert.ok(
+      result.cause instanceof Error,
+      `cause must be an Error for input ${JSON.stringify(bad)}`
+    );
+  }
+});
+
+test('fails when a step is missing for the next hop', async () => {
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 3,
+    steps: { 1: (data) => ({ ...data, version: 2 }) },
+  };
+  const result = await runMigrations({ version: 1 }, definition);
+  if (result.status !== 'failed') assert.fail(`expected 'failed', got '${result.status}'`);
+  assert.equal(result.sourceVersion, 2);
+  assert.equal(result.targetVersion, 3);
+  assert.ok(result.cause instanceof Error && /version 2/.test(result.cause.message));
+});
+
+test('keeps the original error from a step that throws', async () => {
+  const boom = new Error('boom');
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 1,
+    steps: {
+      0: () => {
+        throw boom;
+      },
+    },
+  };
+  const result = await runMigrations({ version: 0 }, definition);
+  if (result.status !== 'failed') assert.fail(`expected 'failed', got '${result.status}'`);
+  assert.equal(result.sourceVersion, 0);
+  assert.equal(result.targetVersion, 1);
+  assert.equal(result.cause, boom);
+});
+
+test('keeps the original reason from a step that rejects', async () => {
+  const boom = new Error('async boom');
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 1,
+    steps: { 0: () => Promise.reject(boom) },
+  };
+  const result = await runMigrations({ version: 0 }, definition);
+  if (result.status !== 'failed') assert.fail(`expected 'failed', got '${result.status}'`);
+  assert.equal(result.sourceVersion, 0);
+  assert.equal(result.targetVersion, 1);
+  assert.equal(result.cause, boom);
+});
+
+test('fails when a step does not advance exactly one version', async () => {
+  const badSteps: MigrationDefinition<Settings>['steps']['0'][] = [
+    (data) => ({ ...data }),
+    (data) => ({ ...data, version: data.version + 2 }),
+    () => undefined as unknown as Settings,
+  ];
+  for (const badStep of badSteps) {
+    const definition: MigrationDefinition<Settings> = {
+      targetVersion: 1,
+      steps: { 0: badStep },
+    };
+    const result = await runMigrations({ version: 0 }, definition);
+    if (result.status !== 'failed') assert.fail(`expected 'failed', got '${result.status}'`);
+    assert.equal(result.sourceVersion, 0);
+    assert.equal(result.targetVersion, 1);
+    assert.ok(result.cause instanceof Error, 'cause must be an Error');
+  }
+});
+
+test('never mutates the caller input', async () => {
+  const input: Settings = { version: 0, name: 'original', nested: { items: [1, 2] } };
+  const snapshot = structuredClone(input);
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 2,
+    steps: {
+      0: (data) => {
+        data.nested!.items.push(3);
+        data.name = 'changed';
+        data.version = 1;
+        return data;
+      },
+      1: (data) => ({ ...data, version: 2 }),
+    },
+    normalizeCurrentVersion: (data) => ({ ...data, normalized: true }),
+  };
+  const result = await runMigrations(input, definition);
+  assert.deepEqual(input, snapshot);
+  if (result.status !== 'migrated') assert.fail(`expected 'migrated', got '${result.status}'`);
+  assert.notEqual(result.value, input);
+  assert.notEqual(result.value.nested, input.nested);
+  assert.deepEqual(result.value.nested, { items: [1, 2, 3] });
+  assert.equal(input.name, 'original');
+});
+
+test('normalizes only after the chain reaches the target', async () => {
+  const order: string[] = [];
+  let normalizedVersion = -1;
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 2,
+    steps: {
+      0: (data) => {
+        order.push('step0');
+        return { ...data, version: 1 };
+      },
+      1: async (data) => {
+        order.push('step1');
+        return { ...data, version: 2 };
+      },
+    },
+    normalizeCurrentVersion: (data) => {
+      order.push('normalize');
+      normalizedVersion = data.version;
+      return { ...data, normalized: true };
+    },
+  };
+  const result = await runMigrations({ version: 0 }, definition);
+  if (result.status !== 'migrated') assert.fail(`expected 'migrated', got '${result.status}'`);
+  assert.deepEqual(order, ['step0', 'step1', 'normalize']);
+  assert.equal(normalizedVersion, 2);
+  assert.equal(result.value.normalized, true);
+});
+
+test('skips the normalizer when the chain does not succeed', async () => {
+  let normalized = 0;
+  const counting = (data: Settings): Settings => {
+    normalized++;
+    return data;
+  };
+  await runMigrations(
+    { version: 3 },
+    { targetVersion: 2, steps: {}, normalizeCurrentVersion: counting }
+  );
+  await runMigrations(
+    { version: 0 },
+    { targetVersion: 2, minimumSupportedVersion: 1, steps: {}, normalizeCurrentVersion: counting }
+  );
+  await runMigrations(
+    { version: 0 },
+    {
+      targetVersion: 1,
+      steps: {
+        0: () => {
+          throw new Error('boom');
+        },
+      },
+      normalizeCurrentVersion: counting,
+    }
+  );
+  assert.equal(normalized, 0);
+});
+
+test('fails with the original cause when the normalizer throws', async () => {
+  const boom = new Error('normalize boom');
+  const definition: MigrationDefinition<Settings> = {
+    targetVersion: 1,
+    steps: { 0: (data) => ({ ...data, version: 1 }) },
+    normalizeCurrentVersion: () => {
+      throw boom;
+    },
+  };
+  const result = await runMigrations({ version: 0 }, definition);
+  if (result.status !== 'failed') assert.fail(`expected 'failed', got '${result.status}'`);
+  assert.equal(result.sourceVersion, 1);
+  assert.equal(result.targetVersion, 1);
+  assert.equal(result.cause, boom);
+});

--- a/src-shared-ts/src/migration-runner.test.ts
+++ b/src-shared-ts/src/migration-runner.test.ts
@@ -138,6 +138,8 @@ test('fails when the input has no integer version', async () => {
     steps: { 0: (data) => ({ ...data, version: 1 }) },
   };
   const badInputs: unknown[] = [
+    null,
+    3,
     {},
     { version: undefined },
     { version: null },

--- a/src-shared-ts/src/migration-runner.ts
+++ b/src-shared-ts/src/migration-runner.ts
@@ -1,0 +1,109 @@
+export interface Versioned {
+  version: number;
+}
+
+export type MigrationStep<T extends Versioned> = (data: T) => T | Promise<T>;
+
+export interface MigrationDefinition<T extends Versioned> {
+  targetVersion: number;
+  /** Keyed by source version; each step must return data at its key plus one. */
+  steps: Readonly<Record<number, MigrationStep<T>>>;
+  /** Inputs below this version are reported as 'unsupported' without running any step. */
+  minimumSupportedVersion?: number;
+  /** Runs only once the data has reached 'targetVersion', including when no step was needed. */
+  normalizeCurrentVersion?: (data: T) => T | Promise<T>;
+}
+
+/** 'future' means the input version is above the target; 'unsupported' below the minimum. */
+export type MigrationResult<T extends Versioned> =
+  | { status: 'unchanged'; value: T }
+  | { status: 'migrated'; value: T }
+  | { status: 'future'; value: T }
+  | { status: 'unsupported'; value: T; minimumSupportedVersion: number }
+  | { status: 'failed'; sourceVersion: number | null; targetVersion: number; cause: unknown };
+
+/**
+ * Migrates a structured clone of `data` up to `definition.targetVersion`; the input is never
+ * mutated. A thrown or rejected step or normalizer surfaces as a 'failed' result carrying the
+ * original cause.
+ */
+export async function runMigrations<T extends Versioned>(
+  data: T,
+  definition: MigrationDefinition<T>
+): Promise<MigrationResult<T>> {
+  let current: T;
+  try {
+    current = structuredClone(data);
+  } catch (cause) {
+    return failed(null, definition.targetVersion, cause);
+  }
+  const version = readVersion(current);
+  if (version === null)
+    return failed(
+      null,
+      definition.targetVersion,
+      new Error(`data.version must be an integer, but was ${String(current.version)}`)
+    );
+  if (
+    definition.minimumSupportedVersion !== undefined &&
+    version < definition.minimumSupportedVersion
+  )
+    return {
+      status: 'unsupported',
+      value: current,
+      minimumSupportedVersion: definition.minimumSupportedVersion,
+    };
+  if (version > definition.targetVersion) return { status: 'future', value: current };
+  let migrated = false;
+  while (current.version < definition.targetVersion) {
+    const sourceVersion = current.version;
+    const step = definition.steps[sourceVersion];
+    if (!step)
+      return failed(
+        sourceVersion,
+        sourceVersion + 1,
+        new Error(`no migration step defined for version ${sourceVersion}`)
+      );
+    let next: T;
+    try {
+      next = await step(current);
+    } catch (cause) {
+      return failed(sourceVersion, sourceVersion + 1, cause);
+    }
+    const produced = readVersion(next);
+    if (produced !== sourceVersion + 1)
+      return failed(
+        sourceVersion,
+        sourceVersion + 1,
+        new Error(
+          `the migration step for version ${sourceVersion} must produce version ${
+            sourceVersion + 1
+          }, but produced ${produced === null ? 'no integer version' : produced}`
+        )
+      );
+    current = next;
+    migrated = true;
+  }
+  if (definition.normalizeCurrentVersion) {
+    try {
+      current = await definition.normalizeCurrentVersion(current);
+    } catch (cause) {
+      return failed(definition.targetVersion, definition.targetVersion, cause);
+    }
+  }
+  return { status: migrated ? 'migrated' : 'unchanged', value: current };
+}
+
+function readVersion(data: unknown): number | null {
+  if (typeof data === 'object' && data !== null && Number.isInteger((data as Versioned).version))
+    return (data as Versioned).version;
+  return null;
+}
+
+function failed<T extends Versioned>(
+  sourceVersion: number | null,
+  targetVersion: number,
+  cause: unknown
+): MigrationResult<T> {
+  return { status: 'failed', sourceVersion, targetVersion, cause };
+}

--- a/src-shared-ts/src/migration-runner.ts
+++ b/src-shared-ts/src/migration-runner.ts
@@ -42,7 +42,7 @@ export async function runMigrations<T extends Versioned>(
     return failed(
       null,
       definition.targetVersion,
-      new Error(`data.version must be an integer, but was ${String(current.version)}`)
+      new Error(`data.version must be an integer, but was ${String(readRawVersion(current))}`)
     );
   if (
     definition.minimumSupportedVersion !== undefined &&
@@ -95,9 +95,14 @@ export async function runMigrations<T extends Versioned>(
 }
 
 function readVersion(data: unknown): number | null {
-  if (typeof data === 'object' && data !== null && Number.isInteger((data as Versioned).version))
-    return (data as Versioned).version;
+  const version = readRawVersion(data);
+  if (Number.isInteger(version)) return version as number;
   return null;
+}
+
+function readRawVersion(data: unknown): unknown {
+  if (typeof data !== 'object' || data === null) return undefined;
+  return (data as Record<string, unknown>)['version'];
 }
 
 function failed<T extends Versioned>(

--- a/src-shared-ts/src/store-migration.test.ts
+++ b/src-shared-ts/src/store-migration.test.ts
@@ -226,6 +226,66 @@ test('falls back atomically and preserves unversioned live keys when all candida
   assert.deepEqual(calls, ['checkpoint', 'quarantine', 'replace', 'notify']);
 });
 
+test('recovers each key independently when no whole-store candidate is viable', async () => {
+  const migrationSpec = {
+    storeName: 'settings',
+    migrations: {
+      FIRST: migration(2, { 1: (data) => ({ ...data, version: 2 }) }),
+      SECOND: migration(2, { 1: (data) => ({ ...data, version: 2 }) }),
+    },
+    defaults: {
+      FIRST: { version: 2, value: 'first default' },
+      SECOND: { version: 2, value: 'second default' },
+    },
+  };
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', {
+        FIRST: { version: 3, value: 'future' },
+        SECOND: { version: 2, value: 'live' },
+      }),
+      candidate('checkpoint', 'checkpoint', {
+        FIRST: { version: 2, value: 'checkpoint' },
+        SECOND: { version: 3, value: 'future' },
+      }),
+    ],
+    migrationSpec
+  );
+  assert.equal(decision.action, 'install-defaults');
+  if (decision.action !== 'install-defaults') return;
+  assert.deepEqual(JSON.parse(decision.contents), {
+    FIRST: { version: 2, value: 'checkpoint' },
+    SECOND: { version: 2, value: 'live' },
+  });
+});
+
+test('leaves an unreadable live store untouched when no backup is viable', async () => {
+  const decision = await decideStoreMigration(
+    [
+      { id: 'live', kind: 'live', contents: null },
+      { id: 'snapshot', kind: 'snapshot', contents: null },
+    ],
+    spec()
+  );
+  assert.equal(decision.action, 'defer');
+  let calls = 0;
+  const called = async () => {
+    calls++;
+  };
+  await applyStoreMigration(
+    decision,
+    { exists: true, parsesAsObject: false, contents: null, parsed: null },
+    spec(),
+    {
+      createCheckpoint: called,
+      quarantineStore: called,
+      replaceStore: called,
+      notifyFallback: called,
+    }
+  );
+  assert.equal(calls, 0);
+});
+
 test('blocks replacement when quarantine fails', async () => {
   const migrationSpec = spec();
   const decision = await decideStoreMigration(

--- a/src-shared-ts/src/store-migration.test.ts
+++ b/src-shared-ts/src/store-migration.test.ts
@@ -1,0 +1,344 @@
+import assert from 'node:assert/strict';
+import { registerHooks } from 'node:module';
+import test from 'node:test';
+import type { MigrationDefinition, Versioned } from './migration-runner.ts';
+
+registerHooks({
+  resolve(
+    specifier: string,
+    context: unknown,
+    nextResolve: (specifier: string, context: unknown) => unknown
+  ) {
+    try {
+      return nextResolve(specifier, context);
+    } catch (cause) {
+      if (specifier.startsWith('.') && !specifier.endsWith('.ts')) {
+        return nextResolve(specifier + '.ts', context);
+      }
+      throw cause;
+    }
+  },
+});
+
+const { applyStoreMigration, decideStoreMigration } = await import('./store-migration.ts');
+
+const migration = (
+  targetVersion: number,
+  steps: Record<number, (data: Versioned & Record<string, unknown>) => Versioned> = {}
+): MigrationDefinition<Versioned> => ({
+  targetVersion,
+  minimumSupportedVersion: 1,
+  steps,
+});
+
+const spec = (
+  definition: MigrationDefinition<Versioned> = migration(2, {
+    1: (data) => ({ ...data, version: 2 }),
+  })
+) => ({
+  storeName: 'settings',
+  migrations: { CONFIG: definition },
+  defaults: { CONFIG: { version: definition.targetVersion, value: 'default' } },
+});
+
+const candidate = (id: string, kind: 'live' | 'snapshot' | 'checkpoint', value: unknown) => ({
+  id,
+  kind,
+  contents: typeof value === 'string' ? value : JSON.stringify(value),
+});
+
+test('keeps a current live store unchanged', async () => {
+  const decision = await decideStoreMigration(
+    [candidate('live', 'live', { CONFIG: { version: 2, value: 'live' } })],
+    spec()
+  );
+  assert.equal(decision.action, 'keep-live');
+});
+
+test('keep-live performs no filesystem or UI action', async () => {
+  const migrationSpec = spec();
+  const decision = await decideStoreMigration(
+    [candidate('live', 'live', { CONFIG: { version: 2 } })],
+    migrationSpec
+  );
+  let calls = 0;
+  const called = async () => {
+    calls++;
+  };
+  await applyStoreMigration(
+    decision,
+    { exists: true, parsesAsObject: true, contents: '{}', parsed: {} },
+    migrationSpec,
+    {
+      createCheckpoint: called,
+      quarantineStore: called,
+      replaceStore: called,
+      notifyFallback: called,
+    }
+  );
+  assert.equal(calls, 0);
+});
+
+test('checkpoints and installs a forward migration as one store value', async () => {
+  const decision = await decideStoreMigration(
+    [candidate('live', 'live', { CONFIG: { version: 1, value: 'live' }, KEEP: 7 })],
+    spec()
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.checkpointLive, true);
+  assert.equal(decision.checkpointReason, 'schema-migration');
+  assert.deepEqual(JSON.parse(decision.contents), {
+    CONFIG: { version: 2, value: 'live' },
+    KEEP: 7,
+  });
+});
+
+test('uses a rolling snapshot after a corrupt live candidate', async () => {
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', '{'),
+      candidate('snapshot', 'snapshot', { CONFIG: { version: 2, value: 'snapshot' } }),
+    ],
+    spec()
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.selectedId, 'snapshot');
+  assert.equal(decision.checkpointLive, false);
+  assert.equal(decision.quarantineLive, true);
+});
+
+test('checkpoints future live bytes before restoring a compatible checkpoint', async () => {
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', { CONFIG: { version: 3, value: 'beta' } }),
+      candidate('release', 'checkpoint', { CONFIG: { version: 2, value: 'release' } }),
+    ],
+    spec()
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.selectedId, 'release');
+  assert.equal(decision.checkpointLive, true);
+  assert.equal(decision.checkpointReason, 'store-recovery');
+});
+
+test('skips a broken newest checkpoint for an older compatible checkpoint', async () => {
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', { CONFIG: { version: 3 } }),
+      { id: 'newest', kind: 'checkpoint' as const, contents: null },
+      candidate('older', 'checkpoint', { CONFIG: { version: 2, value: 'older' } }),
+    ],
+    spec()
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.selectedId, 'older');
+});
+
+test('tries the next candidate after a migration throws', async () => {
+  const throwing = spec(
+    migration(2, {
+      1: () => {
+        throw new Error('broken migration');
+      },
+    })
+  );
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', { CONFIG: { version: 1 } }),
+      candidate('checkpoint', 'checkpoint', { CONFIG: { version: 2, value: 'safe' } }),
+    ],
+    throwing
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.selectedId, 'checkpoint');
+});
+
+test('tries the next candidate after normalization throws', async () => {
+  const definition = migration(1);
+  definition.normalizeCurrentVersion = (data) => {
+    if ((data as Record<string, unknown>)['bad']) throw new Error('broken normalization');
+    return data;
+  };
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', { CONFIG: { version: 1, bad: true } }),
+      candidate('checkpoint', 'checkpoint', { CONFIG: { version: 1, value: 'safe' } }),
+    ],
+    spec(definition)
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.selectedId, 'checkpoint');
+});
+
+test('treats a non-versioned known key as an unviable candidate', async () => {
+  const decision = await decideStoreMigration(
+    [candidate('live', 'live', { CONFIG: null })],
+    spec()
+  );
+  assert.equal(decision.action, 'install-defaults');
+});
+
+test('prefers newer migratable live data over an older current checkpoint', async () => {
+  const decision = await decideStoreMigration(
+    [
+      candidate('live', 'live', { CONFIG: { version: 1, value: 'newer' } }),
+      candidate('checkpoint', 'checkpoint', { CONFIG: { version: 2, value: 'older' } }),
+    ],
+    spec()
+  );
+  assert.equal(decision.action, 'install');
+  if (decision.action !== 'install') return;
+  assert.equal(decision.selectedId, 'live');
+  assert.equal(JSON.parse(decision.contents).CONFIG.value, 'newer');
+});
+
+test('falls back atomically and preserves unversioned live keys when all candidates fail', async () => {
+  const migrationSpec = spec();
+  const decision = await decideStoreMigration(
+    [candidate('live', 'live', { CONFIG: { version: 9 }, KEEP: { enabled: true } })],
+    migrationSpec
+  );
+  assert.equal(decision.action, 'install-defaults');
+  if (decision.action !== 'install-defaults') return;
+  assert.deepEqual(JSON.parse(decision.contents), {
+    KEEP: { enabled: true },
+    CONFIG: { version: 2, value: 'default' },
+  });
+
+  const calls: string[] = [];
+  await applyStoreMigration(
+    decision,
+    { exists: true, parsesAsObject: true, contents: '{}', parsed: {} },
+    migrationSpec,
+    {
+      createCheckpoint: async () => void calls.push('checkpoint'),
+      quarantineStore: async () => void calls.push('quarantine'),
+      replaceStore: async () => void calls.push('replace'),
+      notifyFallback: async () => void calls.push('notify'),
+    }
+  );
+  assert.deepEqual(calls, ['checkpoint', 'quarantine', 'replace', 'notify']);
+});
+
+test('blocks replacement when quarantine fails', async () => {
+  const migrationSpec = spec();
+  const decision = await decideStoreMigration(
+    [candidate('live', 'live', { CONFIG: { version: 9 } })],
+    migrationSpec
+  );
+  let replaced = false;
+  await assert.rejects(() =>
+    applyStoreMigration(
+      decision,
+      { exists: true, parsesAsObject: true, contents: '{}', parsed: {} },
+      migrationSpec,
+      {
+        createCheckpoint: async () => undefined,
+        quarantineStore: async () => {
+          throw new Error('locked');
+        },
+        replaceStore: async () => {
+          replaced = true;
+        },
+        notifyFallback: async () => undefined,
+      }
+    )
+  );
+  assert.equal(replaced, false);
+});
+
+test('does not expose a partially migrated multi-key candidate', async () => {
+  const original = {
+    FIRST: { version: 1, value: 'one' },
+    SECOND: { version: 1, value: 'two' },
+  };
+  const migrationSpec = {
+    storeName: 'settings',
+    migrations: {
+      FIRST: migration(2, { 1: (data) => ({ ...data, version: 2 }) }),
+      SECOND: migration(2, {
+        1: () => {
+          throw new Error('second failed');
+        },
+      }),
+    },
+    defaults: {
+      FIRST: { version: 2, value: 'first default' },
+      SECOND: { version: 2, value: 'second default' },
+    },
+  };
+  const decision = await decideStoreMigration([candidate('live', 'live', original)], migrationSpec);
+  assert.equal(decision.action, 'install-defaults');
+  assert.deepEqual(original, {
+    FIRST: { version: 1, value: 'one' },
+    SECOND: { version: 1, value: 'two' },
+  });
+});
+
+test('bootstraps a fresh install without a fallback notice', async () => {
+  const migrationSpec = spec();
+  const decision = await decideStoreMigration([], migrationSpec);
+  assert.equal(decision.action, 'install-defaults');
+  if (decision.action !== 'install-defaults') return;
+  assert.equal(decision.hadCandidates, false);
+  let notified = false;
+  await applyStoreMigration(
+    decision,
+    { exists: false, parsesAsObject: false, contents: null, parsed: null },
+    migrationSpec,
+    {
+      createCheckpoint: async () => undefined,
+      quarantineStore: async () => undefined,
+      replaceStore: async () => undefined,
+      notifyFallback: async () => {
+        notified = true;
+      },
+    }
+  );
+  assert.equal(notified, false);
+});
+
+test('restores the most recent compatible state across an A/B/A/B channel round trip', async () => {
+  const releaseA = spec(migration(1));
+  const betaB = spec(
+    migration(2, {
+      1: (data) => ({ ...data, version: 2 }),
+    })
+  );
+  const stateA = { CONFIG: { version: 1, channel: 'release' } };
+  const firstBeta = await decideStoreMigration([candidate('live', 'live', stateA)], betaB);
+  assert.equal(firstBeta.action, 'install');
+  if (firstBeta.action !== 'install') return;
+  const stateB = JSON.parse(firstBeta.contents);
+  stateB.CONFIG.channel = 'beta-updated';
+
+  const backToA = await decideStoreMigration(
+    [candidate('live', 'live', stateB), candidate('checkpoint-a', 'checkpoint', stateA)],
+    releaseA
+  );
+  assert.equal(backToA.action, 'install');
+  if (backToA.action !== 'install') return;
+  assert.equal(backToA.selectedId, 'checkpoint-a');
+  const updatedRelease = JSON.parse(backToA.contents);
+  updatedRelease.CONFIG.channel = 'release-updated';
+
+  const backToB = await decideStoreMigration(
+    [
+      candidate('live', 'live', updatedRelease),
+      candidate('snapshot', 'snapshot', stateB),
+      candidate('checkpoint-b', 'checkpoint', stateB),
+      candidate('checkpoint-a', 'checkpoint', stateA),
+    ],
+    betaB
+  );
+  assert.equal(backToB.action, 'install');
+  if (backToB.action !== 'install') return;
+  assert.equal(backToB.selectedId, 'live');
+  assert.equal(JSON.parse(backToB.contents).CONFIG.channel, 'release-updated');
+});

--- a/src-shared-ts/src/store-migration.ts
+++ b/src-shared-ts/src/store-migration.ts
@@ -26,6 +26,7 @@ export interface CandidateReport {
 
 export type StoreMigrationDecision =
   | { action: 'keep-live'; reports: CandidateReport[] }
+  | { action: 'defer'; reports: CandidateReport[] }
   | {
       action: 'install';
       contents: string;
@@ -66,6 +67,7 @@ interface CandidateEvaluation {
   report: CandidateReport;
   parsed: Record<string, unknown> | null;
   migrated: Record<string, unknown> | null;
+  resolved: Record<string, unknown>;
   migratedAnyKey: boolean;
 }
 
@@ -81,9 +83,16 @@ export async function decideStoreMigration(
   const selected = evaluations.find((evaluation) => evaluation.report.viable);
   if (!selected) {
     const live = evaluations.find((e) => e.report.kind === 'live');
+    if (
+      live &&
+      live.parsed === null &&
+      candidates.find((candidate) => candidate.kind === 'live')?.contents === null
+    ) {
+      return { action: 'defer', reports };
+    }
     return {
       action: 'install-defaults',
-      contents: defaultsContents(live?.parsed ?? null, spec),
+      contents: recoveredContents(evaluations, spec),
       hadCandidates: candidates.length > 0,
       reports,
     };
@@ -120,7 +129,7 @@ export async function applyStoreMigration(
   spec: StoreMigrationSpec,
   ports: StoreMigrationPorts
 ): Promise<void> {
-  if (decision.action === 'keep-live') return;
+  if (decision.action === 'keep-live' || decision.action === 'defer') return;
   if (decision.action === 'install') {
     if (decision.checkpointLive && live.contents !== null) {
       await ports.createCheckpoint(
@@ -182,6 +191,7 @@ async function evaluateCandidate(
     report: { ...report, reason },
     parsed,
     migrated: null,
+    resolved: {},
     migratedAnyKey: false,
   });
   if (candidate.contents === null) return unviable('candidate could not be read', null);
@@ -195,27 +205,44 @@ async function evaluateCandidate(
     return unviable('candidate is not a JSON object', null);
   }
   const migrated = structuredClone(parsed);
+  const resolved: Record<string, unknown> = {};
+  const failures: string[] = [];
   let migratedAnyKey = false;
   for (const [key, definition] of Object.entries(spec.migrations)) {
     if (!(key in migrated)) {
       migrated[key] = structuredClone(spec.defaults[key]);
+      resolved[key] = structuredClone(migrated[key]);
       continue;
     }
     const result = await runMigrations(migrated[key] as Versioned, definition);
-    if (result.status !== 'migrated' && result.status !== 'unchanged')
-      return unviable(describeFailure(key, result, definition.targetVersion), parsed);
-    if (result.value.version !== definition.targetVersion)
-      return unviable(
-        `key '${key}' finished at version ${result.value.version} instead of ${definition.targetVersion}`,
-        parsed
+    if (result.status !== 'migrated' && result.status !== 'unchanged') {
+      failures.push(describeFailure(key, result, definition.targetVersion));
+      continue;
+    }
+    if (result.value.version !== definition.targetVersion) {
+      failures.push(
+        `key '${key}' finished at version ${result.value.version} instead of ${definition.targetVersion}`
       );
+      continue;
+    }
     migrated[key] = result.value;
+    resolved[key] = result.value;
     if (result.status === 'migrated') migratedAnyKey = true;
+  }
+  if (failures.length > 0) {
+    return {
+      report: { ...report, reason: failures.join('; ') },
+      parsed,
+      migrated: null,
+      resolved,
+      migratedAnyKey,
+    };
   }
   return {
     report: { ...report, viable: true, atTarget: !migratedAnyKey },
     parsed,
     migrated,
+    resolved,
     migratedAnyKey,
   };
 }
@@ -237,18 +264,17 @@ function describeFailure(
   }
 }
 
-function defaultsContents(
-  liveParsed: Record<string, unknown> | null,
-  spec: StoreMigrationSpec
-): string {
+function recoveredContents(evaluations: CandidateEvaluation[], spec: StoreMigrationSpec): string {
   const contents: Record<string, unknown> = {};
+  const liveParsed = evaluations.find((evaluation) => evaluation.report.kind === 'live')?.parsed;
   if (liveParsed) {
     for (const [key, value] of Object.entries(liveParsed)) {
       if (!(key in spec.migrations)) contents[key] = value;
     }
   }
   for (const [key, value] of Object.entries(spec.defaults)) {
-    contents[key] = structuredClone(value);
+    const recovered = evaluations.find((evaluation) => key in evaluation.resolved)?.resolved[key];
+    contents[key] = structuredClone(recovered ?? value);
   }
   return JSON.stringify(contents);
 }

--- a/src-shared-ts/src/store-migration.ts
+++ b/src-shared-ts/src/store-migration.ts
@@ -1,0 +1,254 @@
+import { runMigrations } from './migration-runner';
+import type { MigrationDefinition, MigrationResult, Versioned } from './migration-runner';
+
+export interface StoreMigrationSpec {
+  storeName: string;
+  migrations: Record<string, MigrationDefinition<Versioned>>;
+  defaults: Record<string, unknown>;
+}
+
+export type StoreCandidateKind = 'live' | 'snapshot' | 'checkpoint';
+
+export interface StoreCandidate {
+  id: string;
+  kind: StoreCandidateKind;
+  /** Raw store bytes; null marks a candidate that exists but cannot be read. */
+  contents: string | null;
+}
+
+export interface CandidateReport {
+  id: string;
+  kind: StoreCandidateKind;
+  viable: boolean;
+  atTarget: boolean;
+  reason?: string;
+}
+
+export type StoreMigrationDecision =
+  | { action: 'keep-live'; reports: CandidateReport[] }
+  | {
+      action: 'install';
+      contents: string;
+      selectedId: string;
+      checkpointLive: boolean;
+      quarantineLive: boolean;
+      checkpointReason: 'schema-migration' | 'normalization' | 'store-recovery';
+      reports: CandidateReport[];
+    }
+  | {
+      action: 'install-defaults';
+      contents: string;
+      hadCandidates: boolean;
+      reports: CandidateReport[];
+    };
+
+export interface StoreMigrationPorts {
+  createCheckpoint(
+    storeName: string,
+    reason: string,
+    schemaVersions: Record<string, number>,
+    contents: string
+  ): Promise<void>;
+  /** Must move the live file aside or resolve for an absent file; a rejection blocks the caller. */
+  quarantineStore(storeName: string): Promise<void>;
+  replaceStore(storeName: string, contents: string): Promise<void>;
+  notifyFallback(storeName: string): Promise<void>;
+}
+
+export interface LiveStoreState {
+  exists: boolean;
+  parsesAsObject: boolean;
+  contents: string | null;
+  parsed: Record<string, unknown> | null;
+}
+
+interface CandidateEvaluation {
+  report: CandidateReport;
+  parsed: Record<string, unknown> | null;
+  migrated: Record<string, unknown> | null;
+  migratedAnyKey: boolean;
+}
+
+export async function decideStoreMigration(
+  candidates: StoreCandidate[],
+  spec: StoreMigrationSpec
+): Promise<StoreMigrationDecision> {
+  const evaluations: CandidateEvaluation[] = [];
+  for (const candidate of candidates) {
+    evaluations.push(await evaluateCandidate(candidate, spec));
+  }
+  const reports = evaluations.map((evaluation) => evaluation.report);
+  const selected = evaluations.find((evaluation) => evaluation.report.viable);
+  if (!selected) {
+    const live = evaluations.find((e) => e.report.kind === 'live');
+    return {
+      action: 'install-defaults',
+      contents: defaultsContents(live?.parsed ?? null, spec),
+      hadCandidates: candidates.length > 0,
+      reports,
+    };
+  }
+  if (selected.report.kind === 'live') {
+    if (JSON.stringify(selected.parsed) === JSON.stringify(selected.migrated)) {
+      return { action: 'keep-live', reports };
+    }
+    return {
+      action: 'install',
+      contents: JSON.stringify(selected.migrated),
+      selectedId: selected.report.id,
+      checkpointLive: true,
+      quarantineLive: false,
+      checkpointReason: selected.migratedAnyKey ? 'schema-migration' : 'normalization',
+      reports,
+    };
+  }
+  const live = evaluations.find((e) => e.report.kind === 'live');
+  return {
+    action: 'install',
+    contents: JSON.stringify(selected.migrated),
+    selectedId: selected.report.id,
+    checkpointLive: live?.parsed != null,
+    quarantineLive: live !== undefined && live.parsed === null,
+    checkpointReason: 'store-recovery',
+    reports,
+  };
+}
+
+export async function applyStoreMigration(
+  decision: StoreMigrationDecision,
+  live: LiveStoreState,
+  spec: StoreMigrationSpec,
+  ports: StoreMigrationPorts
+): Promise<void> {
+  if (decision.action === 'keep-live') return;
+  if (decision.action === 'install') {
+    if (decision.checkpointLive && live.contents !== null) {
+      await ports.createCheckpoint(
+        spec.storeName,
+        decision.checkpointReason,
+        schemaVersionVector(live.parsed, spec),
+        live.contents
+      );
+    }
+    if (decision.quarantineLive) await ports.quarantineStore(spec.storeName);
+    await ports.replaceStore(spec.storeName, decision.contents);
+    return;
+  }
+  if (live.parsed !== null && live.contents !== null) {
+    await ports.createCheckpoint(
+      spec.storeName,
+      'store-recovery',
+      schemaVersionVector(live.parsed, spec),
+      live.contents
+    );
+  }
+  await ports.quarantineStore(spec.storeName);
+  await ports.replaceStore(spec.storeName, decision.contents);
+  if (decision.hadCandidates) await ports.notifyFallback(spec.storeName);
+}
+
+export function schemaVersionVector(
+  parsed: Record<string, unknown> | null,
+  spec: StoreMigrationSpec
+): Record<string, number> {
+  const versions: Record<string, number> = {};
+  if (!parsed) return versions;
+  for (const key of Object.keys(spec.migrations)) {
+    const value = parsed[key];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      Number.isInteger((value as Versioned).version)
+    )
+      versions[key] = (value as Versioned).version;
+  }
+  return versions;
+}
+
+async function evaluateCandidate(
+  candidate: StoreCandidate,
+  spec: StoreMigrationSpec
+): Promise<CandidateEvaluation> {
+  const report: CandidateReport = {
+    id: candidate.id,
+    kind: candidate.kind,
+    viable: false,
+    atTarget: false,
+  };
+  const unviable = (
+    reason: string,
+    parsed: Record<string, unknown> | null
+  ): CandidateEvaluation => ({
+    report: { ...report, reason },
+    parsed,
+    migrated: null,
+    migratedAnyKey: false,
+  });
+  if (candidate.contents === null) return unviable('candidate could not be read', null);
+  let parsed: Record<string, unknown>;
+  try {
+    const value: unknown = JSON.parse(candidate.contents);
+    if (typeof value !== 'object' || value === null || Array.isArray(value))
+      throw new Error('not a JSON object');
+    parsed = value as Record<string, unknown>;
+  } catch {
+    return unviable('candidate is not a JSON object', null);
+  }
+  const migrated = structuredClone(parsed);
+  let migratedAnyKey = false;
+  for (const [key, definition] of Object.entries(spec.migrations)) {
+    if (!(key in migrated)) {
+      migrated[key] = structuredClone(spec.defaults[key]);
+      continue;
+    }
+    const result = await runMigrations(migrated[key] as Versioned, definition);
+    if (result.status !== 'migrated' && result.status !== 'unchanged')
+      return unviable(describeFailure(key, result, definition.targetVersion), parsed);
+    if (result.value.version !== definition.targetVersion)
+      return unviable(
+        `key '${key}' finished at version ${result.value.version} instead of ${definition.targetVersion}`,
+        parsed
+      );
+    migrated[key] = result.value;
+    if (result.status === 'migrated') migratedAnyKey = true;
+  }
+  return {
+    report: { ...report, viable: true, atTarget: !migratedAnyKey },
+    parsed,
+    migrated,
+    migratedAnyKey,
+  };
+}
+
+function describeFailure(
+  key: string,
+  result: MigrationResult<Versioned>,
+  targetVersion: number
+): string {
+  switch (result.status) {
+    case 'future':
+      return `key '${key}' is at version ${result.value.version}, which is from a newer release (this release supports ${targetVersion})`;
+    case 'unsupported':
+      return `key '${key}' is at version ${result.value.version}, which is below the minimum supported version ${result.minimumSupportedVersion}`;
+    case 'failed':
+      return `migrating key '${key}' to version ${result.targetVersion} failed: ${result.cause}`;
+    default:
+      return `key '${key}' unexpectedly reported ${result.status}`;
+  }
+}
+
+function defaultsContents(
+  liveParsed: Record<string, unknown> | null,
+  spec: StoreMigrationSpec
+): string {
+  const contents: Record<string, unknown> = {};
+  if (liveParsed) {
+    for (const [key, value] of Object.entries(liveParsed)) {
+      if (!(key in spec.migrations)) contents[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(spec.defaults)) {
+    contents[key] = structuredClone(value);
+  }
+  return JSON.stringify(contents);
+}

--- a/src-ui/app/app.module.ts
+++ b/src-ui/app/app.module.ts
@@ -271,6 +271,7 @@ import { SleepDevicePowerAutomationsService } from './services/power-automations
 import { TurnOffDevicesWhenChargingAutomationService } from './services/power-automations/turn-off-devices-when-charging-automation.service';
 import { VRCXService } from './services/vrcx.service';
 import { StoreSnapshotService } from './services/store-snapshot.service';
+import { MigrationCoordinatorService } from './services/migration-coordinator.service';
 
 [
   localeEN,
@@ -514,6 +515,7 @@ export class AppModule {
     private frameLimiterService: FrameLimiterService,
     private deviceManagerService: DeviceManagerService,
     private storeSnapshotService: StoreSnapshotService,
+    private migrationCoordinatorService: MigrationCoordinatorService,
     // GPU automations
     private gpuAutomations: GpuAutomationsService,
     // Sleep mode automations
@@ -603,8 +605,12 @@ export class AppModule {
           if (!(await this.elevationCheck())) return;
           const initStartTime = Date.now();
           await this.logInit('Initializing dev debug services', this.developerDebugService.init());
-          // Set up store snapshots (and restore them if needed)
-          await this.logInit('Initializing store snapshots', this.storeSnapshotService.init());
+          await this.logInit(
+            'Initializing store recovery',
+            this.storeSnapshotService.initializeRecovery()
+          );
+          await this.logInit('Migrating store schemas', this.migrationCoordinatorService.run());
+          this.storeSnapshotService.enablePeriodicSnapshots();
           // Clean cache
           await this.logInit('Cleaning cache', CachedValue.cleanCache()).catch(() => {}); // Allow initialization to continue if failed
           // Preload assets (Not blocking)

--- a/src-ui/app/migrations/app-settings.migrations.ts
+++ b/src-ui/app/migrations/app-settings.migrations.ts
@@ -1,93 +1,13 @@
-import { mergeWith } from 'lodash';
-import { APP_SETTINGS_DEFAULT, AppSettings } from '../models/settings';
-import { error, info } from '@tauri-apps/plugin-log';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
-import { message } from '@tauri-apps/plugin-dialog';
+import { APP_SETTINGS_DEFAULT } from '../models/settings';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
 import { migrateLighthouseDeviceId } from './lighthouse-device-id';
 import { protectSecret } from '../utils/secrets';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: from1to2,
-  3: from2to3,
-  4: from3to4,
-  5: from4to5,
-  6: from5to6,
-  7: from6to7,
-  8: from7to8,
-  9: from8to9,
-  10: from9to10,
-  11: from10to11,
-  12: from11to12,
-};
+import { normalizeWithDefaults } from './migration-defaults';
 
 async function from11to12(data: any): Promise<any> {
-  try {
-    data.mqttProtectedPassword = await protectSecret(data.mqttPassword);
-  } catch (e) {
-    error("[app-settings-migrations] Couldn't protect the MQTT password: " + e);
-  }
+  data.mqttProtectedPassword = await protectSecret(data.mqttPassword);
   data.mqttPassword = null;
   data.version = 12;
-  return data;
-}
-
-export async function migrateAppSettings(data: any): Promise<AppSettings> {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > APP_SETTINGS_DEFAULT.version) {
-    data = resetToLatest(data);
-    info(
-      `[app-settings-migrations] Reset future app settings version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < APP_SETTINGS_DEFAULT.version) {
-    try {
-      data = await migrations[++currentVersion](data);
-    } catch (e) {
-      error(
-        "[app-settings-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(data));
-      data = resetToLatest(data);
-      currentVersion = data.version;
-      message(
-        'Your application settings could not to be migrated to the new version of OyasumiVR, and have therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (App Settings)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(`[app-settings-migrations] Migrated app settings to version ${currentVersion + ''}`);
-  }
-  data = mergeWith(structuredClone(APP_SETTINGS_DEFAULT), data, (objValue, srcValue) => {
-    // Delete irrelevant keys
-    if (objValue === undefined) {
-      return undefined;
-    }
-    // Do not merge array values
-    if (Array.isArray(objValue)) {
-      return srcValue;
-    }
-  });
-  return data as AppSettings;
-}
-
-async function saveBackup(oldData: any) {
-  const redacted = { ...oldData, mqttPassword: undefined, mqttProtectedPassword: undefined };
-  await writeTextFile('app-settings.backup.json', JSON.stringify(redacted, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
-
-function resetToLatest(data: any): any {
-  // Reset to latest
-  data = structuredClone(APP_SETTINGS_DEFAULT);
   return data;
 }
 
@@ -109,7 +29,6 @@ function from9to10(data: any): any {
   data.overlayGpuAcceleration = !(data.overlayGpuFix ?? false);
   delete data.overlayGpuFix;
 
-  // Remove unused one-time flags
   if (data.oneTimeFlags) {
     data.oneTimeFlags = data.oneTimeFlags.filter(
       (flag: string) =>
@@ -118,10 +37,8 @@ function from9to10(data: any): any {
     );
   }
 
-  // Remove device nicknames
   delete data.deviceNicknames;
 
-  // Remove ignored lighthouses
   delete data.ignoredLighthouses;
 
   return data;
@@ -184,7 +101,6 @@ function from3to4(data: any): any {
 
 function from2to3(data: any): any {
   data.version = 3;
-  // Missing keys are now always added by default
   return data;
 }
 
@@ -193,3 +109,22 @@ function from1to2(data: any): any {
   data.askForAdminOnStart = false;
   return data;
 }
+
+export const APP_SETTINGS_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: APP_SETTINGS_DEFAULT.version,
+  minimumSupportedVersion: 1,
+  steps: {
+    1: from1to2,
+    2: from2to3,
+    3: from3to4,
+    4: from4to5,
+    5: from5to6,
+    6: from6to7,
+    7: from7to8,
+    8: from8to9,
+    9: from9to10,
+    10: from10to11,
+    11: from11to12,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(APP_SETTINGS_DEFAULT, data),
+};

--- a/src-ui/app/migrations/automation-configs.historical-defaults.ts
+++ b/src-ui/app/migrations/automation-configs.historical-defaults.ts
@@ -1,0 +1,153 @@
+export const MSI_AFTERBURNER_V6 = {
+  enabled: false,
+  msiAfterburnerPath: 'C:\\Program Files (x86)\\MSI Afterburner\\MSIAfterburner.exe',
+  onSleepEnableProfile: 0,
+  onSleepDisableProfile: 0,
+};
+
+export const SET_BRIGHTNESS_AUTOMATIONS_V9 = {
+  SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE: {
+    enabled: false,
+    brightness: 20,
+    imageBrightness: 20,
+    displayBrightness: 100,
+    transition: true,
+    transitionTime: 1000 * 60 * 5,
+    applyOnStart: true,
+  },
+  SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE: {
+    enabled: false,
+    brightness: 100,
+    imageBrightness: 100,
+    displayBrightness: 100,
+    transition: true,
+    transitionTime: 10000,
+    applyOnStart: true,
+  },
+  SET_BRIGHTNESS_ON_SLEEP_PREPARATION: {
+    enabled: false,
+    brightness: 50,
+    imageBrightness: 50,
+    displayBrightness: 100,
+    transition: true,
+    transitionTime: 30000,
+  },
+};
+
+export const BRIGHTNESS_AUTOMATIONS_V17 = {
+  enabled: true,
+  advancedMode: false,
+  SLEEP_PREPARATION: {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 50,
+    softwareBrightness: 50,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 1000 * 60 * 5,
+    colorTemperature: 3500,
+  },
+  SLEEP_MODE_ENABLE: {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 20,
+    softwareBrightness: 20,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 10000,
+    colorTemperature: 1800,
+  },
+  SLEEP_MODE_DISABLE: {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 100,
+    softwareBrightness: 100,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 10000,
+    colorTemperature: 6600,
+  },
+  AT_SUNSET: {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 80,
+    softwareBrightness: 80,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 1000 * 60 * 5,
+    colorTemperature: 1800,
+  },
+  AT_SUNRISE: {
+    enabled: false,
+    changeBrightness: true,
+    changeColorTemperature: true,
+    brightness: 100,
+    softwareBrightness: 100,
+    hardwareBrightness: 100,
+    transition: true,
+    transitionTime: 1000 * 60 * 5,
+    colorTemperature: 6600,
+  },
+};
+
+export const JOIN_NOTIFICATIONS_SOUNDS_V18 = {
+  joinSound: {
+    sound: {
+      id: 'ripple',
+      type: 'BUILT_IN',
+      duration: 3.6,
+      name: 'Ripple',
+      userConfigurable: true,
+    },
+    volume: 100,
+    enabled: true,
+  },
+  leaveSound: {
+    sound: {
+      id: 'pulse',
+      type: 'BUILT_IN',
+      duration: 1.1,
+      name: 'Pulse',
+      userConfigurable: true,
+    },
+    volume: 100,
+    enabled: true,
+  },
+};
+
+export const NIGHTMARE_DETECTION_SOUND_V18 = {
+  sound: {
+    id: 'ripple',
+    type: 'BUILT_IN',
+    duration: 3.6,
+    name: 'Ripple',
+    userConfigurable: true,
+  },
+  volume: 100,
+  enabled: true,
+};
+
+const deviceSelection = () => ({
+  devices: [] as string[],
+  types: [] as string[],
+  tagIds: [] as string[],
+});
+
+export const DEVICE_POWER_AUTOMATIONS_V18 = {
+  enabled: true,
+  turnOffDevicesOnSleepModeEnable: deviceSelection(),
+  turnOffDevicesOnSleepModeDisable: deviceSelection(),
+  turnOffDevicesOnSleepPreparation: deviceSelection(),
+  turnOffDevicesWhenCharging: deviceSelection(),
+  turnOffDevicesBelowBatteryLevel: deviceSelection(),
+  turnOffDevicesBelowBatteryLevel_threshold: 50,
+  turnOffDevicesBelowBatteryLevel_onlyWhileAsleep: false,
+  turnOffDevicesOnSteamVRStop: deviceSelection(),
+  turnOnDevicesOnSteamVRStart: deviceSelection(),
+  turnOnDevicesOnOyasumiStart: deviceSelection(),
+  turnOnDevicesOnSleepModeDisable: deviceSelection(),
+};

--- a/src-ui/app/migrations/automation-configs.migrations.ts
+++ b/src-ui/app/migrations/automation-configs.migrations.ts
@@ -1,9 +1,5 @@
-import { mergeWith } from 'lodash';
 import { AUTOMATION_CONFIGS_DEFAULT } from '../models/automations';
-import type { AutomationConfigs } from '../models/automations';
-import { error, info } from '@tauri-apps/plugin-log';
-import { message } from '@tauri-apps/plugin-dialog';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
 import { migrateOscScript } from './osc-script.migrations';
 import { migrateKnownLighthouseDeviceId } from './lighthouse-device-id';
 import { decryptStorageData, deserializeStorageCryptoKey } from './legacy/storage-crypto';
@@ -15,29 +11,7 @@ import {
   NIGHTMARE_DETECTION_SOUND_V18,
   SET_BRIGHTNESS_AUTOMATIONS_V9,
 } from './automation-configs.historical-defaults';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: resetToLatest,
-  3: from2to3,
-  4: from3to4,
-  5: from4to5,
-  6: from5to6,
-  7: from6to7,
-  8: from7to8,
-  9: from8to9,
-  10: from9to10,
-  11: from10to11,
-  12: from11to12,
-  13: from12to13,
-  14: from13to14,
-  15: from14to15,
-  16: from15to16,
-  17: from16to17,
-  18: from17to18,
-  19: from18to19,
-  20: from19to20,
-};
+import { normalizeWithDefaults } from './migration-defaults';
 
 const RUN_AUTOMATION_COMMAND_FIELDS = [
   'onSleepModeEnableCommands',
@@ -50,34 +24,17 @@ async function from19to20(data: any): Promise<any> {
     data.version = 20;
     return data;
   }
-  const original = structuredClone(data);
   const legacyKey = data.RUN_AUTOMATIONS.runAutomationsCryptoKey;
   delete data.RUN_AUTOMATIONS.runAutomationsCryptoKey;
   let key: CryptoKey | null = null;
   if (legacyKey) {
-    try {
-      key = await deserializeStorageCryptoKey(legacyKey);
-    } catch (e) {
-      error("[automation-configs-migrations] Couldn't read the Run Automations command key: " + e);
-    }
+    key = await deserializeStorageCryptoKey(legacyKey);
   }
-  let discarded = false;
   for (const field of RUN_AUTOMATION_COMMAND_FIELDS) {
     const commands = data.RUN_AUTOMATIONS[field];
     if (!commands) continue;
-    try {
-      if (!key) throw new Error('No command key available');
-      data.RUN_AUTOMATIONS[field] = await decryptStorageData(commands, key);
-    } catch (e) {
-      error("[automation-configs-migrations] Couldn't migrate " + field + ': ' + e);
-      data.RUN_AUTOMATIONS[field] = '';
-      discarded = true;
-    }
-  }
-  if (discarded) {
-    await saveBackup(original).catch((e) =>
-      error("[automation-configs-migrations] Couldn't write the backup: " + e)
-    );
+    if (!key) throw new Error('No command key available');
+    data.RUN_AUTOMATIONS[field] = await decryptStorageData(commands, key);
   }
   data.version = 20;
   return data;
@@ -89,7 +46,6 @@ function from18to19(data: any): any {
   return data;
 }
 
-// Rewrites the base station ids in every device selection, wherever it sits in the config tree
 function migrateSelectedDeviceIds(value: any) {
   if (Array.isArray(value)) {
     value.forEach(migrateSelectedDeviceIds);
@@ -106,71 +62,34 @@ function migrateSelectedDeviceIds(value: any) {
   Object.values(value).forEach(migrateSelectedDeviceIds);
 }
 
-export async function migrateAutomationConfigs(data: any): Promise<AutomationConfigs> {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > AUTOMATION_CONFIGS_DEFAULT.version) {
-    data = resetToLatest(data);
-    info(
-      `[automation-configs-migrations] Reset future automation configs version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < AUTOMATION_CONFIGS_DEFAULT.version) {
-    try {
-      data = await migrations[++currentVersion](structuredClone(data));
-    } catch (e) {
-      error(
-        "[automation-configs-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(data));
-      data = resetToLatest(data);
-      currentVersion = data.version;
-      message(
-        'Your automation settings could not to be migrated to the new version of OyasumiVR, and have therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (Automation Config)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(
-      `[automation-configs-migrations] Migrated automation configs to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  data = mergeWith(structuredClone(AUTOMATION_CONFIGS_DEFAULT), data, (objValue, srcValue) => {
-    // Delete irrelevant keys
-    if (objValue === undefined) {
-      return undefined;
-    }
-    // Do not merge array values
-    if (Array.isArray(objValue)) {
-      return srcValue;
-    }
-  });
-  return data as AutomationConfigs;
-}
+export const AUTOMATION_CONFIGS_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: AUTOMATION_CONFIGS_DEFAULT.version,
+  minimumSupportedVersion: 2,
+  steps: {
+    2: from2to3,
+    3: from3to4,
+    4: from4to5,
+    5: from5to6,
+    6: from6to7,
+    7: from7to8,
+    8: from8to9,
+    9: from9to10,
+    10: from10to11,
+    11: from11to12,
+    12: from12to13,
+    13: from13to14,
+    14: from14to15,
+    15: from15to16,
+    16: from16to17,
+    17: from17to18,
+    18: from18to19,
+    19: from19to20,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(AUTOMATION_CONFIGS_DEFAULT, data),
+};
 
-async function saveBackup(oldData: any) {
-  await writeTextFile('automation-config.backup.json', JSON.stringify(oldData, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
-
-function resetToLatest(data: any): any {
-  // Reset to latest
-  data = structuredClone(AUTOMATION_CONFIGS_DEFAULT);
-  return data;
-}
-
-function from17to18(data: any): any {
+async function from17to18(data: any): Promise<any> {
   data.version = 18;
-  // Migrate notification sounds
   if (data.JOIN_NOTIFICATIONS) {
     if (data.JOIN_NOTIFICATIONS.joinSound) {
       data.JOIN_NOTIFICATIONS.joinSoundMode = data.JOIN_NOTIFICATIONS.joinSound;
@@ -193,27 +112,31 @@ function from17to18(data: any): any {
     delete data.NIGHTMARE_DETECTION.soundVolume;
   }
 
-  // Migrate OSC scripts
   if (data.OSC_GENERAL) {
     if (data.OSC_GENERAL.onSleepModeEnable) {
-      data.OSC_GENERAL.onSleepModeEnable = migrateOscScript(data.OSC_GENERAL.onSleepModeEnable);
+      data.OSC_GENERAL.onSleepModeEnable = await migrateOscScript(
+        data.OSC_GENERAL.onSleepModeEnable
+      );
     }
     if (data.OSC_GENERAL.onSleepModeDisable) {
-      data.OSC_GENERAL.onSleepModeDisable = migrateOscScript(data.OSC_GENERAL.onSleepModeDisable);
+      data.OSC_GENERAL.onSleepModeDisable = await migrateOscScript(
+        data.OSC_GENERAL.onSleepModeDisable
+      );
     }
     if (data.OSC_GENERAL.onSleepPreparation) {
-      data.OSC_GENERAL.onSleepPreparation = migrateOscScript(data.OSC_GENERAL.onSleepPreparation);
+      data.OSC_GENERAL.onSleepPreparation = await migrateOscScript(
+        data.OSC_GENERAL.onSleepPreparation
+      );
     }
   }
   if (data.SLEEPING_ANIMATIONS && Object.keys(data.SLEEPING_ANIMATIONS.oscScripts ?? {}).length) {
-    Object.keys(data.SLEEPING_ANIMATIONS.oscScripts).forEach((key) => {
-      data.SLEEPING_ANIMATIONS.oscScripts[key] = migrateOscScript(
+    for (const key of Object.keys(data.SLEEPING_ANIMATIONS.oscScripts)) {
+      data.SLEEPING_ANIMATIONS.oscScripts[key] = await migrateOscScript(
         data.SLEEPING_ANIMATIONS.oscScripts[key]
       );
-    });
+    }
   }
 
-  // Helper function to map OVRDeviceClass to DMDeviceType
   const mapOVRDeviceClassToDMDeviceType = (ovrClass: string): string | null => {
     switch (ovrClass) {
       case 'HMD':
@@ -229,10 +152,8 @@ function from17to18(data: any): any {
     }
   };
 
-  // Migrate device power automations
   data.DEVICE_POWER_AUTOMATIONS = structuredClone(DEVICE_POWER_AUTOMATIONS_V18);
 
-  // Migrate TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE
   if (
     data.TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE?.enabled &&
     data.TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE.deviceClasses?.length
@@ -245,7 +166,6 @@ function from17to18(data: any): any {
     }
   }
 
-  // Migrate TURN_OFF_DEVICES_WHEN_CHARGING
   if (
     data.TURN_OFF_DEVICES_WHEN_CHARGING?.enabled &&
     data.TURN_OFF_DEVICES_WHEN_CHARGING.deviceClasses?.length
@@ -258,7 +178,6 @@ function from17to18(data: any): any {
     }
   }
 
-  // Migrate TURN_OFF_DEVICES_ON_BATTERY_LEVEL
   if (data.TURN_OFF_DEVICES_ON_BATTERY_LEVEL?.enabled) {
     const batteryConfig = data.TURN_OFF_DEVICES_ON_BATTERY_LEVEL;
     const deviceTypes = [];
@@ -284,7 +203,6 @@ function from17to18(data: any): any {
     }
   }
 
-  // Migrate lighthouse automations
   if (data.TURN_ON_LIGHTHOUSES_ON_OYASUMI_START?.enabled) {
     data.DEVICE_POWER_AUTOMATIONS.turnOnDevicesOnOyasumiStart.types.push('LIGHTHOUSE');
   }
@@ -297,7 +215,6 @@ function from17to18(data: any): any {
     data.DEVICE_POWER_AUTOMATIONS.turnOffDevicesOnSteamVRStop.types.push('LIGHTHOUSE');
   }
 
-  // Delete old automation configs
   delete data.TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE;
   delete data.TURN_OFF_DEVICES_WHEN_CHARGING;
   delete data.TURN_OFF_DEVICES_ON_BATTERY_LEVEL;
@@ -305,7 +222,6 @@ function from17to18(data: any): any {
   delete data.TURN_ON_LIGHTHOUSES_ON_STEAMVR_START;
   delete data.TURN_OFF_LIGHTHOUSES_ON_STEAMVR_STOP;
 
-  // Migrate shutdown automations
   if (data.SHUTDOWN_AUTOMATIONS) {
     data.SHUTDOWN_AUTOMATIONS.turnOffDevices = {
       devices: [],
@@ -532,17 +448,14 @@ function from9to10(data: any): any {
 
 function from8to9(data: any): any {
   data.version = 9;
-  // Reference old configuration
   const displayBrightnessOnEnableConfig = data.DISPLAY_BRIGHTNESS_ON_SLEEP_MODE_ENABLE;
   const displayBrightnessOnDisableConfig = data.DISPLAY_BRIGHTNESS_ON_SLEEP_MODE_DISABLE;
   const imageBrightnessOnEnableConfig = data.IMAGE_BRIGHTNESS_ON_SLEEP_MODE_ENABLE;
   const imageBrightnessOnDisableConfig = data.IMAGE_BRIGHTNESS_ON_SLEEP_MODE_DISABLE;
-  // Delete old configuration
   delete data.DISPLAY_BRIGHTNESS_ON_SLEEP_MODE_ENABLE;
   delete data.DISPLAY_BRIGHTNESS_ON_SLEEP_MODE_DISABLE;
   delete data.IMAGE_BRIGHTNESS_ON_SLEEP_MODE_ENABLE;
   delete data.IMAGE_BRIGHTNESS_ON_SLEEP_MODE_DISABLE;
-  // Insert new configuration defaults
   data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE = structuredClone(
     SET_BRIGHTNESS_AUTOMATIONS_V9.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE
   );
@@ -552,7 +465,6 @@ function from8to9(data: any): any {
   data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION = structuredClone(
     SET_BRIGHTNESS_AUTOMATIONS_V9.SET_BRIGHTNESS_ON_SLEEP_PREPARATION
   );
-  // Attempt to migrate old on sleep enable automations
   if (displayBrightnessOnEnableConfig?.enabled) {
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.enabled = true;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.brightness =
@@ -574,7 +486,6 @@ function from8to9(data: any): any {
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.transitionTime =
       imageBrightnessOnEnableConfig.transitionTime;
   }
-  // Attempt to migrate old on sleep disable automations
   if (displayBrightnessOnDisableConfig?.enabled) {
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.enabled = true;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.brightness =
@@ -603,13 +514,11 @@ function from8to9(data: any): any {
 
 function from7to8(data: any): any {
   data.version = 8;
-  // Missing keys are now always added by default
   return data;
 }
 
 function from6to7(data: any): any {
   data.version = 7;
-  // Missing keys are now always added by default
   return data;
 }
 
@@ -622,18 +531,15 @@ function from5to6(data: any): any {
 
 function from4to5(data: any): any {
   data.version = 5;
-  // Missing keys are now always added by default
   return data;
 }
 
 function from3to4(data: any): any {
   data.version = 4;
-  // Missing keys are now always added by default
   return data;
 }
 
 function from2to3(data: any): any {
   data.version = 3;
-  // Missing keys are now always added by default
   return data;
 }

--- a/src-ui/app/migrations/automation-configs.migrations.ts
+++ b/src-ui/app/migrations/automation-configs.migrations.ts
@@ -1,11 +1,20 @@
 import { mergeWith } from 'lodash';
-import { AUTOMATION_CONFIGS_DEFAULT, AutomationConfigs } from '../models/automations';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../models/automations';
+import type { AutomationConfigs } from '../models/automations';
 import { error, info } from '@tauri-apps/plugin-log';
 import { message } from '@tauri-apps/plugin-dialog';
 import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
 import { migrateOscScript } from './osc-script.migrations';
 import { migrateKnownLighthouseDeviceId } from './lighthouse-device-id';
 import { decryptStorageData, deserializeStorageCryptoKey } from './legacy/storage-crypto';
+import {
+  BRIGHTNESS_AUTOMATIONS_V17,
+  DEVICE_POWER_AUTOMATIONS_V18,
+  JOIN_NOTIFICATIONS_SOUNDS_V18,
+  MSI_AFTERBURNER_V6,
+  NIGHTMARE_DETECTION_SOUND_V18,
+  SET_BRIGHTNESS_AUTOMATIONS_V9,
+} from './automation-configs.historical-defaults';
 
 const migrations: { [v: number]: (data: any) => any } = {
   1: resetToLatest,
@@ -110,7 +119,6 @@ export async function migrateAutomationConfigs(data: any): Promise<AutomationCon
   }
   while (currentVersion < AUTOMATION_CONFIGS_DEFAULT.version) {
     try {
-      console.log('Migrating to version', currentVersion + 1);
       data = await migrations[++currentVersion](structuredClone(data));
     } catch (e) {
       error(
@@ -166,32 +174,38 @@ function from17to18(data: any): any {
   if (data.JOIN_NOTIFICATIONS) {
     if (data.JOIN_NOTIFICATIONS.joinSound) {
       data.JOIN_NOTIFICATIONS.joinSoundMode = data.JOIN_NOTIFICATIONS.joinSound;
-      data.JOIN_NOTIFICATIONS.joinSound = AUTOMATION_CONFIGS_DEFAULT.JOIN_NOTIFICATIONS.joinSound;
+      data.JOIN_NOTIFICATIONS.joinSound = structuredClone(JOIN_NOTIFICATIONS_SOUNDS_V18.joinSound);
     }
     if (data.JOIN_NOTIFICATIONS.leaveSound) {
       data.JOIN_NOTIFICATIONS.leaveSoundMode = data.JOIN_NOTIFICATIONS.leaveSound;
-      data.JOIN_NOTIFICATIONS.leaveSound = AUTOMATION_CONFIGS_DEFAULT.JOIN_NOTIFICATIONS.leaveSound;
+      data.JOIN_NOTIFICATIONS.leaveSound = structuredClone(
+        JOIN_NOTIFICATIONS_SOUNDS_V18.leaveSound
+      );
     }
   }
-  data.NIGHTMARE_DETECTION.sound = {
-    ...AUTOMATION_CONFIGS_DEFAULT.NIGHTMARE_DETECTION.sound,
-    volume: data.NIGHTMARE_DETECTION.soundVolume,
-    enabled: !!data.NIGHTMARE_DETECTION.playSound,
-  };
-  delete data.NIGHTMARE_DETECTION.playSound;
-  delete data.NIGHTMARE_DETECTION.soundVolume;
+  if (data.NIGHTMARE_DETECTION) {
+    data.NIGHTMARE_DETECTION.sound = {
+      ...structuredClone(NIGHTMARE_DETECTION_SOUND_V18),
+      volume: data.NIGHTMARE_DETECTION.soundVolume,
+      enabled: !!data.NIGHTMARE_DETECTION.playSound,
+    };
+    delete data.NIGHTMARE_DETECTION.playSound;
+    delete data.NIGHTMARE_DETECTION.soundVolume;
+  }
 
   // Migrate OSC scripts
-  if (data.OSC_GENERAL.onSleepModeEnable) {
-    data.OSC_GENERAL.onSleepModeEnable = migrateOscScript(data.OSC_GENERAL.onSleepModeEnable);
+  if (data.OSC_GENERAL) {
+    if (data.OSC_GENERAL.onSleepModeEnable) {
+      data.OSC_GENERAL.onSleepModeEnable = migrateOscScript(data.OSC_GENERAL.onSleepModeEnable);
+    }
+    if (data.OSC_GENERAL.onSleepModeDisable) {
+      data.OSC_GENERAL.onSleepModeDisable = migrateOscScript(data.OSC_GENERAL.onSleepModeDisable);
+    }
+    if (data.OSC_GENERAL.onSleepPreparation) {
+      data.OSC_GENERAL.onSleepPreparation = migrateOscScript(data.OSC_GENERAL.onSleepPreparation);
+    }
   }
-  if (data.OSC_GENERAL.onSleepModeDisable) {
-    data.OSC_GENERAL.onSleepModeDisable = migrateOscScript(data.OSC_GENERAL.onSleepModeDisable);
-  }
-  if (data.OSC_GENERAL.onSleepPreparation) {
-    data.OSC_GENERAL.onSleepPreparation = migrateOscScript(data.OSC_GENERAL.onSleepPreparation);
-  }
-  if (Object.keys(data.SLEEPING_ANIMATIONS.oscScripts).length) {
+  if (data.SLEEPING_ANIMATIONS && Object.keys(data.SLEEPING_ANIMATIONS.oscScripts ?? {}).length) {
     Object.keys(data.SLEEPING_ANIMATIONS.oscScripts).forEach((key) => {
       data.SLEEPING_ANIMATIONS.oscScripts[key] = migrateOscScript(
         data.SLEEPING_ANIMATIONS.oscScripts[key]
@@ -216,9 +230,7 @@ function from17to18(data: any): any {
   };
 
   // Migrate device power automations
-  data.DEVICE_POWER_AUTOMATIONS = structuredClone(
-    AUTOMATION_CONFIGS_DEFAULT.DEVICE_POWER_AUTOMATIONS
-  );
+  data.DEVICE_POWER_AUTOMATIONS = structuredClone(DEVICE_POWER_AUTOMATIONS_V18);
 
   // Migrate TURN_OFF_DEVICES_ON_SLEEP_MODE_ENABLE
   if (
@@ -319,50 +331,48 @@ function from17to18(data: any): any {
 
 function from16to17(data: any): any {
   data.version = 17;
-  data.BRIGHTNESS_AUTOMATIONS = structuredClone(AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS);
-  data.BRIGHTNESS_AUTOMATIONS.advancedMode = data.BRIGHTNESS_CONTROL_ADVANCED_MODE.enabled;
+  data.BRIGHTNESS_AUTOMATIONS = structuredClone(BRIGHTNESS_AUTOMATIONS_V17);
+  data.BRIGHTNESS_AUTOMATIONS.advancedMode =
+    data.BRIGHTNESS_CONTROL_ADVANCED_MODE?.enabled ?? false;
   data.BRIGHTNESS_AUTOMATIONS.enabled = true;
   data.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE = {
     enabled: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.enabled,
     changeBrightness: true,
     changeColorTemperature: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.enabled
       ? false
-      : AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE.changeColorTemperature,
+      : BRIGHTNESS_AUTOMATIONS_V17.SLEEP_MODE_ENABLE.changeColorTemperature,
     brightness: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.brightness,
     softwareBrightness: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.softwareBrightness,
     hardwareBrightness: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.hardwareBrightness,
     transition: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.transition,
     transitionTime: data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.transitionTime,
-    colorTemperature:
-      AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE.colorTemperature,
+    colorTemperature: BRIGHTNESS_AUTOMATIONS_V17.SLEEP_MODE_ENABLE.colorTemperature,
   };
   data.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_DISABLE = {
     enabled: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.enabled,
     changeBrightness: true,
     changeColorTemperature: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.enabled
       ? false
-      : AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_DISABLE.changeColorTemperature,
+      : BRIGHTNESS_AUTOMATIONS_V17.SLEEP_MODE_DISABLE.changeColorTemperature,
     brightness: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.brightness,
     softwareBrightness: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.softwareBrightness,
     hardwareBrightness: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.hardwareBrightness,
     transition: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.transition,
     transitionTime: data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.transitionTime,
-    colorTemperature:
-      AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_DISABLE.colorTemperature,
+    colorTemperature: BRIGHTNESS_AUTOMATIONS_V17.SLEEP_MODE_DISABLE.colorTemperature,
   };
   data.BRIGHTNESS_AUTOMATIONS.SLEEP_PREPARATION = {
     enabled: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.enabled,
     changeBrightness: true,
     changeColorTemperature: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.enabled
       ? false
-      : AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_PREPARATION.changeColorTemperature,
+      : BRIGHTNESS_AUTOMATIONS_V17.SLEEP_PREPARATION.changeColorTemperature,
     brightness: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.brightness,
     softwareBrightness: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.softwareBrightness,
     hardwareBrightness: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.hardwareBrightness,
     transition: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.transition,
     transitionTime: data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION.transitionTime,
-    colorTemperature:
-      AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_PREPARATION.colorTemperature,
+    colorTemperature: BRIGHTNESS_AUTOMATIONS_V17.SLEEP_PREPARATION.colorTemperature,
   };
 
   delete data.BRIGHTNESS_CONTROL_ADVANCED_MODE;
@@ -376,6 +386,9 @@ function from15to16(data: any): any {
   data.version = 16;
 
   const oscAutomationsConfig = data.OSC_GENERAL;
+  if (!oscAutomationsConfig) {
+    return data;
+  }
 
   const oscAutomations = [
     oscAutomationsConfig.onSleepModeEnable,
@@ -395,6 +408,7 @@ function from15to16(data: any): any {
     }
 
     automation.version = 2;
+    automation.commands ??= [];
 
     for (const command of automation.commands) {
       if (command.type !== 'COMMAND') {
@@ -417,20 +431,26 @@ function from15to16(data: any): any {
 
 function from14to15(data: any): any {
   data.version = 15;
-  data.triggerOnSleepDuration = data.sleepDuration;
-  delete data.sleepDuration;
-  data.triggerOnSleepActivationWindow = data.activationWindow;
-  delete data.activationWindow;
-  data.triggerOnSleepActivationWindowStart = data.activationWindowStart;
-  delete data.activationWindowStart;
-  data.triggerOnSleepActivationWindowEnd = data.activationWindowEnd;
-  delete data.activationWindowEnd;
+  if (data.SHUTDOWN_AUTOMATIONS) {
+    const shutdownAutomations = data.SHUTDOWN_AUTOMATIONS;
+    shutdownAutomations.triggerOnSleepDuration = shutdownAutomations.sleepDuration;
+    delete shutdownAutomations.sleepDuration;
+    shutdownAutomations.triggerOnSleepActivationWindow = shutdownAutomations.activationWindow;
+    delete shutdownAutomations.activationWindow;
+    shutdownAutomations.triggerOnSleepActivationWindowStart =
+      shutdownAutomations.activationWindowStart;
+    delete shutdownAutomations.activationWindowStart;
+    shutdownAutomations.triggerOnSleepActivationWindowEnd = shutdownAutomations.activationWindowEnd;
+    delete shutdownAutomations.activationWindowEnd;
+  }
   return data;
 }
 
 function from13to14(data: any): any {
   data.version = 14;
-  delete data['VRCHAT_MIC_MUTE_AUTOMATIONS'].mode;
+  if (data.VRCHAT_MIC_MUTE_AUTOMATIONS) {
+    delete data.VRCHAT_MIC_MUTE_AUTOMATIONS.mode;
+  }
   return data;
 }
 
@@ -524,13 +544,13 @@ function from8to9(data: any): any {
   delete data.IMAGE_BRIGHTNESS_ON_SLEEP_MODE_DISABLE;
   // Insert new configuration defaults
   data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE = structuredClone(
-    (AUTOMATION_CONFIGS_DEFAULT as any)['SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE']
+    SET_BRIGHTNESS_AUTOMATIONS_V9.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE
   );
   data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE = structuredClone(
-    (AUTOMATION_CONFIGS_DEFAULT as any)['SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE']
+    SET_BRIGHTNESS_AUTOMATIONS_V9.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE
   );
   data.SET_BRIGHTNESS_ON_SLEEP_PREPARATION = structuredClone(
-    (AUTOMATION_CONFIGS_DEFAULT as any)['SET_BRIGHTNESS_ON_SLEEP_PREPARATION']
+    SET_BRIGHTNESS_AUTOMATIONS_V9.SET_BRIGHTNESS_ON_SLEEP_PREPARATION
   );
   // Attempt to migrate old on sleep enable automations
   if (displayBrightnessOnEnableConfig?.enabled) {
@@ -559,8 +579,8 @@ function from8to9(data: any): any {
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.enabled = true;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.brightness =
       displayBrightnessOnDisableConfig.brightness;
-    data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.imageBrightness = 100;
-    data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.displayBrightness =
+    data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.imageBrightness = 100;
+    data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.displayBrightness =
       displayBrightnessOnDisableConfig.brightness;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.transition =
       displayBrightnessOnDisableConfig.transition;
@@ -570,9 +590,9 @@ function from8to9(data: any): any {
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.enabled = true;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.brightness =
       imageBrightnessOnDisableConfig.brightness;
-    data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.imageBrightness =
+    data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.imageBrightness =
       imageBrightnessOnDisableConfig.brightness;
-    data.SET_BRIGHTNESS_ON_SLEEP_MODE_ENABLE.displayBrightness = 100;
+    data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.displayBrightness = 100;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.transition =
       imageBrightnessOnDisableConfig.transition;
     data.SET_BRIGHTNESS_ON_SLEEP_MODE_DISABLE.transitionTime =
@@ -595,8 +615,8 @@ function from6to7(data: any): any {
 
 function from5to6(data: any): any {
   data.version = 6;
-  data.MSI_AFTERBURNER = structuredClone(AUTOMATION_CONFIGS_DEFAULT.MSI_AFTERBURNER);
-  data.MSI_AFTERBURNER.enabled = data.GPU_POWER_LIMITS.enabled;
+  data.MSI_AFTERBURNER = structuredClone(MSI_AFTERBURNER_V6);
+  data.MSI_AFTERBURNER.enabled = data.GPU_POWER_LIMITS?.enabled ?? false;
   return data;
 }
 

--- a/src-ui/app/migrations/device-manager.migrations.ts
+++ b/src-ui/app/migrations/device-manager.migrations.ts
@@ -1,14 +1,7 @@
-import { mergeWith } from 'lodash';
-import { error, info } from '@tauri-apps/plugin-log';
-import { DEVICE_MANAGER_DATA_DEFAULT, DeviceManagerData } from '../models/device-manager';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
-import { message } from '@tauri-apps/plugin-dialog';
+import { DEVICE_MANAGER_DATA_DEFAULT } from '../models/device-manager';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
 import { migrateKnownLighthouseDeviceId } from './lighthouse-device-id';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: from1to2,
-};
+import { normalizeWithDefaults } from './migration-defaults';
 
 function from1to2(data: any): any {
   data.version = 2;
@@ -30,64 +23,11 @@ function from1to2(data: any): any {
   return data;
 }
 
-export function migrateDeviceManagerData(data: any): DeviceManagerData {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > DEVICE_MANAGER_DATA_DEFAULT.version) {
-    data = resetToLatest(data);
-    info(
-      `[device-manager-migrations] Reset future Device Manager settings version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < DEVICE_MANAGER_DATA_DEFAULT.version) {
-    try {
-      data = migrations[++currentVersion](data);
-    } catch (e) {
-      error(
-        "[device-manager-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(data));
-      data = resetToLatest(data);
-      currentVersion = data.version;
-      message(
-        'Your Device Manager settings could not be migrated to the new version of OyasumiVR, and have therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (Device Manager Settings)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(
-      `[device-manager-migrations] Migrated Device Manager settings to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  data = mergeWith(structuredClone(DEVICE_MANAGER_DATA_DEFAULT), data, (objValue, srcValue) => {
-    // Delete irrelevant keys
-    if (objValue === undefined) {
-      return undefined;
-    }
-    // Do not merge array values
-    if (Array.isArray(objValue)) {
-      return srcValue;
-    }
-  });
-  return data as DeviceManagerData;
-}
-
-async function saveBackup(oldData: any) {
-  await writeTextFile('device-manager.backup.json', JSON.stringify(oldData, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
-
-function resetToLatest(data: any): any {
-  // Reset to latest
-  data = structuredClone(DEVICE_MANAGER_DATA_DEFAULT);
-  return data;
-}
+export const DEVICE_MANAGER_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: DEVICE_MANAGER_DATA_DEFAULT.version,
+  minimumSupportedVersion: 1,
+  steps: {
+    1: from1to2,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(DEVICE_MANAGER_DATA_DEFAULT, data),
+};

--- a/src-ui/app/migrations/event-log.migrations.ts
+++ b/src-ui/app/migrations/event-log.migrations.ts
@@ -1,58 +1,6 @@
-import { error, info } from '@tauri-apps/plugin-log';
-
-import { EVENT_LOG_DEFAULT, EventLog } from '../models/event-log-entry';
-import { message } from '@tauri-apps/plugin-dialog';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: from1to2,
-  3: from2to3,
-  4: from3to4,
-  5: from4to5,
-};
-
-export function migrateEventLog(log: EventLog): EventLog {
-  let currentVersion = log.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > EVENT_LOG_DEFAULT.version) {
-    log = resetToLatest(log);
-    info(
-      `[event-log-migrations] Reset future app settings version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < EVENT_LOG_DEFAULT.version) {
-    try {
-      log = migrations[++currentVersion](log);
-    } catch (e) {
-      error(
-        "[event-log-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(log));
-      log = resetToLatest(log);
-      currentVersion = log.version;
-      message(
-        'Your event log data could not to be migrated to the new version of OyasumiVR, and has therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (Event Log)' }
-      );
-      continue;
-    }
-    currentVersion = log.version;
-    info(`[event-log-migrations] Migrated event log to version ${currentVersion + ''}`);
-  }
-  return log as EventLog;
-}
-
-async function saveBackup(oldData: any) {
-  await writeTextFile('event-log.backup.json', JSON.stringify(oldData, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
+import { EVENT_LOG_DEFAULT } from '../models/event-log-entry';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
+import { normalizeWithDefaults } from './migration-defaults';
 
 function from4to5(data: any): any {
   data.version = 5;
@@ -116,8 +64,14 @@ function from1to2(data: any): any {
   return data;
 }
 
-function resetToLatest(data: any): any {
-  // Reset to latest
-  data = structuredClone(EVENT_LOG_DEFAULT);
-  return data;
-}
+export const EVENT_LOG_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: EVENT_LOG_DEFAULT.version,
+  minimumSupportedVersion: 1,
+  steps: {
+    1: from1to2,
+    2: from2to3,
+    3: from3to4,
+    4: from4to5,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(EVENT_LOG_DEFAULT, data),
+};

--- a/src-ui/app/migrations/migration-defaults.ts
+++ b/src-ui/app/migrations/migration-defaults.ts
@@ -1,0 +1,29 @@
+import { mergeWith } from 'lodash';
+
+export function normalizeWithDefaults<T>(defaults: T, data: unknown): T {
+  const normalized = mergeWith(structuredClone(defaults), data, (defaultValue, storedValue) =>
+    Array.isArray(defaultValue) ? storedValue : undefined
+  );
+  assertDefaultShape(normalized, defaults, 'value');
+  return normalized;
+}
+
+function assertDefaultShape(value: unknown, defaults: unknown, path: string): void {
+  if (defaults === null) return;
+  if (Array.isArray(defaults)) {
+    if (!Array.isArray(value)) throw new Error(`${path} must be an array`);
+    return;
+  }
+  if (typeof defaults === 'object') {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      throw new Error(`${path} must be an object`);
+    }
+    for (const [key, childDefaults] of Object.entries(defaults)) {
+      assertDefaultShape((value as Record<string, unknown>)[key], childDefaults, `${path}.${key}`);
+    }
+    return;
+  }
+  if (typeof value !== typeof defaults) {
+    throw new Error(`${path} must be a ${typeof defaults}`);
+  }
+}

--- a/src-ui/app/migrations/osc-script.migrations.ts
+++ b/src-ui/app/migrations/osc-script.migrations.ts
@@ -1,43 +1,30 @@
-import { error, info } from '@tauri-apps/plugin-log';
 import { OSC_SCRIPT_VERSION } from '../models/osc-script';
 import type { OscScript } from '../models/osc-script';
-import { message } from '@tauri-apps/plugin-dialog';
+import { runMigrations } from 'src-shared-ts/src/migration-runner';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
 
-const migrations: { [v: number]: (data: any) => any } = {
-  1: keepSame(1),
-  2: keepSame(2),
-  3: from2to3,
+export const OSC_SCRIPT_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: OSC_SCRIPT_VERSION,
+  minimumSupportedVersion: 0,
+  steps: {
+    0: keepSame(1),
+    1: keepSame(2),
+    2: from2to3,
+  },
+  normalizeCurrentVersion: (data) => {
+    const commands = (data as any).commands ?? [];
+    if (!Array.isArray(commands)) throw new Error('OSC script commands must be an array');
+    return { ...data, commands };
+  },
 };
 
-export function migrateOscScript(data: any): OscScript {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > OSC_SCRIPT_VERSION) {
-    data = resetToEmpty();
-    info(
-      `[osc-script-migrations] Resetting OSC script as it's version is higher than the latest version`
-    );
+export async function migrateOscScript(data: any): Promise<OscScript> {
+  const result = await runMigrations(data, OSC_SCRIPT_MIGRATION);
+  if (result.status === 'migrated' || result.status === 'unchanged') {
+    return result.value as OscScript;
   }
-  while (currentVersion < OSC_SCRIPT_VERSION) {
-    try {
-      data = migrations[++currentVersion](structuredClone(data));
-    } catch {
-      error(
-        "[osc-script-migrations] Couldn't migrate osc script to version " +
-          currentVersion +
-          '. Resetting to empty script'
-      );
-      data = resetToEmpty();
-      message(
-        'One of your OSC scripts could not be migrated to the new version of OyasumiVR, and has therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (OSC Script)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(`[osc-script-migrations] Migrated OSC script to version ${currentVersion + ''}`);
-  }
-  return data as OscScript;
+  if (result.status === 'failed') throw result.cause;
+  throw new Error(`OSC script migration failed with status ${result.status}`);
 }
 
 function keepSame(version: number): (data: any) => any {
@@ -47,41 +34,31 @@ function keepSame(version: number): (data: any) => any {
   };
 }
 
-function resetToEmpty(): OscScript {
-  return {
-    version: 3,
-    commands: [],
-  };
-}
-
 function from2to3(data: any): any {
   data.version = 3;
   data.commands ??= [];
   data.commands = data.commands.map((command: any) => {
-    if (command.type === 'COMMAND') {
-      command = structuredClone(command);
-      command.parameters = command.parameters.map((parameter: any) => {
-        parameter = structuredClone(parameter);
-        switch (parameter.type) {
-          case 'INT':
-            parameter.type = 'Int';
-            break;
-          case 'FLOAT':
-            parameter.type = 'Float';
-            break;
-          case 'BOOLEAN':
-            parameter.type = 'Boolean';
-            break;
-          case 'STRING':
-            parameter.type = 'String';
-            break;
-        }
-        return parameter;
-      });
-      return command;
-    } else {
-      return command;
-    }
+    if (command.type !== 'COMMAND') return command;
+    command = structuredClone(command);
+    command.parameters = command.parameters.map((parameter: any) => {
+      parameter = structuredClone(parameter);
+      switch (parameter.type) {
+        case 'INT':
+          parameter.type = 'Int';
+          break;
+        case 'FLOAT':
+          parameter.type = 'Float';
+          break;
+        case 'BOOLEAN':
+          parameter.type = 'Boolean';
+          break;
+        case 'STRING':
+          parameter.type = 'String';
+          break;
+      }
+      return parameter;
+    });
+    return command;
   });
   return data;
 }

--- a/src-ui/app/migrations/osc-script.migrations.ts
+++ b/src-ui/app/migrations/osc-script.migrations.ts
@@ -1,5 +1,6 @@
 import { error, info } from '@tauri-apps/plugin-log';
-import { OSC_SCRIPT_VERSION, OscScript } from '../models/osc-script';
+import { OSC_SCRIPT_VERSION } from '../models/osc-script';
+import type { OscScript } from '../models/osc-script';
 import { message } from '@tauri-apps/plugin-dialog';
 
 const migrations: { [v: number]: (data: any) => any } = {
@@ -17,12 +18,9 @@ export function migrateOscScript(data: any): OscScript {
       `[osc-script-migrations] Resetting OSC script as it's version is higher than the latest version`
     );
   }
-  console.log(0, currentVersion + 0, structuredClone(data));
   while (currentVersion < OSC_SCRIPT_VERSION) {
     try {
-      console.log(1, currentVersion + 0, structuredClone(data));
       data = migrations[++currentVersion](structuredClone(data));
-      console.log(2, currentVersion + 0, structuredClone(data));
     } catch {
       error(
         "[osc-script-migrations] Couldn't migrate osc script to version " +

--- a/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
+++ b/src-ui/app/migrations/pulsoid-api-settings.migrations.ts
@@ -1,85 +1,19 @@
-import { mergeWith } from 'lodash';
-import { error, info } from '@tauri-apps/plugin-log';
-import { PULSOID_API_SETTINGS_DEFAULT, PulsoidApiSettings } from '../models/pulsoid-api-settings';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
-import { message } from '@tauri-apps/plugin-dialog';
+import { PULSOID_API_SETTINGS_DEFAULT } from '../models/pulsoid-api-settings';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
 import { protectSecret } from '../utils/secrets';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: from1to2,
-};
+import { normalizeWithDefaults } from './migration-defaults';
 
 async function from1to2(data: any): Promise<any> {
-  try {
-    data.accessToken = (await protectSecret(data.accessToken)) ?? undefined;
-  } catch (e) {
-    error("[pulsoid-api-settings-migrations] Couldn't protect the access token: " + e);
-    delete data.accessToken;
-  }
+  data.accessToken = (await protectSecret(data.accessToken)) ?? undefined;
   data.version = 2;
   return data;
 }
 
-export async function migratePulsoidApiSettings(data: any): Promise<PulsoidApiSettings> {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > PULSOID_API_SETTINGS_DEFAULT.version) {
-    data = resetToLatest(data);
-    info(
-      `[pulsoid-api-settings-migrations] Reset future Pulsoid API settings version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < PULSOID_API_SETTINGS_DEFAULT.version) {
-    try {
-      data = await migrations[++currentVersion](data);
-    } catch (e) {
-      error(
-        "[pulsoid-api-settings-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(data));
-      data = resetToLatest(data);
-      currentVersion = data.version;
-      message(
-        'Your Pulsoid settings could not to be migrated to the new version of OyasumiVR, and have therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (Pulsoid Settings)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(
-      `[pulsoid-api-settings-migrations] Migrated Pulsoid API settings to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  data = mergeWith(structuredClone(PULSOID_API_SETTINGS_DEFAULT), data, (objValue, srcValue) => {
-    // Delete irrelevant keys
-    if (objValue === undefined) {
-      return undefined;
-    }
-    // Do not merge array values
-    if (Array.isArray(objValue)) {
-      return srcValue;
-    }
-  });
-  return data as PulsoidApiSettings;
-}
-
-async function saveBackup(oldData: any) {
-  const redacted = { ...oldData, accessToken: undefined };
-  await writeTextFile('pulsoid-api-settings.backup.json', JSON.stringify(redacted, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
-
-function resetToLatest(data: any): any {
-  // Reset to latest
-  data = structuredClone(PULSOID_API_SETTINGS_DEFAULT);
-  return data;
-}
+export const PULSOID_API_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: PULSOID_API_SETTINGS_DEFAULT.version,
+  minimumSupportedVersion: 1,
+  steps: {
+    1: from1to2,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(PULSOID_API_SETTINGS_DEFAULT, data),
+};

--- a/src-ui/app/migrations/store-migrations.ts
+++ b/src-ui/app/migrations/store-migrations.ts
@@ -1,0 +1,50 @@
+import { APP_SETTINGS_DEFAULT } from '../models/settings';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../models/automations';
+import { VRCHAT_API_SETTINGS_DEFAULT } from '../models/vrchat-api-settings';
+import { DEVICE_MANAGER_DATA_DEFAULT } from '../models/device-manager';
+import { TELEMETRY_SETTINGS_DEFAULT } from '../models/telemetry-settings';
+import { PULSOID_API_SETTINGS_DEFAULT } from '../models/pulsoid-api-settings';
+import { EVENT_LOG_DEFAULT } from '../models/event-log-entry';
+import { APP_SETTINGS_MIGRATION } from './app-settings.migrations';
+import { AUTOMATION_CONFIGS_MIGRATION } from './automation-configs.migrations';
+import { VRCHAT_API_MIGRATION } from './vrchat-api-settings.migrations';
+import { DEVICE_MANAGER_MIGRATION } from './device-manager.migrations';
+import { TELEMETRY_SETTINGS_MIGRATION } from './telemetry-settings.migrations';
+import { PULSOID_API_MIGRATION } from './pulsoid-api-settings.migrations';
+import { EVENT_LOG_MIGRATION } from './event-log.migrations';
+import type { StoreMigrationSpec } from 'src-shared-ts/src/store-migration';
+
+export const SETTINGS_STORE_MIGRATION: StoreMigrationSpec = {
+  storeName: 'settings',
+  migrations: {
+    APP_SETTINGS: APP_SETTINGS_MIGRATION,
+    AUTOMATION_CONFIGS: AUTOMATION_CONFIGS_MIGRATION,
+    VRCHAT_API: VRCHAT_API_MIGRATION,
+    DEVICE_MANAGER: DEVICE_MANAGER_MIGRATION,
+    TELEMETRY_SETTINGS: TELEMETRY_SETTINGS_MIGRATION,
+    PULSOID_API: PULSOID_API_MIGRATION,
+  },
+  defaults: {
+    APP_SETTINGS: APP_SETTINGS_DEFAULT,
+    AUTOMATION_CONFIGS: AUTOMATION_CONFIGS_DEFAULT,
+    VRCHAT_API: VRCHAT_API_SETTINGS_DEFAULT,
+    DEVICE_MANAGER: DEVICE_MANAGER_DATA_DEFAULT,
+    TELEMETRY_SETTINGS: TELEMETRY_SETTINGS_DEFAULT,
+    PULSOID_API: PULSOID_API_SETTINGS_DEFAULT,
+  },
+};
+
+export const EVENT_LOG_STORE_MIGRATION: StoreMigrationSpec = {
+  storeName: 'event_log',
+  migrations: {
+    EVENT_LOG: EVENT_LOG_MIGRATION,
+  },
+  defaults: {
+    EVENT_LOG: EVENT_LOG_DEFAULT,
+  },
+};
+
+export const STORE_MIGRATIONS: StoreMigrationSpec[] = [
+  SETTINGS_STORE_MIGRATION,
+  EVENT_LOG_STORE_MIGRATION,
+];

--- a/src-ui/app/migrations/telemetry-settings.migrations.ts
+++ b/src-ui/app/migrations/telemetry-settings.migrations.ts
@@ -1,70 +1,6 @@
-import { mergeWith } from 'lodash';
-import { TELEMETRY_SETTINGS_DEFAULT, TelemetrySettings } from '../models/telemetry-settings';
-import { error, info } from '@tauri-apps/plugin-log';
-import { v4 as uuidv4 } from 'uuid';
-import { message } from '@tauri-apps/plugin-dialog';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: from1to2,
-};
-
-export function migrateTelemetrySettings(data: any): TelemetrySettings {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > TELEMETRY_SETTINGS_DEFAULT.version) {
-    data = resetToLatest(data);
-    info(
-      `[telemetry-settings-migrations] Reset future telemetry settings version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < TELEMETRY_SETTINGS_DEFAULT.version) {
-    try {
-      data = migrations[++currentVersion](data);
-    } catch (e) {
-      error(
-        "[telemetry-settings-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(data));
-      data = resetToLatest(data);
-      currentVersion = data.version;
-      message(
-        'Your telemetry settings could not to be migrated to the new version of OyasumiVR, and have therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (Telemetry Settings)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(
-      `[telemetry-settings-migrations] Migrated telemetry settings to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  data = mergeWith(structuredClone(TELEMETRY_SETTINGS_DEFAULT), data, (objValue, srcValue) => {
-    // Delete irrelevant keys
-    if (objValue === undefined) {
-      return undefined;
-    }
-    // Do not merge array values
-    if (Array.isArray(objValue)) {
-      return srcValue;
-    }
-  });
-  return data as TelemetrySettings;
-}
-
-async function saveBackup(oldData: any) {
-  await writeTextFile('telemetry-settings.backup.json', JSON.stringify(oldData, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
+import { TELEMETRY_SETTINGS_DEFAULT } from '../models/telemetry-settings';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
+import { normalizeWithDefaults } from './migration-defaults';
 
 function from1to2(data: any): any {
   return {
@@ -73,10 +9,11 @@ function from1to2(data: any): any {
   };
 }
 
-function resetToLatest(data: any): any {
-  // Reset to latest
-  const telemetryId = data.telemetryId || uuidv4();
-  data = structuredClone(TELEMETRY_SETTINGS_DEFAULT);
-  data.telemetryId = telemetryId;
-  return data;
-}
+export const TELEMETRY_SETTINGS_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: TELEMETRY_SETTINGS_DEFAULT.version,
+  minimumSupportedVersion: 1,
+  steps: {
+    1: from1to2,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(TELEMETRY_SETTINGS_DEFAULT, data),
+};

--- a/src-ui/app/migrations/vrchat-api-settings.migrations.ts
+++ b/src-ui/app/migrations/vrchat-api-settings.migrations.ts
@@ -1,75 +1,8 @@
-import { mergeWith } from 'lodash';
-import { VRCHAT_API_SETTINGS_DEFAULT, VRChatApiSettings } from '../models/vrchat-api-settings';
-import { error, info } from '@tauri-apps/plugin-log';
-import { BaseDirectory, writeTextFile } from '@tauri-apps/plugin-fs';
-import { message } from '@tauri-apps/plugin-dialog';
+import { VRCHAT_API_SETTINGS_DEFAULT } from '../models/vrchat-api-settings';
+import type { MigrationDefinition, Versioned } from 'src-shared-ts/src/migration-runner';
 import { decryptStorageData, deserializeStorageCryptoKey } from './legacy/storage-crypto';
-
-const migrations: { [v: number]: (data: any) => any } = {
-  1: resetToLatest,
-  2: from1To2,
-  3: from2To3,
-  4: from3To4,
-  5: from4To5,
-  6: from5To6,
-  7: from6To7,
-};
-
-export async function migrateVRChatApiSettings(data: any): Promise<VRChatApiSettings> {
-  let currentVersion = data.version || 0;
-  // Reset to latest when the current version is higher than the latest
-  if (currentVersion > VRCHAT_API_SETTINGS_DEFAULT.version) {
-    data = resetToLatest(data);
-    info(
-      `[vrchat-api-settings-migrations] Reset future VRChat API settings version back to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  while (currentVersion < VRCHAT_API_SETTINGS_DEFAULT.version) {
-    try {
-      data = await migrations[++currentVersion](data);
-    } catch (e) {
-      error(
-        "[vrchat-api-settings-migrations] Couldn't migrate to version " +
-          currentVersion +
-          '. Backing up configuration and resetting to the latest version. : ' +
-          e
-      );
-      saveBackup(structuredClone(data));
-      data = resetToLatest(data);
-      currentVersion = data.version;
-      message(
-        'Your VRChat settings could not to be migrated to the new version of OyasumiVR, and have therefore been reset. Apologies for the inconvenience.\n\nPlease report this issue to the developer so this issue may be fixed in the future. Thank you!',
-        { title: 'Migration Error (VRChat Settings)' }
-      );
-      continue;
-    }
-    currentVersion = data.version;
-    info(
-      `[vrchat-api-settings-migrations] Migrated VRChat API settings to version ${
-        currentVersion + ''
-      }`
-    );
-  }
-  data = mergeWith(structuredClone(VRCHAT_API_SETTINGS_DEFAULT), data, (objValue, srcValue) => {
-    // Delete irrelevant keys
-    if (objValue === undefined) {
-      return undefined;
-    }
-    // Do not merge array values
-    if (Array.isArray(objValue)) {
-      return srcValue;
-    }
-  });
-  return data as VRChatApiSettings;
-}
-
-async function saveBackup(oldData: any) {
-  await writeTextFile('vrchat-api-settings.backup.json', JSON.stringify(oldData, null, 2), {
-    baseDir: BaseDirectory.AppData,
-  });
-}
+import { protectSecret } from '../utils/secrets';
+import { normalizeWithDefaults } from './migration-defaults';
 
 function from1To2(data: any): any {
   delete data['apiKey'];
@@ -150,65 +83,64 @@ const LEGACY_SECRET_TEXT_FIELDS = [
 ];
 
 async function from6To7(data: any): Promise<any> {
-  const original = structuredClone(data);
   const legacyKey = data.legacyCredentialCryptoKey;
   let key: CryptoKey | null = null;
   if (legacyKey) {
-    try {
-      key = await deserializeStorageCryptoKey(legacyKey);
-    } catch (e) {
-      error("[vrchat-api-settings-migrations] Couldn't read the credential key: " + e);
-    }
+    key = await deserializeStorageCryptoKey(legacyKey);
   }
-  let discarded = false;
   data.profiles = await Promise.all(
     (data.profiles ?? []).map(async (profile: any) => {
       const migrated = { ...profile };
       if (migrated.encryptedPendingTwoFactorLoginIdentifier != null) {
-        migrated.pendingTwoFactorLoginIdentifier = key
-          ? await decryptLegacyValue(
-              migrated.encryptedPendingTwoFactorLoginIdentifier,
-              key,
-              profile.id
-            )
-          : null;
-        if (migrated.pendingTwoFactorLoginIdentifier == null) discarded = true;
+        if (!key) throw new Error(`Profile ${profile.id} has encrypted data but no legacy key`);
+        migrated.pendingTwoFactorLoginIdentifier = await decryptLegacyValue(
+          migrated.encryptedPendingTwoFactorLoginIdentifier,
+          key,
+          profile.id
+        );
         delete migrated.encryptedPendingTwoFactorLoginIdentifier;
       }
       if ('rememberedCredentials' in migrated) {
         const stored = migrated.rememberedCredentials;
-        migrated.rememberedCredentials =
-          typeof stored === 'string'
-            ? key
-              ? await decryptLegacyCredentials(stored, key, profile.id)
-              : null
-            : readCredentials(stored, profile.id);
-        if (stored && migrated.rememberedCredentials == null) discarded = true;
+        if (typeof stored === 'string') {
+          if (!key)
+            throw new Error(`Profile ${profile.id} has encrypted credentials but no legacy key`);
+          migrated.rememberedCredentials = await decryptLegacyCredentials(stored, key, profile.id);
+        } else {
+          migrated.rememberedCredentials = readCredentials(stored, profile.id);
+        }
       }
       migrated.rememberCredentials =
         !!migrated.rememberedCredentials && !!profile.rememberCredentials;
       for (const field of LEGACY_SECRET_TEXT_FIELDS) {
         if (field in migrated && migrated[field] != null && typeof migrated[field] !== 'string') {
-          error(
-            '[vrchat-api-settings-migrations] Discarded the ' +
-              field +
-              ' of profile ' +
-              profile.id +
-              ': not a string'
-          );
-          migrated[field] = null;
-          discarded = true;
+          throw new Error(`The ${field} of profile ${profile.id} is not a string`);
         }
       }
-      return migrated;
+      const protectedSecret = await protectSecret(
+        JSON.stringify({
+          authCookie: migrated.authCookie ?? null,
+          twoFactorCookie: migrated.twoFactorCookie ?? null,
+          twoFactorCookieLoginIdentifierHash: migrated.twoFactorCookieLoginIdentifierHash ?? null,
+          pendingTwoFactorLoginIdentifier: migrated.pendingTwoFactorLoginIdentifier ?? null,
+          rememberCredentials: migrated.rememberCredentials,
+          rememberedCredentials: migrated.rememberedCredentials ?? null,
+        })
+      );
+      if (!protectedSecret) throw new Error(`Profile ${profile.id} could not be protected`);
+      return {
+        id: migrated.id,
+        sourceProfileId: migrated.sourceProfileId,
+        restoreProfileId: migrated.restoreProfileId,
+        userId: migrated.userId,
+        username: migrated.username,
+        displayName: migrated.displayName,
+        draft: migrated.draft,
+        protectedSecret,
+      };
     })
   );
   delete data.legacyCredentialCryptoKey;
-  if (discarded) {
-    await saveBackup(original).catch((e) =>
-      error("[vrchat-api-settings-migrations] Couldn't write the backup: " + e)
-    );
-  }
   data.version = 7;
   return data;
 }
@@ -221,12 +153,7 @@ function readCredentials(
   if (typeof value?.username === 'string' && typeof value?.password === 'string') {
     return { username: value.username, password: value.password };
   }
-  error(
-    '[vrchat-api-settings-migrations] Discarded the credentials of profile ' +
-      profileId +
-      ': unexpected shape'
-  );
-  return null;
+  throw new Error(`The credentials of profile ${profileId} have an unexpected shape`);
 }
 
 async function decryptLegacyValue(
@@ -236,14 +163,8 @@ async function decryptLegacyValue(
 ): Promise<string | null> {
   try {
     return await decryptStorageData(value, key);
-  } catch (e) {
-    error(
-      "[vrchat-api-settings-migrations] Couldn't decrypt a value for profile " +
-        profileId +
-        ': ' +
-        e
-    );
-    return null;
+  } catch (cause) {
+    throw new Error(`Could not decrypt a value for profile ${profileId}`, { cause });
   }
 }
 
@@ -255,25 +176,23 @@ async function decryptLegacyCredentials(
   const encoded = await decryptLegacyValue(value, key, profileId);
   if (encoded == null) return null;
   const separator = encoded.indexOf(':');
-  try {
-    if (separator < 0) throw new Error('missing separator');
-    return {
-      username: atob(encoded.slice(0, separator)),
-      password: atob(encoded.slice(separator + 1)),
-    };
-  } catch (e) {
-    error(
-      '[vrchat-api-settings-migrations] Discarded the credentials of profile ' +
-        profileId +
-        ': ' +
-        e
-    );
-    return null;
-  }
+  if (separator < 0) throw new Error(`The credentials of profile ${profileId} have no separator`);
+  return {
+    username: atob(encoded.slice(0, separator)),
+    password: atob(encoded.slice(separator + 1)),
+  };
 }
 
-function resetToLatest(data: any): any {
-  // Reset to latest
-  data = structuredClone(VRCHAT_API_SETTINGS_DEFAULT);
-  return data;
-}
+export const VRCHAT_API_MIGRATION: MigrationDefinition<Versioned> = {
+  targetVersion: VRCHAT_API_SETTINGS_DEFAULT.version,
+  minimumSupportedVersion: 1,
+  steps: {
+    1: from1To2,
+    2: from2To3,
+    3: from3To4,
+    4: from4To5,
+    5: from5To6,
+    6: from6To7,
+  },
+  normalizeCurrentVersion: (data) => normalizeWithDefaults(VRCHAT_API_SETTINGS_DEFAULT, data),
+};

--- a/src-ui/app/models/automations.ts
+++ b/src-ui/app/models/automations.ts
@@ -1,12 +1,13 @@
-import { OVRDeviceClass } from './ovr-device';
-import { OscScript } from './osc-script';
-import { SleepingPose } from './sleeping-pose';
+import type { OVRDeviceClass } from './ovr-device';
+import type { OscScript } from './osc-script';
+import type { SleepingPose } from './sleeping-pose';
 import { UserStatus } from './vrchat';
-import { AudioDeviceParsedName, AudioDeviceType } from './audio-device';
-import { PersistedAvatar } from './vrchat';
+import type { AudioDeviceParsedName, AudioDeviceType } from './audio-device';
+import type { PersistedAvatar } from './vrchat';
 import { FrameLimiterPresets } from '../services/frame-limiter.service';
-import { getBuiltInNotificationSound, NotificationSound } from './notification-sounds';
-import { DeviceSelection } from './device-manager';
+import { getBuiltInNotificationSound } from './notification-sounds';
+import type { NotificationSound } from './notification-sounds';
+import type { DeviceSelection } from './device-manager';
 
 export type AutomationType =
   | 'GPU_POWER_LIMITS'

--- a/src-ui/app/models/osc-script.ts
+++ b/src-ui/app/models/osc-script.ts
@@ -1,4 +1,4 @@
-import { TString } from './translatable-string';
+import type { TString } from './translatable-string';
 
 export const OSC_SCRIPT_VERSION = 3;
 

--- a/src-ui/app/services/app-settings.service.ts
+++ b/src-ui/app/services/app-settings.service.ts
@@ -13,10 +13,8 @@ import {
 } from 'rxjs';
 import { SETTINGS_KEY_APP_SETTINGS, SETTINGS_STORE } from '../globals';
 import { isEqual, uniq } from 'lodash';
-import { migrateAppSettings } from '../migrations/app-settings.migrations';
 import { protectSecret, unprotectSecret } from '../utils/secrets';
 import { error } from '@tauri-apps/plugin-log';
-import { TranslocoService } from '@jsverse/transloco';
 import { OneTimeFlag } from '../models/one-time-flags';
 import { ModalService } from './modal.service';
 import {
@@ -42,10 +40,7 @@ export class AppSettingsService {
   >(undefined);
   public loadedDefaults: Observable<boolean | undefined> = this._loadedDefaults.asObservable();
 
-  constructor(
-    private translateService: TranslocoService,
-    private modalService: ModalService
-  ) {}
+  constructor(private modalService: ModalService) {}
 
   async init() {
     await this.loadSettings();
@@ -63,13 +58,7 @@ export class AppSettingsService {
     let settings: AppSettings | undefined =
       await SETTINGS_STORE.get<AppSettings>(SETTINGS_KEY_APP_SETTINGS);
     let loadedDefaults = false;
-    if (settings) {
-      const oldSettings = structuredClone(settings);
-      settings = await migrateAppSettings(settings);
-      if (oldSettings.userLanguage !== settings.userLanguage) {
-        this.translateService.setActiveLang(settings.userLanguage);
-      }
-    } else {
+    if (!settings) {
       settings = this._settings.value;
       loadedDefaults = true;
     }
@@ -78,10 +67,9 @@ export class AppSettingsService {
     settings.mqttPassword = await unprotectSecret(stored);
     this.storedMqttPassword =
       stored && settings.mqttPassword ? { plain: settings.mqttPassword, protected: stored } : null;
-    // Hold on to a password that cannot be unlocked, so the save below rewrites it instead of nothing
+    // Hold on to a password that cannot be unlocked, so a later save rewrites it instead of nothing
     settings.mqttProtectedPassword = settings.mqttPassword ? null : stored;
     this._settings.next(settings);
-    await this.saveSettings();
     this._loadedDefaults.next(loadedDefaults);
   }
 

--- a/src-ui/app/services/automation-config.service.ts
+++ b/src-ui/app/services/automation-config.service.ts
@@ -9,7 +9,6 @@ import {
 import { asyncScheduler, BehaviorSubject, Observable, skip, switchMap, throttleTime } from 'rxjs';
 import { SETTINGS_KEY_AUTOMATION_CONFIGS, SETTINGS_STORE } from '../globals';
 
-import { migrateAutomationConfigs } from '../migrations/automation-configs.migrations';
 import { listen } from '@tauri-apps/api/event';
 
 @Injectable({
@@ -58,9 +57,7 @@ export class AutomationConfigService {
     let configs: AutomationConfigs | undefined = await SETTINGS_STORE.get<AutomationConfigs>(
       SETTINGS_KEY_AUTOMATION_CONFIGS
     );
-    configs = configs ? await migrateAutomationConfigs(configs) : this._configs.value;
-    this._configs.next(configs);
-    await this.saveConfigs();
+    this._configs.next(configs ?? this._configs.value);
   }
 
   async saveConfigs() {

--- a/src-ui/app/services/device-manager.service.ts
+++ b/src-ui/app/services/device-manager.service.ts
@@ -7,6 +7,7 @@ import {
   firstValueFrom,
   map,
   Observable,
+  skip,
   switchMap,
   tap,
   throttleTime,
@@ -20,7 +21,6 @@ import {
   DMDeviceType,
   DMKnownDevice,
 } from '../models/device-manager';
-import { migrateDeviceManagerData } from '../migrations/device-manager.migrations';
 import { SETTINGS_KEY_DEVICE_MANAGER, SETTINGS_STORE } from '../globals';
 import { OpenVRService } from './openvr.service';
 import { LighthouseService } from './lighthouse.service';
@@ -47,14 +47,15 @@ export class DeviceManagerService {
 
   async init() {
     await this.loadData();
-    this.listenForOpenVRDevices();
-    this.listenForLighthouseDevices();
     this._data
       .pipe(
+        skip(1),
         throttleTime(2000, asyncScheduler, { leading: true, trailing: true }),
         switchMap(() => this.saveData())
       )
       .subscribe();
+    this.listenForOpenVRDevices();
+    this.listenForLighthouseDevices();
   }
 
   public getKnownDeviceById(id: string): DMKnownDevice | undefined {
@@ -480,12 +481,10 @@ export class DeviceManagerService {
   }
 
   private async loadData() {
-    let data: DeviceManagerData | undefined = await SETTINGS_STORE.get<DeviceManagerData>(
+    const data: DeviceManagerData | undefined = await SETTINGS_STORE.get<DeviceManagerData>(
       SETTINGS_KEY_DEVICE_MANAGER
     );
-    data = data ? migrateDeviceManagerData(data) : this._data.value;
-    this._data.next(data);
-    await this.saveData();
+    if (data) this._data.next(data);
   }
 
   private async saveData() {

--- a/src-ui/app/services/event-log.service.ts
+++ b/src-ui/app/services/event-log.service.ts
@@ -8,7 +8,6 @@ import {
 import { async, BehaviorSubject, Observable, throttleTime } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import { migrateEventLog } from '../migrations/event-log.migrations';
 import { EVENT_LOG_STORE } from '../globals';
 
 const MAX_LOG_AGE = 48 * 60 * 60 * 1000;
@@ -56,9 +55,7 @@ export class EventLogService {
 
   private async loadEventLog() {
     let log: EventLog | undefined = await EVENT_LOG_STORE.get<EventLog>('EVENT_LOG');
-    if (log) {
-      log = migrateEventLog(log);
-    } else {
+    if (!log) {
       log = this._eventLog.value;
     }
     // Remove events that are too old

--- a/src-ui/app/services/integrations/pulsoid.service.ts
+++ b/src-ui/app/services/integrations/pulsoid.service.ts
@@ -31,7 +31,6 @@ import {
   PULSOID_API_SETTINGS_DEFAULT,
   PulsoidApiSettings,
 } from '../../models/pulsoid-api-settings';
-import { migratePulsoidApiSettings } from '../../migrations/pulsoid-api-settings.migrations';
 import * as shell from '@tauri-apps/plugin-shell';
 import { protectSecret, unprotectSecret } from '../../utils/secrets';
 
@@ -254,22 +253,22 @@ export class PulsoidService {
   private async loadSettings() {
     let settings: PulsoidApiSettings | undefined =
       await SETTINGS_STORE.get<PulsoidApiSettings>(SETTINGS_KEY_PULSOID_API);
-    settings = settings ? await migratePulsoidApiSettings(settings) : this.settings.value;
+    if (!settings) settings = this.settings.value;
     const plain = await unprotectSecret(settings.accessToken);
     this.accessToken.next(plain);
     this.storedAccessToken =
       settings.accessToken && plain ? { plain, protected: settings.accessToken } : null;
     // Handle token expiry
-    if (settings.expiresAt && settings.expiresAt < Date.now() / 1000) {
+    const expired = !!settings.expiresAt && settings.expiresAt < Date.now() / 1000;
+    if (expired) {
       info('[Pulsoid] Token expired, throwing it away.');
       this.accessToken.next(null);
       settings.accessToken = undefined;
       settings.expiresAt = undefined;
       // TODO: Let user in some way know that their existing login has expired, and they should reauthenticate
     }
-    // Finish loading settings & write changes to disk
     this.settings.next(settings);
-    await this.saveSettings();
+    if (expired) await this.saveSettings();
   }
 
   private async updateSettings(settings: Partial<PulsoidApiSettings>) {

--- a/src-ui/app/services/migration-coordinator.service.ts
+++ b/src-ui/app/services/migration-coordinator.service.ts
@@ -54,6 +54,11 @@ export class MigrationCoordinatorService {
       case 'keep-live':
         info(`[MigrationCoordinator] ${spec.storeName}: live store is current, nothing to do`);
         break;
+      case 'defer':
+        warn(
+          `[MigrationCoordinator] ${spec.storeName}: live store could not be read and no backup was viable, leaving it untouched`
+        );
+        break;
       case 'install':
         info(
           `[MigrationCoordinator] ${spec.storeName}: installing candidate '${decision.selectedId}' (checkpoint reason '${decision.checkpointReason}')`
@@ -62,7 +67,7 @@ export class MigrationCoordinatorService {
       case 'install-defaults':
         if (decision.hadCandidates) {
           error(
-            `[MigrationCoordinator] ${spec.storeName}: no viable candidate, quarantining the live store and installing defaults`
+            `[MigrationCoordinator] ${spec.storeName}: no viable candidate, quarantining the live store and recovering each key where possible`
           );
         } else {
           info(`[MigrationCoordinator] ${spec.storeName}: no store yet, installing defaults`);

--- a/src-ui/app/services/migration-coordinator.service.ts
+++ b/src-ui/app/services/migration-coordinator.service.ts
@@ -1,0 +1,191 @@
+import { Injectable } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
+import { error, info, warn } from '@tauri-apps/plugin-log';
+import { message } from '@tauri-apps/plugin-dialog';
+import { applyStoreMigration, decideStoreMigration } from 'src-shared-ts/src/store-migration';
+import type {
+  LiveStoreState,
+  StoreCandidate,
+  StoreMigrationPorts,
+  StoreMigrationSpec,
+} from 'src-shared-ts/src/store-migration';
+import { STORE_MIGRATIONS } from '../migrations/store-migrations';
+import { StoreSnapshotService } from './store-snapshot.service';
+import type { StoreCheckpoint } from './store-snapshot.service';
+
+const STORE_FALLBACK_LABELS: Record<string, string> = {
+  settings: 'settings',
+  event_log: 'event log',
+};
+
+/** Migrates stores before services read them, restoring compatible candidates when needed. */
+@Injectable({
+  providedIn: 'root',
+})
+export class MigrationCoordinatorService {
+  constructor(
+    private storeSnapshotService: StoreSnapshotService,
+    private translate: TranslocoService
+  ) {}
+
+  public async run(): Promise<void> {
+    for (const spec of STORE_MIGRATIONS) {
+      await this.runStore(spec);
+    }
+  }
+
+  private async runStore(spec: StoreMigrationSpec): Promise<void> {
+    const candidates = await this.gatherCandidates(spec.storeName);
+    const decision = await decideStoreMigration(candidates, spec);
+    for (const report of decision.reports) {
+      if (report.viable) {
+        info(
+          `[MigrationCoordinator] ${spec.storeName}: candidate '${report.id}' is ${
+            report.atTarget ? 'at the current schema' : 'viable after migration'
+          }`
+        );
+      } else {
+        warn(
+          `[MigrationCoordinator] ${spec.storeName}: skipping candidate '${report.id}' (${report.reason})`
+        );
+      }
+    }
+    switch (decision.action) {
+      case 'keep-live':
+        info(`[MigrationCoordinator] ${spec.storeName}: live store is current, nothing to do`);
+        break;
+      case 'install':
+        info(
+          `[MigrationCoordinator] ${spec.storeName}: installing candidate '${decision.selectedId}' (checkpoint reason '${decision.checkpointReason}')`
+        );
+        break;
+      case 'install-defaults':
+        if (decision.hadCandidates) {
+          error(
+            `[MigrationCoordinator] ${spec.storeName}: no viable candidate, quarantining the live store and installing defaults`
+          );
+        } else {
+          info(`[MigrationCoordinator] ${spec.storeName}: no store yet, installing defaults`);
+        }
+        break;
+    }
+    await applyStoreMigration(decision, this.liveState(candidates), spec, this.createPorts());
+  }
+
+  private async gatherCandidates(storeName: string): Promise<StoreCandidate[]> {
+    const candidates: StoreCandidate[] = [];
+    const backups: Array<{ candidate: StoreCandidate; createdAtMillis: number }> = [];
+    const live = await this.storeSnapshotService.readLiveStore(storeName);
+    if (live.exists) candidates.push({ id: 'live', kind: 'live', contents: live.contents });
+    try {
+      const snapshot = await this.storeSnapshotService.readSnapshot(storeName);
+      if (snapshot !== null)
+        backups.push({
+          candidate: { id: 'snapshot', kind: 'snapshot', contents: snapshot.contents },
+          createdAtMillis: snapshot.modifiedAtMillis,
+        });
+    } catch (e) {
+      warn(`[MigrationCoordinator] ${storeName}: rolling snapshot could not be read (${e})`);
+      backups.push({
+        candidate: { id: 'snapshot', kind: 'snapshot', contents: null },
+        createdAtMillis: 0,
+      });
+    }
+    let checkpoints: StoreCheckpoint[];
+    try {
+      checkpoints = await this.storeSnapshotService.listCheckpoints(storeName);
+    } catch (e) {
+      warn(`[MigrationCoordinator] ${storeName}: checkpoints could not be listed (${e})`);
+      backups.push({
+        candidate: { id: 'checkpoints', kind: 'checkpoint', contents: null },
+        createdAtMillis: 0,
+      });
+      candidates.push(...this.sortBackups(backups));
+      return candidates;
+    }
+    for (const checkpoint of checkpoints) {
+      if (!checkpoint.contentFileExists) {
+        backups.push({
+          candidate: { id: checkpoint.id, kind: 'checkpoint', contents: null },
+          createdAtMillis: checkpoint.createdAtMillis,
+        });
+        continue;
+      }
+      try {
+        const contents = await this.storeSnapshotService.readCheckpoint(storeName, checkpoint.id);
+        backups.push({
+          candidate: { id: checkpoint.id, kind: 'checkpoint', contents },
+          createdAtMillis: checkpoint.createdAtMillis,
+        });
+      } catch (e) {
+        warn(`[MigrationCoordinator] ${storeName}: skipping checkpoint '${checkpoint.id}' (${e})`);
+        backups.push({
+          candidate: { id: checkpoint.id, kind: 'checkpoint', contents: null },
+          createdAtMillis: checkpoint.createdAtMillis,
+        });
+      }
+    }
+    candidates.push(...this.sortBackups(backups));
+    return candidates;
+  }
+
+  private sortBackups(
+    backups: Array<{ candidate: StoreCandidate; createdAtMillis: number }>
+  ): StoreCandidate[] {
+    return backups
+      .sort(
+        (a, b) =>
+          b.createdAtMillis - a.createdAtMillis ||
+          Number(b.candidate.kind === 'checkpoint') - Number(a.candidate.kind === 'checkpoint')
+      )
+      .map(({ candidate }) => candidate);
+  }
+
+  private liveState(candidates: StoreCandidate[]): LiveStoreState {
+    const live = candidates.find((candidate) => candidate.kind === 'live');
+    if (!live) return { exists: false, parsesAsObject: false, contents: null, parsed: null };
+    if (live.contents === null)
+      return { exists: true, parsesAsObject: false, contents: null, parsed: null };
+    try {
+      const parsed: unknown = JSON.parse(live.contents);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
+        throw new Error('not a JSON object');
+      return {
+        exists: true,
+        parsesAsObject: true,
+        contents: live.contents,
+        parsed: parsed as Record<string, unknown>,
+      };
+    } catch {
+      return { exists: true, parsesAsObject: false, contents: live.contents, parsed: null };
+    }
+  }
+
+  private createPorts(): StoreMigrationPorts {
+    return {
+      createCheckpoint: (storeName, reason, schemaVersions, contents) =>
+        this.storeSnapshotService
+          .createCheckpoint(storeName, reason, schemaVersions, contents)
+          .then(() => undefined),
+      quarantineStore: async (storeName) => {
+        const quarantined = await this.storeSnapshotService.quarantineStore(storeName);
+        info(
+          `[MigrationCoordinator] ${storeName}: ${
+            quarantined ? 'live store quarantined' : 'no live store to quarantine'
+          }`
+        );
+      },
+      replaceStore: (storeName, contents) =>
+        this.storeSnapshotService.replaceStore(storeName, contents),
+      notifyFallback: async (storeName) => {
+        const label = STORE_FALLBACK_LABELS[storeName] ?? storeName;
+        void message(this.translate.translate('migration-recovery.message', { store: label }), {
+          title: this.translate.translate('migration-recovery.title', { store: label }),
+          kind: 'error',
+        }).catch((e) => {
+          warn(`[MigrationCoordinator] ${storeName}: failed to show the recovery dialog: ${e}`);
+        });
+      },
+    };
+  }
+}

--- a/src-ui/app/services/store-snapshot.service.ts
+++ b/src-ui/app/services/store-snapshot.service.ts
@@ -1,4 +1,7 @@
 import { Injectable } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
+import { invoke } from '@tauri-apps/api/core';
+import { LazyStore } from '@tauri-apps/plugin-store';
 import {
   EVENT_LOG_STORE,
   CACHE_FILE,
@@ -7,40 +10,108 @@ import {
   SETTINGS_STORE,
   EVENT_LOG_FILE,
 } from '../globals';
-import { StoreProtector } from '../utils/store-protector';
-import { TranslocoService } from '@jsverse/transloco';
+import { getVersion } from '../utils/app-utils';
+import { serializeStoreContents, StoreProtector } from '../utils/store-protector';
 
 // Workaround for https://github.com/tauri-apps/plugins-workspace/issues/3085
+
+export interface StoreCheckpoint {
+  formatVersion: number;
+  id: string;
+  storeName: string;
+  appVersion: string;
+  reason: string;
+  createdAt: string;
+  createdAtMillis: number;
+  sequence: number;
+  schemaVersions: Record<string, number>;
+  contentChecksum: string;
+  contentSizeBytes: number;
+  contentFile: string;
+  contentFileExists: boolean;
+}
+
+const PROTECTED_STORES: Record<string, { file: string; store: LazyStore }> = {
+  settings: { file: SETTINGS_FILE, store: SETTINGS_STORE },
+  cache: { file: CACHE_FILE, store: CACHE_STORE },
+  event_log: { file: EVENT_LOG_FILE, store: EVENT_LOG_STORE },
+};
 
 @Injectable({
   providedIn: 'root',
 })
 export class StoreSnapshotService {
+  private protectors?: StoreProtector[];
+
   constructor(private translate: TranslocoService) {}
 
   public async init() {
-    const settingsStoreProtector = new StoreProtector(
-      SETTINGS_STORE,
-      'settings',
-      SETTINGS_FILE,
-      this.translate
-    );
-    const cacheStoreProtector = new StoreProtector(
-      CACHE_STORE,
-      'cache',
-      CACHE_FILE,
-      this.translate
-    );
-    const eventLogStoreProtector = new StoreProtector(
-      EVENT_LOG_STORE,
-      'event_log',
-      EVENT_LOG_FILE,
-      this.translate
-    );
-    await Promise.all([
-      settingsStoreProtector.init(),
-      cacheStoreProtector.init(),
-      eventLogStoreProtector.init(),
-    ]);
+    await this.initializeRecovery();
+    this.enablePeriodicSnapshots();
+  }
+
+  // Restore any corrupted stores from their latest known good snapshots
+  public async initializeRecovery() {
+    if (!this.protectors) {
+      this.protectors = Object.entries(PROTECTED_STORES).map(
+        ([name, { file, store }]) => new StoreProtector(store, name, file, this.translate)
+      );
+    }
+    await Promise.all(this.protectors.map((protector) => protector.initializeRecovery()));
+  }
+
+  // Only enable once startup recovery has finished, so snapshots never race recovery
+  public enablePeriodicSnapshots() {
+    this.protectors?.forEach((protector) => protector.startPeriodicSnapshots());
+  }
+
+  // Write an immutable checkpoint, verified on disk before it is reported back
+  public async createCheckpoint(
+    storeName: string,
+    reason: string,
+    schemaVersions: Record<string, number>,
+    contents?: string
+  ): Promise<StoreCheckpoint> {
+    const store = this.getStoreEntry(storeName).store;
+    return invoke<StoreCheckpoint>('store_safety_create_checkpoint', {
+      storeName,
+      contents: contents ?? (await serializeStoreContents(store)),
+      reason,
+      appVersion: await getVersion(),
+      schemaVersions,
+    });
+  }
+
+  // Newest first; candidates are viable when contentFileExists and readCheckpoint succeeds
+  public listCheckpoints(storeName: string): Promise<StoreCheckpoint[]> {
+    return invoke<StoreCheckpoint[]>('store_safety_list_checkpoints', { storeName });
+  }
+
+  public readCheckpoint(storeName: string, checkpointId: string): Promise<string> {
+    return invoke<string>('store_safety_read_checkpoint', { storeName, checkpointId });
+  }
+
+  // Preserve unusable live store bytes for inspection instead of deleting them
+  public quarantineStore(storeName: string): Promise<string | null> {
+    return invoke<string | null>('store_safety_quarantine_store', {
+      storeName,
+      storeFileName: this.getStoreEntry(storeName).file,
+    });
+  }
+
+  // Atomically replace the physical store file, then reload the in-memory store
+  public async replaceStore(storeName: string, contents: string): Promise<void> {
+    const entry = this.getStoreEntry(storeName);
+    await invoke('store_safety_replace_store', {
+      storeFileName: entry.file,
+      contents,
+    });
+    await entry.store.reload({ ignoreDefaults: true });
+  }
+
+  private getStoreEntry(storeName: string): { file: string; store: LazyStore } {
+    const entry = PROTECTED_STORES[storeName];
+    if (!entry) throw new Error(`Unknown protected store '${storeName}'`);
+    return entry;
   }
 }

--- a/src-ui/app/services/store-snapshot.service.ts
+++ b/src-ui/app/services/store-snapshot.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { TranslocoService } from '@jsverse/transloco';
 import { invoke } from '@tauri-apps/api/core';
 import { LazyStore } from '@tauri-apps/plugin-store';
+import { appDataDir, join } from '@tauri-apps/api/path';
+import { exists, readTextFile } from '@tauri-apps/plugin-fs';
+import { error } from '@tauri-apps/plugin-log';
 import {
   EVENT_LOG_STORE,
   CACHE_FILE,
@@ -12,8 +14,6 @@ import {
 } from '../globals';
 import { getVersion } from '../utils/app-utils';
 import { serializeStoreContents, StoreProtector } from '../utils/store-protector';
-
-// Workaround for https://github.com/tauri-apps/plugins-workspace/issues/3085
 
 export interface StoreCheckpoint {
   formatVersion: number;
@@ -31,6 +31,16 @@ export interface StoreCheckpoint {
   contentFileExists: boolean;
 }
 
+export interface LiveStoreRead {
+  exists: boolean;
+  contents: string | null;
+}
+
+export interface StoreSnapshot {
+  contents: string;
+  modifiedAtMillis: number;
+}
+
 const PROTECTED_STORES: Record<string, { file: string; store: LazyStore }> = {
   settings: { file: SETTINGS_FILE, store: SETTINGS_STORE },
   cache: { file: CACHE_FILE, store: CACHE_STORE },
@@ -41,31 +51,44 @@ const PROTECTED_STORES: Record<string, { file: string; store: LazyStore }> = {
   providedIn: 'root',
 })
 export class StoreSnapshotService {
-  private protectors?: StoreProtector[];
+  private protectors?: Record<string, StoreProtector>;
 
-  constructor(private translate: TranslocoService) {}
-
-  public async init() {
-    await this.initializeRecovery();
-    this.enablePeriodicSnapshots();
-  }
-
-  // Restore any corrupted stores from their latest known good snapshots
   public async initializeRecovery() {
     if (!this.protectors) {
-      this.protectors = Object.entries(PROTECTED_STORES).map(
-        ([name, { file, store }]) => new StoreProtector(store, name, file, this.translate)
+      this.protectors = Object.fromEntries(
+        Object.entries(PROTECTED_STORES).map(([name, { file, store }]) => [
+          name,
+          new StoreProtector(store, name, file),
+        ])
       );
     }
-    await Promise.all(this.protectors.map((protector) => protector.initializeRecovery()));
+    await Promise.all(
+      Object.entries(this.protectors).map(([name, protector]) =>
+        protector.initializeRecovery(name === 'cache')
+      )
+    );
   }
 
-  // Only enable once startup recovery has finished, so snapshots never race recovery
+  // startup recovery must finish before snapshots can write
   public enablePeriodicSnapshots() {
-    this.protectors?.forEach((protector) => protector.startPeriodicSnapshots());
+    Object.values(this.protectors ?? {}).forEach((protector) => protector.startPeriodicSnapshots());
   }
 
-  // Write an immutable checkpoint, verified on disk before it is reported back
+  public async readLiveStore(storeName: string): Promise<LiveStoreRead> {
+    const path = await join(await appDataDir(), this.getStoreEntry(storeName).file);
+    if (!(await exists(path))) return { exists: false, contents: null };
+    try {
+      return { exists: true, contents: await readTextFile(path) };
+    } catch (e) {
+      error(`[StoreSnapshot] Failed to read the live store '${storeName}': ${e}`);
+      return { exists: true, contents: null };
+    }
+  }
+
+  public readSnapshot(storeName: string): Promise<StoreSnapshot | null> {
+    return invoke<StoreSnapshot | null>('store_safety_read_snapshot', { storeName });
+  }
+
   public async createCheckpoint(
     storeName: string,
     reason: string,
@@ -82,7 +105,6 @@ export class StoreSnapshotService {
     });
   }
 
-  // Newest first; candidates are viable when contentFileExists and readCheckpoint succeeds
   public listCheckpoints(storeName: string): Promise<StoreCheckpoint[]> {
     return invoke<StoreCheckpoint[]>('store_safety_list_checkpoints', { storeName });
   }
@@ -91,7 +113,6 @@ export class StoreSnapshotService {
     return invoke<string>('store_safety_read_checkpoint', { storeName, checkpointId });
   }
 
-  // Preserve unusable live store bytes for inspection instead of deleting them
   public quarantineStore(storeName: string): Promise<string | null> {
     return invoke<string | null>('store_safety_quarantine_store', {
       storeName,
@@ -99,7 +120,6 @@ export class StoreSnapshotService {
     });
   }
 
-  // Atomically replace the physical store file, then reload the in-memory store
   public async replaceStore(storeName: string, contents: string): Promise<void> {
     const entry = this.getStoreEntry(storeName);
     await invoke('store_safety_replace_store', {

--- a/src-ui/app/services/telemetry.service.ts
+++ b/src-ui/app/services/telemetry.service.ts
@@ -12,7 +12,6 @@ import {
   throttleTime,
 } from 'rxjs';
 import { TELEMETRY_SETTINGS_DEFAULT, TelemetrySettings } from '../models/telemetry-settings';
-import { migrateTelemetrySettings } from '../migrations/telemetry-settings.migrations';
 
 import { invoke } from '@tauri-apps/api/core';
 import { trackEvent } from '@aptabase/tauri';
@@ -82,12 +81,10 @@ export class TelemetryService {
   }
 
   async loadSettings() {
-    let settings: TelemetrySettings | undefined = await SETTINGS_STORE.get<TelemetrySettings>(
+    const settings: TelemetrySettings | undefined = await SETTINGS_STORE.get<TelemetrySettings>(
       SETTINGS_KEY_TELEMETRY_SETTINGS
     );
-    settings = settings ? migrateTelemetrySettings(settings) : this._settings.value;
-    this._settings.next(settings);
-    await this.saveSettings();
+    this._settings.next(settings ?? this._settings.value);
   }
 
   async saveSettings() {

--- a/src-ui/app/services/vrchat-api/vrchat.service.ts
+++ b/src-ui/app/services/vrchat-api/vrchat.service.ts
@@ -11,7 +11,6 @@ import {
   VRChatAccountProfile,
   VRChatApiSettings,
 } from '../../models/vrchat-api-settings';
-import { migrateVRChatApiSettings } from '../../migrations/vrchat-api-settings.migrations';
 import { BehaviorSubject, combineLatest, filter, firstValueFrom, map, Observable } from 'rxjs';
 import { ModalService } from 'src-ui/app/services/modal.service';
 import { AvatarEx, UserStatus, WorldContext } from '../../models/vrchat';
@@ -289,14 +288,8 @@ export class VRChatService {
 
   private async loadSettings(): Promise<void> {
     const stored = await SETTINGS_STORE.get<VRChatApiSettings>(SETTINGS_KEY_VRCHAT_API);
-    let settings = stored
-      ? await migrateVRChatApiSettings(stored)
-      : structuredClone(VRCHAT_API_SETTINGS_DEFAULT);
-    settings = normalizeVRChatProfiles(await this.loadProfileSecrets(settings));
-    await this.saveSettings(settings).catch((cause) =>
-      error(`[VRChat] Failed to persist loaded settings: ${cause}`)
-    );
-    this.settingsSubject.next(settings);
+    const settings = stored ?? structuredClone(VRCHAT_API_SETTINGS_DEFAULT);
+    this.settingsSubject.next(normalizeVRChatProfiles(await this.loadProfileSecrets(settings)));
   }
 
   private async loadProfileSecrets(settings: VRChatApiSettings): Promise<VRChatApiSettings> {

--- a/src-ui/app/utils/store-protector.ts
+++ b/src-ui/app/utils/store-protector.ts
@@ -1,8 +1,3 @@
-//
-// Utility for storing store snapshots and restoring them in case of corruption
-//
-
-import { TranslocoService } from '@jsverse/transloco';
 import { invoke } from '@tauri-apps/api/core';
 import { appDataDir, join } from '@tauri-apps/api/path';
 import { exists, readTextFile } from '@tauri-apps/plugin-fs';
@@ -29,19 +24,17 @@ export class StoreProtector {
   constructor(
     private store: LazyStore,
     private storeName: string,
-    private storePath: string,
-    private translate: TranslocoService
+    private storePath: string
   ) {}
 
-  // Detect a zero-byte, malformed or torn store file and restore it from the snapshot
-  public async initializeRecovery() {
+  public async initializeRecovery(restoreCorruption = true) {
     if (this.recoveryInitialized || PROTECTOR_STORES[this.storeName]) {
       return;
     }
     this.recoveryInitialized = true;
     PROTECTOR_STORES[this.storeName] = this;
     this.snapshotPath = await join(await appDataDir(), 'StoreProtector', this.storeName + '.dat');
-    if (await this.isStoreCorrupted()) {
+    if (restoreCorruption && (await this.isStoreCorrupted())) {
       warn(
         "[StoreProtector] Detected possible corruption in store '" +
           this.storeName +
@@ -115,7 +108,6 @@ export class StoreProtector {
     if (!this.recoveryInitialized || !this.snapshotPath) return;
     const storeDataString = await serializeStoreContents(this.store);
     const storeDataHash = await this.generateHash(storeDataString);
-    // If we wrote the same data last time, no need to save again
     if ((await exists(this.snapshotPath)) && this.lastSavedHash === storeDataHash) return;
     await invoke('store_safety_save_snapshot', {
       storeName: this.storeName,

--- a/src-ui/app/utils/store-protector.ts
+++ b/src-ui/app/utils/store-protector.ts
@@ -3,16 +3,9 @@
 //
 
 import { TranslocoService } from '@jsverse/transloco';
+import { invoke } from '@tauri-apps/api/core';
 import { appDataDir, join } from '@tauri-apps/api/path';
-import {
-  copyFile,
-  exists,
-  mkdir,
-  readTextFile,
-  remove,
-  rename,
-  writeTextFile,
-} from '@tauri-apps/plugin-fs';
+import { exists, readTextFile } from '@tauri-apps/plugin-fs';
 import { debug, error, info, warn } from '@tauri-apps/plugin-log';
 import { LazyStore } from '@tauri-apps/plugin-store';
 import { interval } from 'rxjs';
@@ -20,10 +13,18 @@ import { interval } from 'rxjs';
 const PROTECTOR_STORES: Record<string, StoreProtector> = {};
 const SNAPSHOT_INTERVAL = 30000;
 
+export async function serializeStoreContents(store: LazyStore): Promise<string> {
+  const entries = await store.entries();
+  return JSON.stringify(
+    entries.reduce((acc, e) => ((acc[e[0]] = e[1]), acc), {} as Record<string, unknown>)
+  );
+}
+
 export class StoreProtector {
   private lastSavedHash?: string;
-  private enabled = false;
-  private basePath?: string;
+  private snapshotPath?: string;
+  private recoveryInitialized = false;
+  private periodicSnapshotsStarted = false;
 
   constructor(
     private store: LazyStore,
@@ -32,14 +33,14 @@ export class StoreProtector {
     private translate: TranslocoService
   ) {}
 
-  public async init() {
-    if (this.enabled || PROTECTOR_STORES[this.storeName]) {
+  // Detect a zero-byte, malformed or torn store file and restore it from the snapshot
+  public async initializeRecovery() {
+    if (this.recoveryInitialized || PROTECTOR_STORES[this.storeName]) {
       return;
     }
-    this.enabled = true;
+    this.recoveryInitialized = true;
     PROTECTOR_STORES[this.storeName] = this;
-    this.basePath = await join(await appDataDir(), 'StoreProtector');
-    await mkdir(this.basePath!, { recursive: true });
+    this.snapshotPath = await join(await appDataDir(), 'StoreProtector', this.storeName + '.dat');
     if (await this.isStoreCorrupted()) {
       warn(
         "[StoreProtector] Detected possible corruption in store '" +
@@ -48,24 +49,45 @@ export class StoreProtector {
       );
       if (!(await this.restoreSnapshot())) {
         error(
-          "[StoreProtector] No available snapshot found for store '" +
+          "[StoreProtector] No viable snapshot found for store '" +
             this.storeName +
             "'. Corruption cannot be restored."
         );
       }
     }
-    interval(SNAPSHOT_INTERVAL).subscribe(() => this.saveSnapshot());
+  }
+
+  // Requires initializeRecovery to have finished, so snapshots never race recovery
+  public startPeriodicSnapshots() {
+    if (this.periodicSnapshotsStarted || !this.recoveryInitialized) {
+      return;
+    }
+    this.periodicSnapshotsStarted = true;
+    interval(SNAPSHOT_INTERVAL).subscribe(() => {
+      this.saveSnapshot().catch((e) =>
+        error(
+          "[StoreProtector] Failed to save snapshot for store '" +
+            this.storeName +
+            "': " +
+            JSON.stringify(e)
+        )
+      );
+    });
   }
 
   public async hasAvailableSnapshot(): Promise<boolean> {
-    return exists(await join(this.basePath!, this.storeName + '.dat'));
+    if (!this.snapshotPath) return false;
+    return exists(this.snapshotPath);
   }
 
   public async restoreSnapshot(): Promise<boolean> {
-    const snapshotPath = await join(this.basePath!, this.storeName + '.dat');
-    if (!(await exists(snapshotPath))) return false;
+    if (!(await this.hasAvailableSnapshot())) return false;
     info("[StoreProtector] Restoring snapshot for store '" + this.storeName + "'");
-    await copyFile(snapshotPath, await join(await appDataDir(), this.storePath));
+    const restored = await invoke<boolean>('store_safety_restore_snapshot', {
+      storeName: this.storeName,
+      storeFileName: this.storePath,
+    });
+    if (!restored) return false;
     await this.store.reload({ ignoreDefaults: true });
     info("[StoreProtector] Successfully restored snapshot for store '" + this.storeName + "'");
     return true;
@@ -87,43 +109,19 @@ export class StoreProtector {
       );
       return true;
     }
-
-    return false;
   }
 
   private async saveSnapshot() {
-    if (!this.enabled) return;
-    // Obtain the store data
-    const storeData = await this.store
-      .entries()
-      .then((entries) =>
-        entries.reduce((acc, e) => ((acc[e[0]] = e[1]), acc), {} as Record<string, unknown>)
-      );
-    const storeDataString = JSON.stringify(storeData);
-    const finalPath = await join(this.basePath!, this.storeName + '.dat');
-    // Calculate a hash for the store data
+    if (!this.recoveryInitialized || !this.snapshotPath) return;
+    const storeDataString = await serializeStoreContents(this.store);
     const storeDataHash = await this.generateHash(storeDataString);
     // If we wrote the same data last time, no need to save again
-    if ((await exists(finalPath)) && this.lastSavedHash === storeDataHash) return;
-    // Save the snapshot data to a temporary file
-    const preValidationPath = await join(this.basePath!, this.storeName + '.pre.dat');
-    await writeTextFile(preValidationPath, storeDataString);
-    // Read the pre-validation data and compare it to the current data
-    try {
-      const preValidationData = await readTextFile(preValidationPath);
-      if (preValidationData !== storeDataString) {
-        throw new Error('Pre-validation data does not match current data');
-      }
-    } catch (e) {
-      error("Failed to save snapshot for store '" + this.storeName + "': " + JSON.stringify(e));
-      await remove(preValidationPath);
-      return;
-    }
-    // Move the temporary file to the final file
-    await rename(preValidationPath, finalPath);
-    // Update the last saved hash
+    if ((await exists(this.snapshotPath)) && this.lastSavedHash === storeDataHash) return;
+    await invoke('store_safety_save_snapshot', {
+      storeName: this.storeName,
+      contents: storeDataString,
+    });
     this.lastSavedHash = storeDataHash;
-    // Log the success
     debug("[StoreProtector] Successfully saved snapshot for store '" + this.storeName + "'");
   }
 

--- a/src-ui/assets/i18n/en.json
+++ b/src-ui/assets/i18n/en.json
@@ -1546,6 +1546,10 @@
     "title": "Message Center",
     "tooltip": "Message Center"
   },
+  "migration-recovery": {
+    "message": "OyasumiVR could not recover your {store}, so it reset that data to defaults.\n\nThe previous data remains on disk for manual recovery. Please contact support and report this problem.",
+    "title": "Could not recover {store}"
+  },
   "misc": {
     "GOGO_LOCO_LEGACY_PRESET_WARNING": "This preset uses a workaround that has some issues. Please only use this preset if you can't use the newer GoGo Loco preset. If your avatar still uses an older version of GoGo Loco, it is recommended that you update your avatar to use the latest GoGo Loco version.",
     "GORONE_LEGACY_PRESET_WARNING": "Versions v4.0 and up of this prefab already contain turning functionality, and are not compatible with this preset. This preset is still available if your avatar uses older versions of this prefab.",


### PR DESCRIPTION
This PR makes settings migrations recoverable across release and beta channel switches. It adds no backup management UI.

Settings could reset when a failed migration or a newer schema left the live file unusable. Each settings key also migrated and wrote itself independently, which could expose a partly migrated store.

The app now migrates each physical store before services load. It checkpoints live bytes before replacement, keeps rolling corruption snapshots, ranks compatible recovery sources by time, quarantines rejected files, and writes replacements atomically. Returning to an older build restores the newest compatible state. Returning to a newer build migrates the current live state.

Defaults are installed only after live data, the rolling snapshot, and every checkpoint fail. When no whole-store candidate works, the coordinator recovers each key independently before using defaults. It leaves unreadable live files untouched when no backup is viable. The app preserves rejected files and shows one recovery dialog without blocking startup.

## Review contract

Outcome: OyasumiVR migrates settings without destroying the last usable state. It restores the newest compatible state when users switch between future release and beta builds.

Acceptance:

- Preserve supported historical automation values through migration.
- Keep failed-write recovery through StoreProtector snapshots.
- Checkpoint live bytes before replacement.
- Restore future-schema data from the newest compatible checkpoint or snapshot without user action.
- Prefer newer live data when it can migrate, including release-side changes made after rollback.
- Resolve every versioned key in a store before services load.
- Install defaults only after every recovery source fails, while preserving rejected files and reporting the reset once.

Out of scope:

- Reverse migrations.
- A backup management UI.
- Recovery guarantees for builds released before this checkpoint system.
- Downgrading a fresh beta-only install when no compatible checkpoint has ever existed.

## Scope audit

Original intent: Stop valid automation schemas 2 through 8 from resetting to defaults, preserve user values, and keep full reset for genuinely corrupt input.

Current scope:

- A shared migration runner and store-level coordinator.
- Frozen historical automation transforms and regression fixtures.
- Atomic snapshots, checkpoints, quarantine, replacement, and candidate validation.
- Startup ordering and one last-resort recovery dialog.

Accepted growth: The Plane investigation and T3 thread identify the reset as a framework problem across the settings stores. The thread also requires automatic future release and beta rollback recovery, invisible backup handling, and preservation of StoreProtector failed-write recovery.

Review follow-ups: Consider bounded checkpoint retention, lazy candidate evaluation, and loading dialog translations before the last-resort notice. An installed release and beta channel-switch smoke test remains manual validation.

Revert or split: None. The changed files form one startup migration and recovery path.

Source thread: T3 Code thread `01a044cb-2f12-7830-b12b-4e5dc588c140`.

## Verification

Passed:

- `npm test`, 38 tests
- `npx tsc --noEmit -p tsconfig.app.json`
- ESLint for `src-ui`, `src-shared-ts`, and `scripts`
- `npm run tl:check-icu`, 104 messages
- `npx ng build oyasumivr`
- `cargo test`, 23 tests
- `cargo clippy --all-targets -- -D warnings`
- rustfmt on the changed Rust file
- `git diff --check`

The repository-wide Rust formatter still reports existing differences in four unrelated files. No isolated installed profile was available for a real release and beta channel-switch run. The A/B/A/B test covers candidate ordering and recovery behavior without touching the user's settings.

## Review verdict

Round: legacy recovery pass

Verdict: merge-ready

Reviewed HEAD: `39b7336493a44435692b645bd4744de865820cf6`

Reviewers: Codex, Claude, GLM

The pass confirmed and fixed three blockers: corrupt checkpoint deduplication, whole-store reset after one key failure, and reset after an unreadable live file with no viable backup. GLM's cache recovery claim was rejected because cache recovery receives the enabled flag.

Closure: fix and verify only. Do not start another general review for this frozen scope.