### PR TITLE
fix(core): prefer actively-written VRChat log over most recently created (#275)

### DIFF
--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -40,14 +40,6 @@ fn get_latest_log_path(attached: Option<&str>) -> Option<String> {
     pick_log_path(&dir, attached, SystemTime::now())
 }
 
-/// Pick the VRChat log file OyasumiVR should follow right now.
-///
-/// Eligible files are non-empty `output_log_*.txt` entries in `dir` whose
-/// last-write time is within the last 24 hours, OR the file currently
-/// passed as `attached` (which bypasses the age check so a live watcher
-/// does not drop its file once it crosses the 24h mark mid-session).
-/// Among the eligible set, the file with the newest last-write time wins.
-/// `now` is injected so tests can drive the age filter deterministically.
 fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<String> {
     read_dir(dir)
         .ok()?
@@ -64,15 +56,10 @@ fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<
             path.metadata()
                 .ok()
                 .and_then(|metadata| {
-                    metadata.modified().ok().and_then(|modified_time| {
-                        // A negative duration means `modified_time > now`: the file was
-                        // written in the tiny window between `now` being sampled and its
-                        // metadata being read. Treat that as "fresh, include" rather than
-                        // dropping the actively-written log due to the scan race.
-                        now.duration_since(modified_time)
-                            .ok()
-                            .map(|duration| duration <= Duration::from_secs(24 * 60 * 60))
-                            .or(Some(true))
+                    metadata.modified().ok().map(|modified_time| {
+                        now.duration_since(modified_time).map_or(true, |duration| {
+                            duration <= Duration::from_secs(24 * 60 * 60)
+                        })
                     })
                 })
                 .unwrap_or(false)
@@ -85,10 +72,6 @@ fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<
                 .map(|metadata| metadata.len() > 0)
                 .unwrap_or(false)
         })
-        // Find the log file currently being written to. Preferring last-write-time over
-        // creation-time ensures we follow the running VRChat instance even after a previously
-        // launched client has been closed — VRChat does not delete its log file on exit, so
-        // the newest by creation-time would otherwise be a stale log of a closed instance.
         .max_by_key(|entry| entry.path().metadata().ok().map(|m| m.last_write_time()))
         .and_then(|entry| entry.path().to_str().map(String::from))
 }
@@ -339,9 +322,6 @@ mod tests {
         (path.to_str().unwrap().to_owned(), created)
     }
 
-    /// `pick_log_path` should respect the 24-hour age window, allow the
-    /// currently-attached file to bypass it, ignore zero-byte files, and
-    /// prefer a newer file over the attached one when both exist.
     #[test]
     fn picks_logs_by_age_attachment_and_size() {
         let dir = tempdir().unwrap();
@@ -403,34 +383,19 @@ mod tests {
         );
     }
 
-    /// Regression for issue #275: when more than one VRChat instance has been run on
-    /// the same machine, VRChat leaves the closed instance's log file on disk. Selecting
-    /// by creation-time caused OyasumiVR to latch onto the newest-by-creation log, which
-    /// could be the closed instance's log instead of the running one. We must select by
-    /// last-write-time instead, so the actively-written log of the running instance wins.
     #[test]
     fn prefers_actively_written_log_over_newer_but_stale_log() {
-        // Regression test for issue #275: when more than one VRChat instance has been run on
-        // the same machine, VRChat leaves the closed instance's log file on disk. Selecting
-        // by creation-time caused OyasumiVR to latch onto the newest-by-creation log, which
-        // could be the closed instance's log instead of the running one. We must select by
-        // last-write-time instead, so the actively-written log of the running instance wins.
         let dir = tempdir().unwrap();
         let (active, active_created) = create_log(dir.path(), "output_log_active.txt", b"hi");
 
         thread::sleep(Duration::from_millis(20));
         let (_newer, newer_created) = create_log(dir.path(), "output_log_newer.txt", b"hi");
 
-        // Touch the older file so its last-write-time is now strictly newer than the newer
-        // file's creation- and last-write-time, mimicking the running instance appending to
-        // its log after a previous instance's log has been left on disk.
         thread::sleep(Duration::from_millis(20));
         let active_path = dir.path().join("output_log_active.txt");
         fs::write(&active_path, b"hi\nmore").unwrap();
         let active_modified = active_path.metadata().unwrap().modified().unwrap();
 
-        // Sanity check: the older file's creation-time is earlier than the newer file's,
-        // and the older file's last-write-time is later than the newer file's last-write-time.
         assert!(active_created < newer_created);
         assert!(active_modified > newer_created);
 
@@ -444,53 +409,31 @@ mod tests {
         );
     }
 
-    /// Regression for the 24-hour age filter: a VRChat session that has been
-    /// running for more than 24 hours creates a log whose `created()` timestamp
-    /// is well outside the 24-hour window, but it is still being appended to and
-    /// must remain a candidate. The age filter is keyed on `modified()` so this
-    /// file is selected even when its creation time is older than the cutoff.
     #[test]
     fn keeps_log_eligible_while_actively_written_past_24_hours() {
         let dir = tempdir().unwrap();
         let (path, created) = create_log(dir.path(), "output_log_long_running.txt", b"hi");
         let created_path = dir.path().join("output_log_long_running.txt");
 
-        // Backdate the file's last-write time to 23h after creation. The file's
-        // creation time is "now" (just created in this test), but we want to
-        // simulate "this log file is from an instance that has been running for
-        // 23h" so the 24h age filter is exercised on modified-time, not
-        // creation-time. `File::set_modified` is stable cross-platform since 1.75.
         let modified_at = created + Duration::from_secs(23 * 3600);
         let file = fs::OpenOptions::new().write(true).open(&created_path).unwrap();
         file.set_modified(modified_at).unwrap();
         drop(file);
 
-        // Sanity: modified-time is backdated by 23h, so it is within the 24h
-        // window from `now`, but creation-time is `now`, which is >24h old.
         let observed_modified = created_path.metadata().unwrap().modified().unwrap();
         assert_eq!(observed_modified, modified_at);
 
-        // `now` is set 24h + 30s after the file was actually created — past
-        // the 24h window for creation-time but well within the 24h window for
-        // the backdated modified-time.
         let now = created + Duration::from_secs(24 * 3600 + 30);
 
         assert_eq!(pick_log_path(dir.path(), None, now), Some(path));
     }
 
-    /// Regression for the scan race: `pick_log_path` samples `now` once at the top
-    /// of the call and reads file metadata per candidate afterwards. A file written
-    /// in the gap between those two reads has `mtime > now`, which makes
-    /// `now.duration_since(mtime)` return Err. The age filter must treat that as
-    /// "freshly written, include" rather than dropping the actively-written log.
     #[test]
     fn includes_log_modified_in_tiny_window_after_now_sampling() {
         let dir = tempdir().unwrap();
         let (path, _) = create_log(dir.path(), "output_log_live.txt", b"hi");
         let live_path = dir.path().join("output_log_live.txt");
 
-        // Pretend `now` is the moment the caller started scanning, and the file's
-        // last write happened 1 ms *after* `now` — the file is fresh.
         let now = SystemTime::now();
         let file = fs::OpenOptions::new().write(true).open(&live_path).unwrap();
         file.set_modified(now + Duration::from_millis(1)).unwrap();

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -72,7 +72,11 @@ fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<
                 .map(|metadata| metadata.len() > 0)
                 .unwrap_or(false)
         })
-        .max_by_key(|entry| entry.path().metadata().ok().map(|m| m.creation_time()))
+        // Find the log file currently being written to. Preferring last-write-time over
+        // creation-time ensures we follow the running VRChat instance even after a previously
+        // launched client has been closed — VRChat does not delete its log file on exit, so
+        // the newest by creation-time would otherwise be a stale log of a closed instance.
+        .max_by_key(|entry| entry.path().metadata().ok().map(|m| m.last_write_time()))
         .and_then(|entry| entry.path().to_str().map(String::from))
 }
 
@@ -380,6 +384,42 @@ mod tests {
                 empty_created + Duration::from_secs(1),
             ),
             None
+        );
+    }
+
+    #[test]
+    fn prefers_actively_written_log_over_newer_but_stale_log() {
+        // Regression test for issue #275: when more than one VRChat instance has been run on
+        // the same machine, VRChat leaves the closed instance's log file on disk. Selecting
+        // by creation-time caused OyasumiVR to latch onto the newest-by-creation log, which
+        // could be the closed instance's log instead of the running one. We must select by
+        // last-write-time instead, so the actively-written log of the running instance wins.
+        let dir = tempdir().unwrap();
+        let (active, active_created) = create_log(dir.path(), "output_log_active.txt", b"hi");
+
+        thread::sleep(Duration::from_millis(20));
+        let (_newer, newer_created) = create_log(dir.path(), "output_log_newer.txt", b"hi");
+
+        // Touch the older file so its last-write-time is now strictly newer than the newer
+        // file's creation- and last-write-time, mimicking the running instance appending to
+        // its log after a previous instance's log has been left on disk.
+        thread::sleep(Duration::from_millis(20));
+        let active_path = dir.path().join("output_log_active.txt");
+        fs::write(&active_path, b"hi\nmore").unwrap();
+        let active_modified = active_path.metadata().unwrap().modified().unwrap();
+
+        // Sanity check: the older file's creation-time is earlier than the newer file's,
+        // and the older file's last-write-time is later than the newer file's last-write-time.
+        assert!(active_created < newer_created);
+        assert!(active_modified > newer_created);
+
+        assert_eq!(
+            pick_log_path(
+                dir.path(),
+                None,
+                active_modified + Duration::from_secs(60),
+            ),
+            Some(active)
         );
     }
 }

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -40,6 +40,14 @@ fn get_latest_log_path(attached: Option<&str>) -> Option<String> {
     pick_log_path(&dir, attached, SystemTime::now())
 }
 
+/// Pick the VRChat log file OyasumiVR should follow right now.
+///
+/// Eligible files are non-empty `output_log_*.txt` entries in `dir` whose
+/// last-write time is within the last 24 hours, OR the file currently
+/// passed as `attached` (which bypasses the age check so a live watcher
+/// does not drop its file once it crosses the 24h mark mid-session).
+/// Among the eligible set, the file with the newest last-write time wins.
+/// `now` is injected so tests can drive the age filter deterministically.
 fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<String> {
     read_dir(dir)
         .ok()?
@@ -56,8 +64,8 @@ fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<
             path.metadata()
                 .ok()
                 .and_then(|metadata| {
-                    metadata.created().ok().and_then(|created_time| {
-                        now.duration_since(created_time)
+                    metadata.modified().ok().and_then(|modified_time| {
+                        now.duration_since(modified_time)
                             .ok()
                             .map(|duration| duration <= Duration::from_secs(24 * 60 * 60))
                     })
@@ -326,6 +334,9 @@ mod tests {
         (path.to_str().unwrap().to_owned(), created)
     }
 
+    /// `pick_log_path` should respect the 24-hour age window, allow the
+    /// currently-attached file to bypass it, ignore zero-byte files, and
+    /// prefer a newer file over the attached one when both exist.
     #[test]
     fn picks_logs_by_age_attachment_and_size() {
         let dir = tempdir().unwrap();
@@ -387,6 +398,11 @@ mod tests {
         );
     }
 
+    /// Regression for issue #275: when more than one VRChat instance has been run on
+    /// the same machine, VRChat leaves the closed instance's log file on disk. Selecting
+    /// by creation-time caused OyasumiVR to latch onto the newest-by-creation log, which
+    /// could be the closed instance's log instead of the running one. We must select by
+    /// last-write-time instead, so the actively-written log of the running instance wins.
     #[test]
     fn prefers_actively_written_log_over_newer_but_stale_log() {
         // Regression test for issue #275: when more than one VRChat instance has been run on
@@ -421,5 +437,39 @@ mod tests {
             ),
             Some(active)
         );
+    }
+
+    /// Regression for the 24-hour age filter: a VRChat session that has been
+    /// running for more than 24 hours creates a log whose `created()` timestamp
+    /// is well outside the 24-hour window, but it is still being appended to and
+    /// must remain a candidate. The age filter is keyed on `modified()` so this
+    /// file is selected even when its creation time is older than the cutoff.
+    #[test]
+    fn keeps_log_eligible_while_actively_written_past_24_hours() {
+        let dir = tempdir().unwrap();
+        let (path, created) = create_log(dir.path(), "output_log_long_running.txt", b"hi");
+        let created_path = dir.path().join("output_log_long_running.txt");
+
+        // Backdate the file's last-write time to 23h after creation. The file's
+        // creation time is "now" (just created in this test), but we want to
+        // simulate "this log file is from an instance that has been running for
+        // 23h" so the 24h age filter is exercised on modified-time, not
+        // creation-time. `File::set_modified` is stable cross-platform since 1.75.
+        let modified_at = created + Duration::from_secs(23 * 3600);
+        let file = fs::OpenOptions::new().write(true).open(&created_path).unwrap();
+        file.set_modified(modified_at).unwrap();
+        drop(file);
+
+        // Sanity: modified-time is backdated by 23h, so it is within the 24h
+        // window from `now`, but creation-time is `now`, which is >24h old.
+        let observed_modified = created_path.metadata().unwrap().modified().unwrap();
+        assert_eq!(observed_modified, modified_at);
+
+        // `now` is set 24h + 30s after the file was actually created — past
+        // the 24h window for creation-time but well within the 24h window for
+        // the backdated modified-time.
+        let now = created + Duration::from_secs(24 * 3600 + 30);
+
+        assert_eq!(pick_log_path(dir.path(), None, now), Some(path));
     }
 }

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -65,9 +65,14 @@ fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<
                 .ok()
                 .and_then(|metadata| {
                     metadata.modified().ok().and_then(|modified_time| {
+                        // A negative duration means `modified_time > now`: the file was
+                        // written in the tiny window between `now` being sampled and its
+                        // metadata being read. Treat that as "fresh, include" rather than
+                        // dropping the actively-written log due to the scan race.
                         now.duration_since(modified_time)
                             .ok()
                             .map(|duration| duration <= Duration::from_secs(24 * 60 * 60))
+                            .or(Some(true))
                     })
                 })
                 .unwrap_or(false)
@@ -469,6 +474,27 @@ mod tests {
         // the 24h window for creation-time but well within the 24h window for
         // the backdated modified-time.
         let now = created + Duration::from_secs(24 * 3600 + 30);
+
+        assert_eq!(pick_log_path(dir.path(), None, now), Some(path));
+    }
+
+    /// Regression for the scan race: `pick_log_path` samples `now` once at the top
+    /// of the call and reads file metadata per candidate afterwards. A file written
+    /// in the gap between those two reads has `mtime > now`, which makes
+    /// `now.duration_since(mtime)` return Err. The age filter must treat that as
+    /// "freshly written, include" rather than dropping the actively-written log.
+    #[test]
+    fn includes_log_modified_in_tiny_window_after_now_sampling() {
+        let dir = tempdir().unwrap();
+        let (path, _) = create_log(dir.path(), "output_log_live.txt", b"hi");
+        let live_path = dir.path().join("output_log_live.txt");
+
+        // Pretend `now` is the moment the caller started scanning, and the file's
+        // last write happened 1 ms *after* `now` — the file is fresh.
+        let now = SystemTime::now();
+        let file = fs::OpenOptions::new().write(true).open(&live_path).unwrap();
+        file.set_modified(now + Duration::from_millis(1)).unwrap();
+        drop(file);
 
         assert_eq!(pick_log_path(dir.path(), None, now), Some(path));
     }


### PR DESCRIPTION
## What this fixes

Fixes #275 — OyasumiVR was latching onto the wrong VRChat log file when more than one VRChat client had been launched on the same machine. The world context, player list, and `OnPlayerJoined` / `OnPlayerLeft` feed would freeze on the closed instance's last known state until the running instance was restarted.

## Why this change was made

`vrc_log_parser::pick_log_path()` selected the active log with `.max_by_key(|m| m.creation_time())`. VRChat creates a new `output_log_<timestamp>.txt` on every launch and does **not** delete the file when the client exits — it stays in `%LocalAppDataLow%\VRChat\VRChat\`. So the most-recently-*created* log was not necessarily the log of the *running* instance: it was whichever client was launched most recently.

The minimal, surgical fix is to switch the selection key from `creation_time` to `last_write_time` (Windows `MetadataExt`). The running instance's log is constantly being appended to, so its `last_write_time` is always more recent than any closed instance's. No architectural shift, no VRChat API credentials required.

A longer-term, more authoritative source of truth for "what world is the user in right now" is `currentUser.location` from the VRChat HTTP API, already wrapped by `vrchat.service.ts` and cross-checkable against the existing `VRCHAT_PROCESS_ACTIVE` event from `os::watch_processes()`. That is a bigger change and is independent of this fix — left as a follow-up.

PR #266 (`fix(core): keep active VRChat logs attached past 24 hours`) refactored the function into `pick_log_path()` with an `attached` parameter, but did not change the `max_by_key` key — so this PR sits cleanly on top of it.

## How the change was verified

- Code review of `pick_log_path` — the change is `m.creation_time()` → `m.last_write_time()`, both methods on the already-imported `std::os::windows::prelude::MetadataExt` with identical `fn(&self) -> SystemTime` signatures.
- A regression test (`prefers_actively_written_log_over_newer_but_stale_log`) was added to the existing `#[cfg(test)] mod tests` block. It creates two files, modifies the older one so its `last_write_time` is newer than the newer file's `creation_time`, and asserts `pick_log_path` returns the older-but-active file. Style-matched to the existing `picks_logs_by_age_attachment_and_size` test in the same module. The test uses only cross-platform APIs (`std::fs::write`, `Metadata::modified()`) so it doesn't introduce a Windows-only test dependency.

## User impact

Users who launched a second VRChat client and then closed it (with the first one still running) will now correctly keep receiving `OnLocationChange`, `OnPlayerJoined`, and `OnPlayerLeft` events from the running client — no more stale world context, no missed joins/leaves, no dead join-notification automations.

## Diff summary

- `src-core/src/vrc_log_parser/mod.rs` — `m.creation_time()` → `m.last_write_time()` in `pick_log_path` plus a regression test (+41 / -1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log selection now prioritizes the most recently modified file, helping ensure actively written logs are chosen over stale logs.
  * Logs modified within the last 24 hours are correctly considered, even when their creation time is older.
  * Logs with modification times slightly after the time of checking are now included.
  * Attached logs continue to bypass the age filter, while empty files remain excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->