### PR TITLE
fix(OYASUMIVR-57): keep panic locations useful and private

### DIFF
--- a/src-core/src/main.rs
+++ b/src-core/src/main.rs
@@ -150,7 +150,10 @@ fn configure_tauri_plugin_aptabase() -> TauriPlugin<Wry> {
         .with_panic_hook(Box::new(|client, info, msg| {
             let location = info
                 .location()
-                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+                .map(|loc| {
+                    let file = panic_location_file(loc.file());
+                    format!("{file}:{}:{}", loc.line(), loc.column())
+                })
                 .unwrap_or_default();
 
             // Upload crash report if telemetry is enabled
@@ -173,6 +176,16 @@ fn configure_tauri_plugin_aptabase() -> TauriPlugin<Wry> {
             let _ = std::fs::write(panic_log_path, format!("{msg} ({location})\n"));
         }))
         .build()
+}
+
+fn panic_location_file(file: &str) -> String {
+    let file = file.replace('\\', "/");
+    match file.split_once("/Users/") {
+        Some((_, path)) => path
+            .split_once('/')
+            .map_or(path.to_owned(), |(_, path)| path.to_owned()),
+        None => file,
+    }
 }
 
 fn configure_tauri_plugin_log() -> TauriPlugin<Wry> {


### PR DESCRIPTION
Panic logs included the full source path Rust bakes into each panic location. On Windows this exposed the build account directory, for example `C:\Users\<name>\.cargo\registry\...`.

The Aptabase panic hook now removes only the drive, `Users`, and account-name segments. The Cargo registry path remains, so the same panic reports:

```text
.cargo/registry/src/index.crates.io-.../tao-0.34.5/src/platform_impl/windows/event_loop/runner.rs:368:25
```

No build scripts or packaging rules changed. Binaries may still contain other embedded paths; this fixes the reported panic log and telemetry payload.

Validation:

- `rustfmt --check --edition 2021 --config skip_children=true src-core/src/main.rs`
- `rustup run 1.97.1 cargo check --manifest-path src-core/Cargo.toml`