### PR TITLE
fix(OYASUMIVR-15): recover from corrupt image cache manifests

### DIFF
--- a/src-core/src/image_cache/mod.rs
+++ b/src-core/src/image_cache/mod.rs
@@ -61,12 +61,12 @@ impl ImageCache {
         if !image_path.exists() {
             return None;
         }
-        // Check if image is expired
+        // check expiration
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        if now - manifest.created > manifest.ttl {
+        if now.checked_sub(manifest.created)? > manifest.ttl {
             return None;
         }
         // Get mime type from manifest
@@ -149,12 +149,16 @@ impl ImageCache {
                     continue;
                 }
             };
-            // Check if image is expired
+            // check expiration
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_secs();
-            if only_expired && now - manifest.created < manifest.ttl {
+            if only_expired
+                && now
+                    .checked_sub(manifest.created)
+                    .is_some_and(|age| age < manifest.ttl)
+            {
                 continue;
             }
             // Delete storage directory
@@ -346,5 +350,24 @@ mod tests {
         assert!(entry_path.join("manifest.json").exists());
         assert_eq!(cache.get_image(url.to_string()).unwrap().0, image);
         assert_eq!(std::fs::read_dir(entry_path).unwrap().count(), 2);
+    }
+
+    #[test]
+    fn future_dated_manifests_miss_and_are_removed() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(directory.path().as_os_str().to_owned());
+        let url = "https://example.com/image.png";
+
+        cache.store_image(url, 60, mime::IMAGE_PNG, vec![1, 2, 3]);
+
+        let entry_path = directory.path().join(format!("{:x}", md5::compute(url)));
+        let manifest_path = entry_path.join("manifest.json");
+        let mut manifest = ImageCache::read_manifest(&manifest_path).unwrap();
+        manifest.created = u64::MAX;
+        std::fs::write(manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        assert!(cache.get_image(url.to_string()).is_none());
+        cache.clean(true);
+        assert!(!entry_path.exists());
     }
 }

--- a/src-core/src/image_cache/mod.rs
+++ b/src-core/src/image_cache/mod.rs
@@ -4,7 +4,7 @@ use crate::http::ResBody;
 use hyper::{body::Incoming, Request, Response};
 use log::{error, info};
 use mime::Mime;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 use std::{
     collections::HashMap,
@@ -30,6 +30,16 @@ pub struct ImageCache {
     cache_path_str: OsString,
 }
 
+#[derive(Deserialize, Serialize)]
+struct ImageCacheManifest {
+    url: String,
+    hash: String,
+    ttl: u64,
+    mime: String,
+    created: u64,
+    filename: String,
+}
+
 impl ImageCache {
     pub fn new(cache_path_str: OsString) -> ImageCache {
         ImageCache { cache_path_str }
@@ -44,78 +54,27 @@ impl ImageCache {
         if !storage_path.exists() || !manifest_path.exists() {
             return None;
         }
-        // Read json from manifest
-        let manifest = match std::fs::read_to_string(&manifest_path) {
-            Ok(manifest) => manifest,
-            Err(_) => {
-                error!(
-                    "[Core] Could not read JSON from manifest file. {}",
-                    manifest_path.display()
-                );
-                return None;
-            }
-        };
-        let manifest: serde_json::Value = serde_json::from_str(&manifest).unwrap();
-        // Get filename from manifest
-        let file_name = match manifest["filename"].as_str() {
-            Some(file_name) => file_name,
-            None => {
-                error!(
-                    "[Core] Could not get filename from manifest file. {}",
-                    manifest_path.display()
-                );
-                return None;
-            }
-        };
+        let manifest = Self::read_manifest(&manifest_path)?;
         // Get image path
-        let image_path = storage_path.join(file_name);
+        let image_path = storage_path.join(&manifest.filename);
         // If image doesn't exist, return None
         if !image_path.exists() {
             return None;
         }
         // Check if image is expired
-        let ttl = match manifest["ttl"].as_u64() {
-            Some(ttl) => ttl,
-            None => {
-                error!(
-                    "[Core] Could not get TTL from manifest file. {}",
-                    manifest_path.display()
-                );
-                return None;
-            }
-        };
-        let created = match manifest["created"].as_u64() {
-            Some(created) => created,
-            None => {
-                error!(
-                    "[Core] Could not get created timestamp from manifest file. {}",
-                    manifest_path.display()
-                );
-                return None;
-            }
-        };
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        if now - created > ttl {
+        if now - manifest.created > manifest.ttl {
             return None;
         }
         // Get mime type from manifest
-        let mime = match manifest["mime"].as_str() {
-            Some(mime) => match Mime::from_str(mime) {
-                Ok(mime) => mime,
-                Err(_) => {
-                    error!(
-                        "[Core] Could not parse MIME type from manifest file. {}",
-                        manifest_path.display()
-                    );
-                    return None;
-                }
-            },
-            None => {
+        let mime = match Mime::from_str(&manifest.mime) {
+            Ok(mime) => mime,
+            Err(_) => {
                 error!(
-                    "[Core] Could not get MIME type from manifest file. {}",
+                    "[Core] Could not parse MIME type from manifest file. {}",
                     manifest_path.display()
                 );
                 return None;
@@ -141,6 +100,7 @@ impl ImageCache {
         let url_hash = format!("{:x}", md5::compute(url));
         let storage_path = Path::new(&self.cache_path_str).join(&url_hash);
         let manifest_path = storage_path.join("manifest.json");
+        let temporary_manifest_path = storage_path.join("manifest.json.tmp");
         let file_ext = self.get_ext_for_mime(mime.clone());
         let file_name = format!("image.{file_ext}");
         let image_path = storage_path.join(&file_name);
@@ -153,15 +113,20 @@ impl ImageCache {
         // Store image
         std::fs::write(image_path, image_data).unwrap();
         // Store manifest
-        let manifest = json!({
-            "url": url,
-            "hash": url_hash,
-            "ttl": ttl,
-            "mime": mime.to_string(),
-            "created": chrono::Utc::now().timestamp(),
-            "filename": file_name,
-        });
-        std::fs::write(manifest_path, manifest.to_string()).unwrap();
+        let manifest = ImageCacheManifest {
+            url: url.to_string(),
+            hash: url_hash,
+            ttl,
+            mime: mime.to_string(),
+            created: chrono::Utc::now().timestamp() as u64,
+            filename: file_name,
+        };
+        std::fs::write(
+            &temporary_manifest_path,
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        std::fs::rename(temporary_manifest_path, manifest_path).unwrap();
     }
 
     pub fn clean(&self, only_expired: bool) {
@@ -180,47 +145,20 @@ impl ImageCache {
             if !path.is_dir() {
                 continue;
             }
-            // Read manifest
             let manifest_path = path.join("manifest.json");
-            let manifest = match std::fs::read_to_string(&manifest_path) {
-                Ok(manifest) => manifest,
-                Err(_) => {
-                    error!(
-                        "[Core] Could not read JSON from manifest file. {}",
-                        manifest_path.display()
-                    );
-                    // Delete path if manifest could not be read
+            let manifest = match Self::read_manifest(&manifest_path) {
+                Some(manifest) => manifest,
+                None => {
                     std::fs::remove_dir_all(&path).unwrap();
                     continue;
                 }
             };
-            let manifest: serde_json::Value = serde_json::from_str(&manifest).unwrap();
             // Check if image is expired
-            let ttl = match manifest["ttl"].as_u64() {
-                Some(ttl) => ttl,
-                None => {
-                    error!(
-                        "[Core] Could not get TTL from manifest file. {}",
-                        manifest_path.display()
-                    );
-                    continue;
-                }
-            };
-            let created = match manifest["created"].as_u64() {
-                Some(created) => created,
-                None => {
-                    error!(
-                        "[Core] Could not get created timestamp from manifest file. {}",
-                        manifest_path.display()
-                    );
-                    continue;
-                }
-            };
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_secs();
-            if only_expired && now - created < ttl {
+            if only_expired && now - manifest.created < manifest.ttl {
                 continue;
             }
             // Delete storage directory
@@ -237,6 +175,19 @@ impl ImageCache {
             Some(exts) => exts[0].to_string(),
             None => "bin".to_string(),
         }
+    }
+
+    fn read_manifest(manifest_path: &Path) -> Option<ImageCacheManifest> {
+        let result = std::fs::read(manifest_path)
+            .ok()
+            .and_then(|manifest| serde_json::from_slice(&manifest).ok());
+        if result.is_none() {
+            error!(
+                "[Core] Could not read image cache manifest. {}",
+                manifest_path.display()
+            );
+        }
+        result
     }
 
     pub async fn handle_request(
@@ -361,5 +312,43 @@ impl ImageCache {
             .status(200)
             .body(image_data.into())
             .unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn corrupted_manifests_are_removed_and_miss_on_read() {
+        for contents in [b"{".as_slice(), &[0xff, 0xfe], b"{}"] {
+            let directory = tempfile::tempdir().unwrap();
+            let cache_path = directory.path().join("image_cache");
+            let url = "https://example.com/image.png";
+            let entry_path = cache_path.join(format!("{:x}", md5::compute(url)));
+            std::fs::create_dir_all(&entry_path).unwrap();
+            std::fs::write(entry_path.join("manifest.json"), contents).unwrap();
+
+            let cache = ImageCache::new(cache_path.clone().into_os_string());
+            assert!(cache.get_image(url.to_string()).is_none());
+
+            init(directory.path().to_path_buf()).await;
+            assert!(!entry_path.exists());
+        }
+    }
+
+    #[test]
+    fn stored_manifest_is_published_and_readable() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(directory.path().as_os_str().to_owned());
+        let url = "https://example.com/image.png";
+        let image = vec![1, 2, 3];
+
+        cache.store_image(url, 60, mime::IMAGE_PNG, image.clone());
+
+        let entry_path = directory.path().join(format!("{:x}", md5::compute(url)));
+        assert!(entry_path.join("manifest.json").exists());
+        assert!(!entry_path.join("manifest.json.tmp").exists());
+        assert_eq!(cache.get_image(url.to_string()).unwrap().0, image);
     }
 }

--- a/src-core/src/image_cache/mod.rs
+++ b/src-core/src/image_cache/mod.rs
@@ -100,7 +100,6 @@ impl ImageCache {
         let url_hash = format!("{:x}", md5::compute(url));
         let storage_path = Path::new(&self.cache_path_str).join(&url_hash);
         let manifest_path = storage_path.join("manifest.json");
-        let temporary_manifest_path = storage_path.join("manifest.json.tmp");
         let file_ext = self.get_ext_for_mime(mime.clone());
         let file_name = format!("image.{file_ext}");
         let image_path = storage_path.join(&file_name);
@@ -121,12 +120,9 @@ impl ImageCache {
             created: chrono::Utc::now().timestamp() as u64,
             filename: file_name,
         };
-        std::fs::write(
-            &temporary_manifest_path,
-            serde_json::to_vec(&manifest).unwrap(),
-        )
-        .unwrap();
-        std::fs::rename(temporary_manifest_path, manifest_path).unwrap();
+        let mut temporary_manifest = tempfile::NamedTempFile::new_in(storage_path).unwrap();
+        serde_json::to_writer(&mut temporary_manifest, &manifest).unwrap();
+        temporary_manifest.persist(manifest_path).unwrap();
     }
 
     pub fn clean(&self, only_expired: bool) {
@@ -348,7 +344,7 @@ mod tests {
 
         let entry_path = directory.path().join(format!("{:x}", md5::compute(url)));
         assert!(entry_path.join("manifest.json").exists());
-        assert!(!entry_path.join("manifest.json.tmp").exists());
         assert_eq!(cache.get_image(url.to_string()).unwrap().0, image);
+        assert_eq!(std::fs::read_dir(entry_path).unwrap().count(), 2);
     }
 }

--- a/src-core/src/image_cache/mod.rs
+++ b/src-core/src/image_cache/mod.rs
@@ -5,7 +5,7 @@ use hyper::{body::Incoming, Request, Response};
 use log::{error, info};
 use mime::Mime;
 use serde::{Deserialize, Serialize};
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock, Mutex as SyncMutex};
 use std::{
     collections::HashMap,
     convert::Infallible,
@@ -28,6 +28,7 @@ pub async fn init(cache_dir: PathBuf) {
 #[derive(Debug, Clone)]
 pub struct ImageCache {
     cache_path_str: OsString,
+    write_lock: Arc<SyncMutex<()>>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -42,7 +43,10 @@ struct ImageCacheManifest {
 
 impl ImageCache {
     pub fn new(cache_path_str: OsString) -> ImageCache {
-        ImageCache { cache_path_str }
+        ImageCache {
+            cache_path_str,
+            write_lock: Default::default(),
+        }
     }
 
     fn get_image(&self, url: String) -> Option<(Vec<u8>, Mime)> {
@@ -96,6 +100,10 @@ impl ImageCache {
     }
 
     fn store_image(&self, url: &str, ttl: u64, mime: Mime, image_data: Vec<u8>) {
+        let _write_guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         // Determine paths
         let url_hash = format!("{:x}", md5::compute(url));
         let storage_path = Path::new(&self.cache_path_str).join(&url_hash);
@@ -126,6 +134,10 @@ impl ImageCache {
     }
 
     pub fn clean(&self, only_expired: bool) {
+        let _write_guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         // Create directory at cache_path if it doesn't exist
         let cache_path = Path::new(&self.cache_path_str);
         if !cache_path.exists() {
@@ -145,7 +157,7 @@ impl ImageCache {
             let manifest = match Self::read_manifest(&manifest_path) {
                 Some(manifest) => manifest,
                 None => {
-                    std::fs::remove_dir_all(&path).unwrap();
+                    Self::remove_entry(&path);
                     continue;
                 }
             };
@@ -162,8 +174,9 @@ impl ImageCache {
                 continue;
             }
             // Delete storage directory
-            std::fs::remove_dir_all(&path).unwrap();
-            deleted += 1;
+            if Self::remove_entry(&path) {
+                deleted += 1;
+            }
         }
         if deleted > 0 {
             info!("[Core] Deleted {deleted} image(s) from the cache.");
@@ -188,6 +201,17 @@ impl ImageCache {
             );
         }
         result
+    }
+
+    fn remove_entry(path: &Path) -> bool {
+        if let Err(error) = std::fs::remove_dir_all(path) {
+            error!(
+                "[Core] Could not delete image cache entry. {}: {error}",
+                path.display()
+            );
+            return false;
+        }
+        true
     }
 
     pub async fn handle_request(
@@ -367,6 +391,53 @@ mod tests {
         std::fs::write(manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
 
         assert!(cache.get_image(url.to_string()).is_none());
+        cache.clean(true);
+        assert!(!entry_path.exists());
+    }
+
+    #[test]
+    fn concurrent_writes_publish_a_readable_entry() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(directory.path().as_os_str().to_owned());
+        let url = "https://example.com/image.png";
+
+        std::thread::scope(|scope| {
+            for image in [vec![1, 2, 3], vec![4, 5, 6]] {
+                let cache = cache.clone();
+                scope.spawn(move || {
+                    for _ in 0..16 {
+                        cache.store_image(url, 60, mime::IMAGE_PNG, image.clone());
+                    }
+                });
+            }
+        });
+
+        let entry_path = directory.path().join(format!("{:x}", md5::compute(url)));
+        assert!(cache.get_image(url.to_string()).is_some());
+        assert_eq!(std::fs::read_dir(entry_path).unwrap().count(), 2);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cleanup_continues_when_a_corrupt_entry_is_locked() {
+        use std::os::windows::fs::OpenOptionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(directory.path().as_os_str().to_owned());
+        let entry_path = directory.path().join("entry");
+        let manifest_path = entry_path.join("manifest.json");
+        std::fs::create_dir_all(&entry_path).unwrap();
+        std::fs::write(&manifest_path, b"{").unwrap();
+        let locked_manifest = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(manifest_path)
+            .unwrap();
+
+        cache.clean(true);
+        assert!(entry_path.exists());
+
+        drop(locked_manifest);
         cache.clean(true);
         assert!(!entry_path.exists());
     }


### PR DESCRIPTION
Malformed readable image-cache manifests could panic startup cleanup and runtime cache reads. The cache now parses typed manifests through one fallible reader. Cleanup logs and removes corrupt entries. Reads return a cache miss.

Manifest writes now use a unique same-directory temporary file and atomically persist it as `manifest.json`. Readers cannot observe a partial manifest.

Cache writes and cleanup share one lock. Concurrent requests cannot delete another writer's temporary manifest, and cleanup logs deletion failures without stopping.

## Contract

- Startup handles truncated JSON, invalid UTF-8, and invalid manifest schemas without panicking.
- Future-dated manifests return a cache miss during reads and are removed during cleanup.
- Cleanup logs and removes unusable entries.
- Cleanup logs deletion failures and continues scanning.
- Corrupted reads return a cache miss.
- Manifest publication uses a temporary file and same-directory rename.
- Other image-cache behavior stays unchanged.

## Scope

- In scope: image-cache manifest reads, cleanup, publication, and regression tests.
- Follow-ups: none.
- Accepted growth: future-dated manifest recovery from OYASUMIVR-64.
- Scope drift: none.

## Verification

- `cargo +1.97.1 clippy --manifest-path src-core/Cargo.toml --tests -- -D warnings`
- `cargo +1.97.1 test --manifest-path src-core/Cargo.toml`, 56 passed.
- `rustfmt +1.97.1 --edition 2021 --check src-core/src/image_cache/mod.rs`
- `git diff HEAD^ HEAD --check`

The contract has no app UI path. Isolated backend tests cover startup cleanup, cache reads, and manifest publication with disposable directories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image cache reliability when reading and updating cache metadata.
  * Corrupted cache entries are now automatically removed during cleanup.
  * Cache metadata updates are published more safely to help prevent incomplete files.

* **Tests**
  * Added coverage for corrupted metadata and safe metadata publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Review verdict

- Round: 2
- Verdict: merge-ready
- Reviewed HEAD: `ed6eb801ec69fca23d6597fdf6b00d6e05ed4668`
- Reviewers: Codex, Claude, GLM
- Date: 2026-08-31
- Bot sweep: `ed6eb801ec69fca23d6597fdf6b00d6e05ed4668`
