### PR TITLE
fix(OYASUMIVR-18): cancel stale sleep checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   stopping after VRChat had been running for more than 24 hours
 - Fixed VRChat two-factor login and the restoration of saved sessions
 - Fixed player-count status automations not reacting when sleep mode changed
+- Fixed the sleep detector turning sleep mode back on after its confirmation countdown was canceled by
+  disabling the automation or changing sleep mode manually
 - Fixed base stations being turned off when OyasumiVR was started while SteamVR was already running
 - Fixed base station control leaking memory in the Windows Bluetooth service, which could use up all
   of the system's memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,8 @@
         "recursive-copy": "^2.0.14",
         "rimraf": "^6.1.3",
         "sharp": "^0.35.3",
-        "typescript": "~6.0.3"
+        "typescript": "~6.0.3",
+        "vitest": "^4.0.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5503,6 +5504,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -5857,6 +5876,146 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -6269,6 +6428,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -6638,6 +6807,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7946,6 +8125,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8012,6 +8201,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -11429,6 +11628,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12560,6 +12766,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12724,6 +12937,13 @@
       "resolved": "src-shared-ts",
       "link": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -12733,6 +12953,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",
@@ -12985,6 +13212,23 @@
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -13000,6 +13244,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -13797,6 +14051,106 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/vrchat": {
       "version": "2.22.8",
       "resolved": "https://registry.npmjs.org/vrchat/-/vrchat-2.22.8.tgz",
@@ -14017,6 +14371,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/win-guid": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "format:eslint": "eslint --no-error-on-unmatched-pattern --fix \"src-ui/**/*.ts\" \"src-overlay-ui/**/*.ts\" \"src-shared-ts/**/*.ts\" \"scripts/**/*.ts\"",
     "format:prettier": "prettier --write \"src-ui/**/*.{html,css,scss,js,ts}\" \"src-overlay-ui/**/*.{html,css,scss,js,ts}\" \"src-shared-ts/**/*.{html,css,scss,js,ts}\" \"scripts/**/*.{html,css,scss,js,ts}\"",
     "lint": "ng lint",
-    "test": "node --experimental-strip-types --test \"src-shared-ts/src/*.test.ts\" \"scripts/*.test.ts\" \"src-ui/app/utils/*.test.ts\"",
+    "test": "run-s test:node test:ui",
+    "test:node": "node --experimental-strip-types --test \"src-shared-ts/src/*.test.ts\" \"scripts/*.test.ts\" \"src-ui/app/utils/*.test.ts\"",
+    "test:ui": "vitest run src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts",
     "clean": "rimraf dist && rimraf src-overlay-sidecar/bin && rimraf src-overlay-sidecar/obj && rimraf src-overlay-ui/build && rimraf src-elevated-sidecar/target && rimraf src-privileged-launcher/target && rimraf tools/sign-elevated-sidecar/target && rimraf src-core/target && rimraf src-shared-rust/target && rimraf src-core/resources/elevated-sidecar && rimraf src-core/resources/privileged-launcher && rimraf src-core/resources/overlay-sidecar && rimraf src-core/resources/fonts",
     "tl": "node scripts/translation-utils.js",
     "tl:check-icu": "node scripts/check-icu.mjs",
@@ -159,7 +161,8 @@
     "recursive-copy": "^2.0.14",
     "rimraf": "^6.1.3",
     "sharp": "^0.35.3",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^4.0.8"
   },
   "overrides": {
     "axios": "^1.7.8"

--- a/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts
+++ b/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts
@@ -1,0 +1,206 @@
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TranslocoService } from '@jsverse/transloco';
+import type { AutomationConfigService } from '../automation-config.service';
+import type { EventLogService } from '../event-log.service';
+import type { NotificationService } from '../notification.service';
+import type { OpenVRInputService } from '../openvr-input.service';
+import type { SleepService } from '../sleep.service';
+import type { TelemetryService } from '../telemetry.service';
+import { AUTOMATION_CONFIGS_DEFAULT, type AutomationConfigs } from '../../models/automations';
+import type { SleepDetectorStateReport } from '../../models/events';
+import { OVRInputEventAction } from '../../models/ovr-input-event';
+import type { SleepModeStatusChangeReason } from '../../models/sleep-mode';
+import type { SleepingPose } from '../../models/sleeping-pose';
+import {
+  type SleepDetectorStateReportHandlingResult,
+  SleepModeForSleepDetectorAutomationService,
+} from './sleep-mode-for-sleep-detector-automation.service';
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+const report: SleepDetectorStateReport = {
+  distanceInLast15Minutes: 0,
+  distanceInLast10Minutes: 0,
+  distanceInLast5Minutes: 0,
+  distanceInLast1Minute: 0,
+  distanceInLast10Seconds: 0,
+  rotationInLast15Minutes: 0,
+  rotationInLast10Minutes: 0,
+  rotationInLast5Minutes: 0,
+  rotationInLast1Minute: 0,
+  rotationInLast10Seconds: 0,
+  startTime: 0,
+  lastLog: 0,
+};
+
+function enabledConfigs(): AutomationConfigs {
+  const configs = structuredClone(AUTOMATION_CONFIGS_DEFAULT);
+  Object.assign(configs.SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR, {
+    enabled: true,
+    sleepCheck: true,
+    detectionWindowMinutes: 0,
+    considerControllerPresence: false,
+    considerSleepingPose: false,
+  });
+  return configs;
+}
+
+function createService() {
+  const configs = new BehaviorSubject(enabledConfigs());
+  const sleepMode = new BehaviorSubject(false);
+  const pose = new BehaviorSubject<SleepingPose>('UNKNOWN');
+  const inputState = new BehaviorSubject({
+    [OVRInputEventAction.OpenOverlay]: [],
+    [OVRInputEventAction.MuteMicrophone]: [],
+    [OVRInputEventAction.IndicatePresence]: [],
+    [OVRInputEventAction.OverlayInteract]: [],
+  });
+  const sleep = {
+    mode: sleepMode.asObservable(),
+    pose: pose.asObservable(),
+    enableSleepMode: vi.fn(async (reason: SleepModeStatusChangeReason) => {
+      if (!sleepMode.value) sleepMode.next(true);
+      return reason;
+    }),
+    disableSleepMode: vi.fn(async () => {
+      if (sleepMode.value) sleepMode.next(false);
+    }),
+  };
+  const notifications = {
+    send: vi.fn(async () => 'sleep-check-notification'),
+    clearNotification: vi.fn(async () => {}),
+    playSound: vi.fn(async () => {}),
+  };
+  const eventLog = { logEvent: vi.fn() };
+  const service = new SleepModeForSleepDetectorAutomationService(
+    { configs: configs.asObservable() } as AutomationConfigService,
+    sleep as unknown as SleepService,
+    notifications as unknown as NotificationService,
+    { translate: vi.fn((key: string) => key) } as unknown as TranslocoService,
+    eventLog as unknown as EventLogService,
+    { state: inputState.asObservable() } as OpenVRInputService,
+    { trackEvent: vi.fn(async () => {}) } as unknown as TelemetryService
+  );
+  const results: SleepDetectorStateReportHandlingResult[] = [];
+  service.lastStateReportHandlingResult.subscribe((result) => {
+    if (result) results.push(result);
+  });
+
+  return { configs, eventLog, notifications, results, service, sleep };
+}
+
+async function armSleepCheck(service: SleepModeForSleepDetectorAutomationService) {
+  expect(await service.handleStateReportForEnable(report)).toBe('SLEEP_CHECK');
+}
+
+function automationEnableCalls(sleep: ReturnType<typeof createService>['sleep']) {
+  return sleep.enableSleepMode.mock.calls.filter(([reason]) => reason.type === 'AUTOMATION');
+}
+
+describe('SleepModeForSleepDetectorAutomationService sleep check', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('cancels when the automation is disabled during the countdown', async () => {
+    const { configs, notifications, results, service, sleep } = createService();
+    await service.init();
+    await armSleepCheck(service);
+
+    const disabled = structuredClone(configs.value);
+    disabled.SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR.enabled = false;
+    configs.next(disabled);
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(automationEnableCalls(sleep)).toHaveLength(0);
+    expect(results).toEqual([]);
+    expect(notifications.clearNotification).toHaveBeenCalledWith('sleep-check-notification');
+  });
+
+  it('cancels after manual enable followed by disable', async () => {
+    const { results, service, sleep } = createService();
+    await service.init();
+    await armSleepCheck(service);
+
+    await sleep.enableSleepMode({ type: 'MANUAL' });
+    await sleep.disableSleepMode();
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(automationEnableCalls(sleep)).toHaveLength(0);
+    expect(results).toEqual([]);
+  });
+
+  it('enables sleep mode when eligibility stays unchanged', async () => {
+    const { results, service, sleep } = createService();
+    await service.init();
+    await armSleepCheck(service);
+
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(automationEnableCalls(sleep)).toHaveLength(1);
+    expect(results).toEqual(['SLEEP_CHECK_USER_ASLEEP', 'SLEEP_MODE_ENABLED']);
+  });
+
+  it('preserves gesture cancellation behavior', async () => {
+    const { eventLog, notifications, results, service, sleep } = createService();
+    await service.init();
+    await armSleepCheck(service);
+
+    await service.dismissSleepCheck();
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(automationEnableCalls(sleep)).toHaveLength(0);
+    expect(results).toEqual(['SLEEP_CHECK_USER_AWAKE']);
+    expect(eventLog.logEvent).toHaveBeenCalledWith({
+      type: 'sleepDetectorEnableCancelled',
+    });
+    expect(notifications.playSound).toHaveBeenCalledOnce();
+    expect(notifications.clearNotification).toHaveBeenCalledWith('sleep-check-notification');
+  });
+
+  it('does not publish success after duplicate manual enable', async () => {
+    const { results, service, sleep } = createService();
+    await service.init();
+    await armSleepCheck(service);
+
+    await sleep.enableSleepMode({ type: 'MANUAL' });
+    await sleep.enableSleepMode({ type: 'MANUAL' });
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(automationEnableCalls(sleep)).toHaveLength(0);
+    expect(results).toEqual([]);
+  });
+
+  it('does not arm after cancellation during notification delivery', async () => {
+    const { configs, notifications, results, service, sleep } = createService();
+    let deliverNotification: (id: string) => void = () => {};
+    notifications.send.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          deliverNotification = resolve;
+        })
+    );
+    await service.init();
+
+    const handling = service.handleStateReportForEnable(report);
+    await Promise.resolve();
+    const disabled = structuredClone(configs.value);
+    disabled.SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR.enabled = false;
+    configs.next(disabled);
+    deliverNotification('late-notification');
+
+    expect(await handling).toBe('SLEEP_CHECK');
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(automationEnableCalls(sleep)).toHaveLength(0);
+    expect(results).toEqual([]);
+    expect(notifications.clearNotification).toHaveBeenCalledWith('late-notification');
+  });
+});

--- a/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
+++ b/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
@@ -24,7 +24,7 @@ import { OpenVRInputService } from '../openvr-input.service';
 import { OVRInputEventAction } from '../../models/ovr-input-event';
 import { SleepingPose } from '../../models/sleeping-pose';
 import { TelemetryService } from '../telemetry.service';
-import { getBuiltInNotificationSound } from 'src-ui/app/models/notification-sounds';
+import { getBuiltInNotificationSound } from '../../models/notification-sounds';
 
 export type SleepDetectorStateReportHandlingResult =
   | 'AUTOMATION_DISABLED'
@@ -47,6 +47,7 @@ export type SleepDetectorStateReportHandlingResult =
 })
 export class SleepModeForSleepDetectorAutomationService {
   private sleepEnableTimeoutId: number | null = null;
+  private sleepCheckGeneration = 0;
   private lastEnableAttempt = 0;
   private lastSleepModeDisable = 0;
   private lastControllerButtonPresenceIndication = 0;
@@ -85,11 +86,14 @@ export class SleepModeForSleepDetectorAutomationService {
   ) {}
 
   async init() {
-    this.automationConfig.configs.subscribe(
-      (configs) => (this.enableConfig = configs.SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR)
-    );
-    this.sleep.mode.pipe(distinctUntilChanged(), skip(1)).subscribe((mode) => {
+    this.automationConfig.configs.subscribe(async (configs) => {
+      const wasEnabled = this.enableConfig.enabled;
+      this.enableConfig = configs.SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR;
+      if (wasEnabled && !this.enableConfig.enabled) await this.invalidateSleepCheck();
+    });
+    this.sleep.mode.pipe(distinctUntilChanged(), skip(1)).subscribe(async (mode) => {
       if (!mode) this.lastSleepModeDisable = Date.now();
+      await this.invalidateSleepCheck();
     });
     this.sleep.pose.pipe(pairwise()).subscribe(([previous, current]) => {
       this.lastPose = current;
@@ -128,9 +132,7 @@ export class SleepModeForSleepDetectorAutomationService {
   }
 
   async dismissSleepCheck() {
-    if (this.sleepEnableTimeoutId) {
-      clearTimeout(this.sleepEnableTimeoutId);
-      this.sleepEnableTimeoutId = null;
+    if (this.cancelSleepCheck()) {
       this.eventLog.logEvent({
         type: 'sleepDetectorEnableCancelled',
       });
@@ -140,11 +142,29 @@ export class SleepModeForSleepDetectorAutomationService {
       await this.notifications.send(
         this.translate.translate('notifications.sleepCheckCancel.content')
       );
-      if (this.sleepCheckNotificationId) {
-        await this.notifications.clearNotification(this.sleepCheckNotificationId);
-        this.sleepCheckNotificationId = null;
-      }
+      await this.clearSleepCheckNotification();
     }
+  }
+
+  private async invalidateSleepCheck() {
+    this.cancelSleepCheck();
+    await this.clearSleepCheckNotification();
+  }
+
+  private cancelSleepCheck(): boolean {
+    this.sleepCheckGeneration++;
+    if (this.sleepEnableTimeoutId === null) return false;
+
+    clearTimeout(this.sleepEnableTimeoutId);
+    this.sleepEnableTimeoutId = null;
+    return true;
+  }
+
+  private async clearSleepCheckNotification() {
+    if (!this.sleepCheckNotificationId) return;
+    const notificationId = this.sleepCheckNotificationId;
+    this.sleepCheckNotificationId = null;
+    await this.notifications.clearNotification(notificationId);
   }
 
   async handleStateReportForEnable(
@@ -197,13 +217,23 @@ export class SleepModeForSleepDetectorAutomationService {
     this.lastEnableAttempt = Date.now();
     // If necessary, first check if the user is asleep, allowing them to cancel.
     if (this.enableConfig.sleepCheck) {
-      this.sleepCheckNotificationId = await this.notifications.send(
+      const sleepCheckGeneration = this.sleepCheckGeneration;
+      const notificationId = await this.notifications.send(
         this.translate.translate('notifications.sleepCheck.content'),
         8000
       );
-      if (this.sleepEnableTimeoutId) return 'SLEEP_CHECK_ALREADY_IN_PROGRESS';
+      if (this.sleepEnableTimeoutId !== null) {
+        if (notificationId) await this.notifications.clearNotification(notificationId);
+        return 'SLEEP_CHECK_ALREADY_IN_PROGRESS';
+      }
+      if (sleepCheckGeneration !== this.sleepCheckGeneration) {
+        if (notificationId) await this.notifications.clearNotification(notificationId);
+        return 'SLEEP_CHECK';
+      }
+      this.sleepCheckNotificationId = notificationId;
       this.sleepEnableTimeoutId = setTimeout(async () => {
         this.sleepEnableTimeoutId = null;
+        if (sleepCheckGeneration !== this.sleepCheckGeneration) return;
         this._lastStateReportHandlingResult.next('SLEEP_CHECK_USER_ASLEEP');
         await this.sleep.enableSleepMode({
           type: 'AUTOMATION',


### PR DESCRIPTION
A pending sleep-detector confirmation could survive an automation disable or a manual sleep-mode change. Its old countdown could then enable sleep mode after the user had canceled it.

This change invalidates pending confirmations when the automation is disabled or sleep mode changes. A generation check also stops delayed notification delivery from arming a canceled countdown. Gesture cancellation keeps its existing event log, state, sound, and notification cleanup behavior.

The regression tests cover automation disable during the countdown, manual enable followed by disable, unchanged eligibility, gesture cancellation, duplicate manual enable, and cancellation during notification delivery.

Verification:
- `npm test`, 53 tests passed
- `npm run lint`
- `npx ng build oyasumivr --configuration development`
- `git diff --check origin/develop...HEAD`

The desktop app has no safe way to inject a sleep-detector report, so I did not exercise the countdown in a live VR session. The fake-timer service tests cover the reported timer and notification races.