### PR TITLE
fix(OYASUMIVR-67): follow the running VRChat client's log

### DIFF
--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -106,6 +106,7 @@ windows = { version = "0.62.2", features = [
   "Win32_System_Console",
   "Win32_System_Power",
   "Win32_System_Registry",
+  "Win32_System_RestartManager",
   "Win32_UI_WindowsAndMessaging",
   "Win32_System_LibraryLoader",
   "Win32_Graphics_Gdi",

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -88,33 +88,32 @@ fn collect_file_holders(session: u32, path: &Path) -> Vec<u32> {
     {
         return vec![];
     }
-    // size the buffer, then fetch the holders
-    let (mut needed, mut count, mut reboot_reasons) = (0u32, 0u32, 0u32);
-    if unsafe { RmGetList(session, &mut needed, &mut count, None, &mut reboot_reasons) }
-        != ERROR_MORE_DATA
-        || needed == 0
-    {
-        return vec![];
+    // size the buffer, then fetch the holders; the holder set can grow in between
+    for _ in 0..3 {
+        let (mut needed, mut count, mut reboot_reasons) = (0u32, 0u32, 0u32);
+        if unsafe { RmGetList(session, &mut needed, &mut count, None, &mut reboot_reasons) }
+            != ERROR_MORE_DATA
+            || needed == 0
+        {
+            return vec![];
+        }
+        let mut infos = vec![RM_PROCESS_INFO::default(); needed as usize];
+        count = needed;
+        if unsafe {
+            RmGetList(
+                session,
+                &mut needed,
+                &mut count,
+                Some(infos.as_mut_ptr()),
+                &mut reboot_reasons,
+            )
+        } == ERROR_SUCCESS
+        {
+            infos.truncate(count as usize);
+            return infos.iter().map(|info| info.Process.dwProcessId).collect();
+        }
     }
-    let mut infos = vec![RM_PROCESS_INFO::default(); needed as usize];
-    count = needed;
-    if unsafe {
-        RmGetList(
-            session,
-            &mut needed,
-            &mut count,
-            Some(infos.as_mut_ptr()),
-            &mut reboot_reasons,
-        )
-    } != ERROR_SUCCESS
-    {
-        return vec![];
-    }
-    infos
-        .iter()
-        .take(count as usize)
-        .map(|info| info.Process.dwProcessId)
-        .collect()
+    vec![]
 }
 
 /// Without `kill`, this only requests a close: the target may ignore it, so the caller must escalate.

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -68,9 +68,12 @@ pub async fn process_ids(process_name: &str) -> Vec<u32> {
 pub fn processes_holding_file(path: &Path) -> Vec<u32> {
     let mut session_key = [0u16; CCH_RM_SESSION_KEY as usize + 1];
     let mut session = 0u32;
-    if unsafe { RmStartSession(&mut session, None, PWSTR(session_key.as_mut_ptr())) }
-        != ERROR_SUCCESS
-    {
+    let start = unsafe { RmStartSession(&mut session, None, PWSTR(session_key.as_mut_ptr())) };
+    if start != ERROR_SUCCESS {
+        error!(
+            "[Core] Failed to start a Restart Manager session: {}",
+            start.0
+        );
         return vec![];
     }
     let holders = collect_file_holders(session, path);

--- a/src-core/src/utils/mod.rs
+++ b/src-core/src/utils/mod.rs
@@ -2,8 +2,11 @@ use log::error;
 use serde::Serialize;
 use std::{
     ffi::OsStr,
+    iter::once,
     os::raw::c_char,
+    os::windows::ffi::OsStrExt,
     os::windows::process::CommandExt,
+    path::Path,
     process::Command,
     sync::LazyLock,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -11,6 +14,14 @@ use std::{
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tauri::Emitter;
 use tokio::sync::Mutex;
+use windows::Win32::{
+    Foundation::{ERROR_MORE_DATA, ERROR_SUCCESS},
+    System::RestartManager::{
+        RmEndSession, RmGetList, RmRegisterResources, RmStartSession, CCH_RM_SESSION_KEY,
+        RM_PROCESS_INFO,
+    },
+};
+use windows_core::{PCWSTR, PWSTR};
 use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
 
 use crate::globals::{TAURI_APP_HANDLE, TAURI_CLI_MATCHES};
@@ -43,6 +54,64 @@ pub async fn is_process_active(process_name: &str, refresh_processes: bool) -> b
     }
     let processes = sysinfo.processes_by_exact_name(OsStr::new(process_name));
     processes.count() > 0
+}
+
+pub async fn process_ids(process_name: &str) -> Vec<u32> {
+    let sysinfo_guard = SYSINFO.lock().await;
+    sysinfo_guard
+        .processes_by_exact_name(OsStr::new(process_name))
+        .map(|process| process.pid().as_u32())
+        .collect()
+}
+
+/// Ids of the processes that currently hold `path` open. Empty when nothing holds it, or on failure.
+pub fn processes_holding_file(path: &Path) -> Vec<u32> {
+    let mut session_key = [0u16; CCH_RM_SESSION_KEY as usize + 1];
+    let mut session = 0u32;
+    if unsafe { RmStartSession(&mut session, None, PWSTR(session_key.as_mut_ptr())) }
+        != ERROR_SUCCESS
+    {
+        return vec![];
+    }
+    let holders = collect_file_holders(session, path);
+    let _ = unsafe { RmEndSession(session) };
+    holders
+}
+
+fn collect_file_holders(session: u32, path: &Path) -> Vec<u32> {
+    let file: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
+    if unsafe { RmRegisterResources(session, Some(&[PCWSTR(file.as_ptr())]), None, None) }
+        != ERROR_SUCCESS
+    {
+        return vec![];
+    }
+    // size the buffer, then fetch the holders
+    let (mut needed, mut count, mut reboot_reasons) = (0u32, 0u32, 0u32);
+    if unsafe { RmGetList(session, &mut needed, &mut count, None, &mut reboot_reasons) }
+        != ERROR_MORE_DATA
+        || needed == 0
+    {
+        return vec![];
+    }
+    let mut infos = vec![RM_PROCESS_INFO::default(); needed as usize];
+    count = needed;
+    if unsafe {
+        RmGetList(
+            session,
+            &mut needed,
+            &mut count,
+            Some(infos.as_mut_ptr()),
+            &mut reboot_reasons,
+        )
+    } != ERROR_SUCCESS
+    {
+        return vec![];
+    }
+    infos
+        .iter()
+        .take(count as usize)
+        .map(|info| info.Process.dwProcessId)
+        .collect()
 }
 
 /// Without `kill`, this only requests a close: the target may ignore it, so the caller must escalate.

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -27,6 +27,7 @@ struct VRCLogEvent {
 static MUTE_LOG_DIR_NO_EXIST_WARNINGS: AtomicBool = AtomicBool::new(false);
 
 const HOLDER_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+const RECENT_WRITE: Duration = Duration::from_secs(60);
 
 fn get_latest_log_path(
     attached: Option<&str>,
@@ -63,16 +64,19 @@ fn pick_log_path(
             if attached.is_some_and(|attached| path == Path::new(attached)) {
                 return true;
             }
-            path.metadata()
-                .ok()
-                .and_then(|metadata| {
-                    metadata.created().ok().and_then(|created_time| {
-                        now.duration_since(created_time)
-                            .ok()
-                            .map(|duration| duration <= Duration::from_secs(24 * 60 * 60))
-                    })
+            let Ok(metadata) = path.metadata() else {
+                return false;
+            };
+            // a session running longer than a day still writes to its log
+            let written_just_now = metadata.modified().is_ok_and(|modified_time| {
+                now.duration_since(modified_time)
+                    .is_ok_and(|duration| duration <= RECENT_WRITE)
+            });
+            written_just_now
+                || metadata.created().is_ok_and(|created_time| {
+                    now.duration_since(created_time)
+                        .is_ok_and(|duration| duration <= Duration::from_secs(24 * 60 * 60))
                 })
-                .unwrap_or(false)
         })
         .filter(|entry| {
             entry
@@ -91,7 +95,7 @@ fn pick_log_path(
         .filter(|attached| candidates.iter().any(|candidate| candidate == attached));
     // keep the attached log while VRChat still holds it open
     if let Some(attached) = attached {
-        if attached == newest.as_path() || held_by_vrchat(attached) {
+        if held_by_vrchat(attached) {
             return attached.to_str().map(String::from);
         }
     }
@@ -284,7 +288,7 @@ pub fn start_log_locator_task() -> CancellationToken {
             reader_task_cancellation_token: None,
         };
         let ctx = &mut loop_context;
-        let mut holder_cache: Option<(PathBuf, bool, Instant)> = None;
+        let mut holder_cache: Option<(PathBuf, Vec<u32>, Instant)> = None;
         while !cancellation_token_internal.is_cancelled() {
             tokio::time::sleep(Duration::from_millis(1000)).await;
             let vrchat_pids = crate::utils::process_ids("VRChat.exe").await;
@@ -296,16 +300,20 @@ pub fn start_log_locator_task() -> CancellationToken {
                     if vrchat_pids.is_empty() {
                         return false;
                     }
-                    if let Some((cached, held, checked_at)) = &cache {
-                        if cached == path && checked_at.elapsed() < HOLDER_CHECK_INTERVAL {
-                            return *held;
+                    // cache the holders themselves, so a holder exiting takes effect at once
+                    let holders = match &cache {
+                        Some((cached, holders, checked_at))
+                            if cached == path && checked_at.elapsed() < HOLDER_CHECK_INTERVAL =>
+                        {
+                            holders.clone()
                         }
-                    }
-                    let held = crate::utils::processes_holding_file(path)
-                        .iter()
-                        .any(|pid| vrchat_pids.contains(pid));
-                    cache = Some((path.to_path_buf(), held, Instant::now()));
-                    held
+                        _ => {
+                            let holders = crate::utils::processes_holding_file(path);
+                            cache = Some((path.to_path_buf(), holders.clone(), Instant::now()));
+                            holders
+                        }
+                    };
+                    holders.iter().any(|pid| vrchat_pids.contains(pid))
                 };
                 let picked = get_latest_log_path(attached.as_deref(), &mut held_by_vrchat);
                 (picked, cache)
@@ -469,6 +477,43 @@ mod tests {
         assert_eq!(
             pick_log_path(dir.path(), None, now, &mut |_: &Path| false),
             Some(closed)
+        );
+    }
+
+    #[test]
+    fn drops_a_dead_attachment_even_when_it_is_the_newest_log() {
+        let dir = tempdir().unwrap();
+        let (running, _) = create_log(dir.path(), "output_log_running.txt", b"log");
+        thread::sleep(Duration::from_millis(20));
+        let (closed, closed_created) = create_log(dir.path(), "output_log_closed.txt", b"log");
+        let running_path = Path::new(&running);
+
+        assert_eq!(
+            pick_log_path(
+                dir.path(),
+                Some(&closed),
+                closed_created + Duration::from_secs(1),
+                &mut |path| path == running_path,
+            ),
+            Some(running)
+        );
+    }
+
+    #[test]
+    fn keeps_a_log_that_is_still_being_written_past_the_age_limit() {
+        let dir = tempdir().unwrap();
+        let (running, created) = create_log(dir.path(), "output_log_running.txt", b"log");
+        let running_path = Path::new(&running);
+        let now = created + Duration::from_secs(25 * 60 * 60);
+
+        assert_eq!(
+            pick_log_path(dir.path(), None, now, &mut |_: &Path| false),
+            None
+        );
+        assert_eq!(
+            pick_log_path(dir.path(), None, SystemTime::now(), &mut |path| path
+                == running_path),
+            Some(running)
         );
     }
 }

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -29,6 +29,7 @@ static MUTE_LOG_DIR_NO_EXIST_WARNINGS: AtomicBool = AtomicBool::new(false);
 
 const HOLDER_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 const RECENT_WRITE: Duration = Duration::from_secs(60);
+const LOG_AGE_LIMIT: Duration = Duration::from_secs(24 * 60 * 60);
 
 fn get_latest_log_path(
     attached: Option<&str>,
@@ -45,6 +46,17 @@ fn get_latest_log_path(
     }
     MUTE_LOG_DIR_NO_EXIST_WARNINGS.store(false, Ordering::Relaxed);
     pick_log_path(&dir, attached, SystemTime::now(), held_by_vrchat)
+}
+
+/// A log qualifies on its creation time, or on a write recent enough to mean a session is running.
+fn is_current_enough(
+    created: Option<SystemTime>,
+    modified: Option<SystemTime>,
+    now: SystemTime,
+) -> bool {
+    let elapsed = |time: Option<SystemTime>| time.and_then(|time| now.duration_since(time).ok());
+    elapsed(modified).is_some_and(|duration| duration <= RECENT_WRITE)
+        || elapsed(created).is_some_and(|duration| duration <= LOG_AGE_LIMIT)
 }
 
 fn pick_log_path(
@@ -65,19 +77,9 @@ fn pick_log_path(
             if attached.is_some_and(|attached| path == Path::new(attached)) {
                 return true;
             }
-            let Ok(metadata) = path.metadata() else {
-                return false;
-            };
-            // a session running longer than a day still writes to its log
-            let written_just_now = metadata.modified().is_ok_and(|modified_time| {
-                now.duration_since(modified_time)
-                    .is_ok_and(|duration| duration <= RECENT_WRITE)
-            });
-            written_just_now
-                || metadata.created().is_ok_and(|created_time| {
-                    now.duration_since(created_time)
-                        .is_ok_and(|duration| duration <= Duration::from_secs(24 * 60 * 60))
-                })
+            path.metadata().is_ok_and(|metadata| {
+                is_current_enough(metadata.created().ok(), metadata.modified().ok(), now)
+            })
         })
         .filter(|entry| {
             entry
@@ -367,7 +369,7 @@ pub fn start_log_locator_task() -> CancellationToken {
 
 #[cfg(test)]
 mod tests {
-    use super::pick_log_path;
+    use super::{is_current_enough, pick_log_path};
     use std::{
         fs,
         path::Path,
@@ -499,19 +501,24 @@ mod tests {
 
     #[test]
     fn keeps_a_log_that_is_still_being_written_past_the_age_limit() {
-        let dir = tempdir().unwrap();
-        let (running, created) = create_log(dir.path(), "output_log_running.txt", b"log");
-        let running_path = Path::new(&running);
-        let now = created + Duration::from_secs(25 * 60 * 60);
+        let now = SystemTime::now();
+        let day_ago = now - Duration::from_secs(25 * 60 * 60);
 
-        assert_eq!(
-            pick_log_path(dir.path(), None, now, &mut |_: &Path| false),
-            None
-        );
-        assert_eq!(
-            pick_log_path(dir.path(), None, SystemTime::now(), &mut |path| path
-                == running_path),
-            Some(running)
-        );
+        assert!(is_current_enough(
+            Some(day_ago),
+            Some(now - Duration::from_secs(10)),
+            now
+        ));
+        assert!(!is_current_enough(
+            Some(day_ago),
+            Some(now - Duration::from_secs(120)),
+            now
+        ));
+        assert!(is_current_enough(
+            Some(now - Duration::from_secs(60 * 60)),
+            Some(day_ago),
+            now
+        ));
+        assert!(!is_current_enough(None, None, now));
     }
 }

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -9,9 +9,9 @@ use std::{
     fs::{read_dir, File},
     io::{BufRead, BufReader},
     os::windows::prelude::MetadataExt,
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -26,7 +26,12 @@ struct VRCLogEvent {
 
 static MUTE_LOG_DIR_NO_EXIST_WARNINGS: AtomicBool = AtomicBool::new(false);
 
-fn get_latest_log_path(attached: Option<&str>) -> Option<String> {
+const HOLDER_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+fn get_latest_log_path(
+    attached: Option<&str>,
+    held_by_vrchat: &mut dyn FnMut(&Path) -> bool,
+) -> Option<String> {
     let home_dir = dirs::home_dir()?;
     let dir = home_dir.join("AppData\\LocalLow\\VRChat\\VRChat");
     if read_dir(&dir).is_err() {
@@ -37,11 +42,16 @@ fn get_latest_log_path(attached: Option<&str>) -> Option<String> {
         return None;
     }
     MUTE_LOG_DIR_NO_EXIST_WARNINGS.store(false, Ordering::Relaxed);
-    pick_log_path(&dir, attached, SystemTime::now())
+    pick_log_path(&dir, attached, SystemTime::now(), held_by_vrchat)
 }
 
-fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<String> {
-    read_dir(dir)
+fn pick_log_path(
+    dir: &Path,
+    attached: Option<&str>,
+    now: SystemTime,
+    held_by_vrchat: &mut dyn FnMut(&Path) -> bool,
+) -> Option<String> {
+    let mut candidates: Vec<PathBuf> = read_dir(dir)
         .ok()?
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
@@ -72,8 +82,27 @@ fn pick_log_path(dir: &Path, attached: Option<&str>, now: SystemTime) -> Option<
                 .map(|metadata| metadata.len() > 0)
                 .unwrap_or(false)
         })
-        .max_by_key(|entry| entry.path().metadata().ok().map(|m| m.creation_time()))
-        .and_then(|entry| entry.path().to_str().map(String::from))
+        .map(|entry| entry.path())
+        .collect();
+    candidates.sort_by_key(|path| path.metadata().ok().map(|m| m.creation_time()));
+    let newest = candidates.last()?;
+    let attached = attached
+        .map(Path::new)
+        .filter(|attached| candidates.iter().any(|candidate| candidate == attached));
+    // keep the attached log while VRChat still holds it open
+    if let Some(attached) = attached {
+        if attached == newest.as_path() || held_by_vrchat(attached) {
+            return attached.to_str().map(String::from);
+        }
+    }
+    // otherwise prefer a log VRChat still holds open
+    candidates
+        .iter()
+        .rev()
+        .find(|candidate| held_by_vrchat(candidate))
+        .unwrap_or(newest)
+        .to_str()
+        .map(String::from)
 }
 
 fn parse_datetime_from_line(line: String) -> Option<u64> {
@@ -255,9 +284,35 @@ pub fn start_log_locator_task() -> CancellationToken {
             reader_task_cancellation_token: None,
         };
         let ctx = &mut loop_context;
+        let mut holder_cache: Option<(PathBuf, bool, Instant)> = None;
         while !cancellation_token_internal.is_cancelled() {
             tokio::time::sleep(Duration::from_millis(1000)).await;
-            let log_path_option = get_latest_log_path(ctx.current_log_path.as_deref());
+            let vrchat_pids = crate::utils::process_ids("VRChat.exe").await;
+            let attached = ctx.current_log_path.clone();
+            // the holder check blocks for a few hundred milliseconds
+            let (log_path_option, cache) = tokio::task::spawn_blocking(move || {
+                let mut cache = holder_cache;
+                let mut held_by_vrchat = |path: &Path| {
+                    if vrchat_pids.is_empty() {
+                        return false;
+                    }
+                    if let Some((cached, held, checked_at)) = &cache {
+                        if cached == path && checked_at.elapsed() < HOLDER_CHECK_INTERVAL {
+                            return *held;
+                        }
+                    }
+                    let held = crate::utils::processes_holding_file(path)
+                        .iter()
+                        .any(|pid| vrchat_pids.contains(pid));
+                    cache = Some((path.to_path_buf(), held, Instant::now()));
+                    held
+                };
+                let picked = get_latest_log_path(attached.as_deref(), &mut held_by_vrchat);
+                (picked, cache)
+            })
+            .await
+            .unwrap_or((None, None));
+            holder_cache = cache;
             if log_path_option.is_none() {
                 // If we are currently reading a log file, stop the reader task
                 if ctx.current_log_path.is_some() {
@@ -331,7 +386,8 @@ mod tests {
             pick_log_path(
                 dir.path(),
                 None,
-                created + Duration::from_secs(23 * 60 * 60)
+                created + Duration::from_secs(23 * 60 * 60),
+                &mut |_: &Path| false,
             ),
             Some(attached.clone())
         );
@@ -339,7 +395,8 @@ mod tests {
             pick_log_path(
                 dir.path(),
                 None,
-                created + Duration::from_secs(25 * 60 * 60)
+                created + Duration::from_secs(25 * 60 * 60),
+                &mut |_: &Path| false,
             ),
             None
         );
@@ -348,6 +405,7 @@ mod tests {
                 dir.path(),
                 Some(&attached),
                 created + Duration::from_secs(25 * 60 * 60),
+                &mut |_: &Path| false,
             ),
             Some(attached.clone())
         );
@@ -356,6 +414,7 @@ mod tests {
                 dir.path(),
                 Some(dir.path().join("missing.txt").to_str().unwrap()),
                 created + Duration::from_secs(25 * 60 * 60),
+                &mut |_: &Path| false,
             ),
             None
         );
@@ -367,6 +426,7 @@ mod tests {
                 dir.path(),
                 Some(&attached),
                 newer_created + Duration::from_secs(1),
+                &mut |_: &Path| false,
             ),
             Some(newer)
         );
@@ -378,8 +438,37 @@ mod tests {
                 empty_dir.path(),
                 None,
                 empty_created + Duration::from_secs(1),
+                &mut |_: &Path| false,
             ),
             None
+        );
+    }
+
+    #[test]
+    fn keeps_the_log_a_vrchat_process_still_holds_open() {
+        let dir = tempdir().unwrap();
+        let (running, _) = create_log(dir.path(), "output_log_running.txt", b"log");
+        thread::sleep(Duration::from_millis(20));
+        let (closed, closed_created) = create_log(dir.path(), "output_log_closed.txt", b"log");
+        let now = closed_created + Duration::from_secs(1);
+        let running_path = Path::new(&running);
+
+        assert_eq!(
+            pick_log_path(dir.path(), Some(&running), now, &mut |path| path
+                == running_path),
+            Some(running.clone())
+        );
+        assert_eq!(
+            pick_log_path(dir.path(), Some(&running), now, &mut |_: &Path| false),
+            Some(closed.clone())
+        );
+        assert_eq!(
+            pick_log_path(dir.path(), None, now, &mut |path| path == running_path),
+            Some(running)
+        );
+        assert_eq!(
+            pick_log_path(dir.path(), None, now, &mut |_: &Path| false),
+            Some(closed)
         );
     }
 }

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -6,6 +6,7 @@ use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
+    collections::HashMap,
     fs::{read_dir, File},
     io::{BufRead, BufReader},
     os::windows::prelude::MetadataExt,
@@ -288,7 +289,7 @@ pub fn start_log_locator_task() -> CancellationToken {
             reader_task_cancellation_token: None,
         };
         let ctx = &mut loop_context;
-        let mut holder_cache: Option<(PathBuf, Vec<u32>, Instant)> = None;
+        let mut holder_cache: HashMap<PathBuf, (Vec<u32>, Instant)> = HashMap::new();
         while !cancellation_token_internal.is_cancelled() {
             tokio::time::sleep(Duration::from_millis(1000)).await;
             let vrchat_pids = crate::utils::process_ids("VRChat.exe").await;
@@ -296,20 +297,17 @@ pub fn start_log_locator_task() -> CancellationToken {
             // the holder check blocks for a few hundred milliseconds
             let (log_path_option, cache) = tokio::task::spawn_blocking(move || {
                 let mut cache = holder_cache;
+                cache.retain(|_, (_, checked_at)| checked_at.elapsed() < HOLDER_CHECK_INTERVAL);
                 let mut held_by_vrchat = |path: &Path| {
                     if vrchat_pids.is_empty() {
                         return false;
                     }
                     // cache the holders themselves, so a holder exiting takes effect at once
-                    let holders = match &cache {
-                        Some((cached, holders, checked_at))
-                            if cached == path && checked_at.elapsed() < HOLDER_CHECK_INTERVAL =>
-                        {
-                            holders.clone()
-                        }
-                        _ => {
+                    let holders = match cache.get(path) {
+                        Some((holders, _)) => holders.clone(),
+                        None => {
                             let holders = crate::utils::processes_holding_file(path);
-                            cache = Some((path.to_path_buf(), holders.clone(), Instant::now()));
+                            cache.insert(path.to_path_buf(), (holders.clone(), Instant::now()));
                             holders
                         }
                     };
@@ -319,7 +317,7 @@ pub fn start_log_locator_task() -> CancellationToken {
                 (picked, cache)
             })
             .await
-            .unwrap_or((None, None));
+            .unwrap_or_default();
             holder_cache = cache;
             if log_path_option.is_none() {
                 // If we are currently reading a log file, stop the reader task


### PR DESCRIPTION
VRChat leaves a closed client's log file on disk. The log locator picked the file with the newest creation time, so once a second client had been launched and closed, OyasumiVR kept reading that dead log. The world, instance and player list froze on the closed instance, and every automation that depends on them went with it.

The locator now asks Windows which process holds a log file open, through the Restart Manager API. It keeps the log it is attached to while a VRChat process still holds it, prefers a log some VRChat process holds once the attachment is released, and otherwise falls back to the most recent log as before. Sorting by last write time instead would have flipped between two running clients every second, because the locator re-picks once a second and re-reads the file from the start on every switch.

`RmGetList` takes about 300 ms for a held file and about 18 ms for a free one, measured against a running client. The result is cached per log file for 30 seconds, keyed on the holding process ids so a client exiting takes effect at once, and the whole pick runs on a blocking thread.

A log written within the last minute also survives the 24 hour age filter now, so a session running longer than a day can be picked up again after the watcher restarts.

Two clients of the same account cannot both be online, so this only comes up with a second account. If OyasumiVR starts while two clients are already running it still cannot tell which one you are wearing, and takes the most recent log.

Closes #275

## Verification

`cargo test vrc_log_parser` passes with four cases: the existing age, attachment and size rules, a held log against a newer closed one, a dead attachment that is also the newest file, and the recent-write rule driven with synthetic timestamps. One unrelated test, `webview2_dialog_tests::resolves_dialog_copy_from_embedded_translations`, fails on `develop` as well.

I ran the app against two real clients. OyasumiVR started with no VRChat running and attached to the newest log on disk. Launching a VR client moved it to that client's log within five seconds. Launching a second client in desktop mode on another profile, whose log then became the newest file, changed nothing. Killing that second client changed nothing either. The old picker would have followed the second client at launch and stayed on its dead log afterwards.
