### PR TITLE
fix(OYASUMIVR-27): match queued power-offs by serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed queued controller and tracker power-off requests targeting the wrong device when SteamVR
+  reused its device index
 - Fixed VRChat two-factor login and the restoration of saved sessions
 - Fixed player-count status automations not reacting when sleep mode changed
 - Fixed base stations being turned off when OyasumiVR was started while SteamVR was already running

--- a/src-overlay-ui/app/ipc/ipc.service.ts
+++ b/src-overlay-ui/app/ipc/ipc.service.ts
@@ -97,8 +97,11 @@ export class IpcService {
     await window.OyasumiIPCOut.sendEventVoid('startShutdownSequence');
   }
 
-  async turnOffOVRDevices(deviceIds: number[]): Promise<void> {
-    await window.OyasumiIPCOut.sendEventJson('turnOffOVRDevices', JSON.stringify(deviceIds));
+  async turnOffOVRDevices(deviceSerialNumbers: string[]): Promise<void> {
+    await window.OyasumiIPCOut.sendEventJson(
+      'turnOffOVRDevices',
+      JSON.stringify(deviceSerialNumbers)
+    );
   }
 
   async setBrightness(type: BrightnessType, value: number): Promise<void> {

--- a/src-overlay-ui/app/overlays/dashboard/device-control/device-control.ts
+++ b/src-overlay-ui/app/overlays/dashboard/device-control/device-control.ts
@@ -30,10 +30,14 @@ export class DeviceControl implements OnDestroy {
 
   private readonly state = this.ipc.state;
   private readonly activeControllers = computed(() =>
-    (this.state().deviceInfo?.controllers ?? []).filter((d) => d.canPowerOff && !d.isTurningOff)
+    (this.state().deviceInfo?.controllers ?? []).filter(
+      (d) => d.serialNumber && d.canPowerOff && !d.isTurningOff
+    )
   );
   private readonly activeTrackers = computed(() =>
-    (this.state().deviceInfo?.trackers ?? []).filter((d) => d.canPowerOff && !d.isTurningOff)
+    (this.state().deviceInfo?.trackers ?? []).filter(
+      (d) => d.serialNumber && d.canPowerOff && !d.isTurningOff
+    )
   );
 
   private readonly controllersReady = signal(true);
@@ -60,7 +64,7 @@ export class DeviceControl implements OnDestroy {
     if (!this.canTurnOffControllers()) return;
     this.startCooldown(this.controllersReady);
     this.notify('notifications.turningOffControllers.content');
-    this.turnOff(this.controllerIndices());
+    this.turnOff(this.controllerSerialNumbers());
     this.delay(500, () => this.closeDashboard.emit());
   }
 
@@ -68,27 +72,31 @@ export class DeviceControl implements OnDestroy {
     if (!this.canTurnOffTrackers()) return;
     this.startCooldown(this.trackersReady);
     this.notify('notifications.turningOffTrackers.content');
-    this.turnOff(this.trackerIndices());
+    this.turnOff(this.trackerSerialNumbers());
   }
 
   turnOffControllersAndTrackers(): void {
     if (!this.canTurnOffBoth()) return;
     this.startCooldown(this.bothReady);
     this.notify('notifications.turningOffControllersAndTrackers.content');
-    this.turnOff([...this.trackerIndices(), ...this.controllerIndices()]);
+    this.turnOff([...this.trackerSerialNumbers(), ...this.controllerSerialNumbers()]);
     this.delay(500, () => this.closeDashboard.emit());
   }
 
-  private controllerIndices(): number[] {
-    return (this.state().deviceInfo?.controllers ?? []).map((d) => d.index);
+  private controllerSerialNumbers(): string[] {
+    return (this.state().deviceInfo?.controllers ?? [])
+      .map((device) => device.serialNumber)
+      .filter((serialNumber): serialNumber is string => !!serialNumber);
   }
 
-  private trackerIndices(): number[] {
-    return (this.state().deviceInfo?.trackers ?? []).map((d) => d.index);
+  private trackerSerialNumbers(): string[] {
+    return (this.state().deviceInfo?.trackers ?? [])
+      .map((device) => device.serialNumber)
+      .filter((serialNumber): serialNumber is string => !!serialNumber);
   }
 
-  private turnOff(deviceIds: number[]): void {
-    void this.ipc.turnOffOVRDevices(deviceIds);
+  private turnOff(deviceSerialNumbers: string[]): void {
+    void this.ipc.turnOffOVRDevices(deviceSerialNumbers);
   }
 
   private notify(key: string): void {

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -36,14 +36,14 @@ export class LighthouseConsoleService {
         }
       });
     await listen<string>('turnOffOVRDevices', async (event) => {
-      let deviceIndices: number[];
+      let deviceSerialNumbers: Set<string>;
       try {
-        deviceIndices = JSON.parse(event.payload);
+        deviceSerialNumbers = new Set(JSON.parse(event.payload));
       } catch {
         return;
       }
       const devices = (await firstValueFrom(this.openvr.devices)).filter((d) =>
-        deviceIndices.includes(d.index)
+        d.serialNumber ? deviceSerialNumbers.has(d.serialNumber) : false
       );
       await this.turnOffDevices(devices);
     });

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -102,10 +102,13 @@ export class LighthouseConsoleService {
     const lighthouseConsolePath = settings.lighthouseConsolePath;
     if (this._consoleStatus.value !== 'SUCCESS') return;
     // resolve the devices as they are now, not as the caller saw them
-    const requestedIndices = requestedDevices.map((device) => device.index);
+    const requestedSerials = new Set(
+      requestedDevices.map((device) => device.serialNumber).filter(Boolean)
+    );
     const ovrDevices = (await firstValueFrom(this.openvr.devices)).filter(
       (device) =>
-        requestedIndices.includes(device.index) &&
+        device.serialNumber &&
+        requestedSerials.has(device.serialNumber) &&
         device.canPowerOff &&
         device.dongleId &&
         !device.isTurningOff

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -36,16 +36,21 @@ export class LighthouseConsoleService {
         }
       });
     await listen<string>('turnOffOVRDevices', async (event) => {
-      let deviceSerialNumbers: Set<string>;
+      let deviceSerialNumbers: unknown;
       try {
-        deviceSerialNumbers = new Set(JSON.parse(event.payload));
+        deviceSerialNumbers = JSON.parse(event.payload);
       } catch {
         return;
       }
-      const devices = (await firstValueFrom(this.openvr.devices)).filter((d) =>
-        d.serialNumber ? deviceSerialNumbers.has(d.serialNumber) : false
-      );
-      await this.turnOffDevices(devices);
+      if (
+        !Array.isArray(deviceSerialNumbers) ||
+        !deviceSerialNumbers.every(
+          (serialNumber): serialNumber is string =>
+            typeof serialNumber === 'string' && serialNumber.length > 0
+        )
+      )
+        return;
+      await this.queuePowerOff(deviceSerialNumbers);
     });
   }
 
@@ -92,19 +97,25 @@ export class LighthouseConsoleService {
   }
 
   async turnOffDevices(ovrDevices: OVRDevice[]) {
-    const batch = this.powerOffQueue.then(() => this.runTurnOffDevices(ovrDevices));
+    return this.queuePowerOff(
+      ovrDevices
+        .map((device) => device.serialNumber)
+        .filter((serialNumber): serialNumber is string => !!serialNumber)
+    );
+  }
+
+  private queuePowerOff(deviceSerialNumbers: string[]) {
+    const batch = this.powerOffQueue.then(() => this.runTurnOffDevices(deviceSerialNumbers));
     this.powerOffQueue = batch.catch(() => {});
     return batch;
   }
 
-  private async runTurnOffDevices(requestedDevices: OVRDevice[]) {
+  private async runTurnOffDevices(deviceSerialNumbers: string[]) {
     const settings = await firstValueFrom(this.appSettings.settings);
     const lighthouseConsolePath = settings.lighthouseConsolePath;
     if (this._consoleStatus.value !== 'SUCCESS') return;
     // resolve the devices as they are now, not as the caller saw them
-    const requestedSerials = new Set(
-      requestedDevices.map((device) => device.serialNumber).filter(Boolean)
-    );
+    const requestedSerials = new Set(deviceSerialNumbers);
     const ovrDevices = (await firstValueFrom(this.openvr.devices)).filter(
       (device) =>
         device.serialNumber &&

--- a/src-ui/app/services/shutdown-automations.service.ts
+++ b/src-ui/app/services/shutdown-automations.service.ts
@@ -331,7 +331,11 @@ export class ShutdownAutomationsService {
             switchMap(() =>
               this.openvr.devices.pipe(
                 map((newDevices) =>
-                  newDevices.filter((d) => devices.some((d2) => d2.index === d.index))
+                  newDevices.filter(
+                    (device) =>
+                      device.serialNumber &&
+                      devices.some((requested) => requested.serialNumber === device.serialNumber)
+                  )
                 )
               )
             ),


### PR DESCRIPTION
A queued lighthouse power-off could target the wrong device when OpenVR reused an index. The request now keeps the selected device's serial identity from the overlay through queue execution and shutdown tracking.

The overlay sends serial numbers through IPC. The main UI validates the complete payload, queues the serials directly, and resolves live devices only when execution begins. Missing devices are skipped, while a selected device that reconnects at a new index remains eligible.

## Contract

- Keep each asynchronous power-off bound to the selected physical device.
- Power off nothing when the selected device disappears, even if another device takes its index.
- Power off the selected device when it remains present or reconnects at a new index.
- Preserve duplicate suppression, continuation after a failed command, and overlay controls.
- Leave OpenVR input identity and unused cache refresh code unchanged.

## Scope audit

- Original intent: prevent a queued power-off from targeting a different physical device.
- Current scope: preserve serial identity through overlay IPC, queue execution, and shutdown tracking.
- Accepted growth: the overlay and shutdown wait still used indices, which could discard or misidentify the selected device.
- Follow-ups: none.
- Revert or split: none.

## Verification

Code reviewed at `ae5e77723ef79d576269f0ebeed20db950c5ce19`. The changelog follow-up was added at `5b58bfe6e737c2b3feada8c31f325fc709d1c418`. The branch was refreshed from `develop` and verified at `059c50d6291d2af4e7e44eaf2e76fbb0f8493740`.

- An ephemeral source-bound harness passed malformed payload rejection, index reuse, reconnect at a new index, combined targets, duplicate suppression, continuation after failure, and shutdown tracking.
- `npm ci` passed with no vulnerabilities.
- `npm test` passed, 47 Node tests and 6 UI tests.
- `npm run lint` passed.
- `npx tsc -p tsconfig.app.json --noEmit` passed.
- `npx tsc -p tsconfig.overlay.json --noEmit` passed.
- `npx ng build oyasumivr --configuration development` passed.
- `npx ng build overlay-ui --configuration development` passed.
- Targeted Prettier and `git diff --check` passed.

Physical OpenVR index reuse was not tested because it could power off the wrong device. The ticket requires the isolated harness instead.

T3 thread: `01a054d1-fd58-71a2-9e61-6ea5490f08b0`.

## Review verdict

- Round: 2
- Verdict: merge-ready
- Reviewed code HEAD: `ae5e77723ef79d576269f0ebeed20db950c5ce19`
- PR HEAD: `059c50d6291d2af4e7e44eaf2e76fbb0f8493740`
- Reviewers: Codex, Claude, GLM
- Date: 2026-08-31
- Bot sweep: `059c50d6291d2af4e7e44eaf2e76fbb0f8493740`
- Findings: three round-one blockers were fixed and verified. Round two found no blockers.
- Follow-up: the post-review commits add `CHANGELOG.md` and merge current `develop`. The only conflict was the changelog list.
