### PR TITLE
fix(OYASUMIVR-23): retry update checks after the first check fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@ with [SemVer](https://semver.org/) prerelease suffixes:
   modals when you pressed Save immediately after typing
 - Fixed the Bigscreen Beyond fan staying locked at 100% after turning off the fan safety, while the
   headset brightness was still above 100%
+- Fixed standalone releases never checking for updates again after the check at startup failed, for
+  example when your network was not up yet. OyasumiVR now retries every ten minutes until a check
+  succeeds
 
 ### Removed
 

--- a/src-ui/app/services/update.service.ts
+++ b/src-ui/app/services/update.service.ts
@@ -30,7 +30,6 @@ export class UpdateService {
           filter((info) => !info.checked)
         )
         .subscribe(() => this.checkForUpdate());
-      // Check for updates on start
       await this.checkForUpdate(true);
     }
   }
@@ -93,8 +92,8 @@ export class UpdateService {
             return;
         }
       });
-    } catch (error) {
-      info(`[Update] Update error occurred: ${error}`);
+    } catch (e) {
+      info(`[Update] Update error occurred: ${e}`);
       this.modalService
         .addModal(ConfirmModalComponent, {
           title: 'updater.modals.error.title',

--- a/src-ui/app/services/update.service.ts
+++ b/src-ui/app/services/update.service.ts
@@ -5,7 +5,7 @@ import { ConfirmModalComponent } from '../components/confirm-modal/confirm-modal
 import { ModalService } from 'src-ui/app/services/modal.service';
 import { UpdateModalComponent } from '../components/update-modal/update-modal.component';
 import { FLAVOUR } from '../../build';
-import { info } from '@tauri-apps/plugin-log';
+import { error, info } from '@tauri-apps/plugin-log';
 import { check, Update } from '@tauri-apps/plugin-updater';
 
 @Injectable({
@@ -21,8 +21,6 @@ export class UpdateService {
 
   async init() {
     if (FLAVOUR === 'STANDALONE') {
-      // Check for updates on start
-      await this.checkForUpdate(true);
       // Check for updates every 7 days in case Oyasumi is left running for a long time.
       interval(1000 * 3600 * 24 * 7).subscribe(() => this.checkForUpdate());
       // Check for updates every 10 minutes until at least one update check has been done successfully.
@@ -32,6 +30,8 @@ export class UpdateService {
           filter((info) => !info.checked)
         )
         .subscribe(() => this.checkForUpdate());
+      // Check for updates on start
+      await this.checkForUpdate(true);
     }
   }
 
@@ -45,7 +45,14 @@ export class UpdateService {
     }
     // Check for updates
     info(`[Update] Checking for updates...`);
-    const update = (await check()) ?? undefined;
+    let update: Update | undefined;
+    try {
+      update = (await check()) ?? undefined;
+    } catch (e) {
+      // Leaving `checked` false keeps the 10 minute retry schedule active
+      error(`[Update] Could not check for updates: ${e}`);
+      return;
+    }
     if (update) {
       info(
         `[Update] Update available! New version: ${update.version}, Current version: ${update.currentVersion}`


### PR DESCRIPTION
A failed first update check disabled automatic update checking for the rest of the session.

OyasumiVR checks for updates on startup, then every seven days, and retries every ten minutes until one check succeeds. The service created both schedules only after the startup check finished, and that check awaited the updater plugin without a catch. So when the first check failed, for example when the network was down, the app created neither schedule. Nothing else starts them. A manual check from the Updates settings screen still worked.

The service now creates both schedules before it runs the startup check. `checkForUpdate` catches an updater failure, logs it, and leaves the checked flag false, so the ten-minute schedule keeps retrying until a check succeeds. That catch also removes an unhandled promise rejection when a scheduled check fails.

Only the standalone flavour reaches the changed code. Steam and dev builds return at the flavour guard above it.

I tested this with a temporary vitest spec, which is not part of the diff. A rejected first check followed by a successful second check retries after ten minutes, marks the check complete, stops the ten-minute retries, and still fires the seven-day check. A successful first check runs one check and no retry. An update found on startup still opens the update modal. `tsc`, eslint, prettier and the repository suite pass (47 node tests, 6 UI tests).

I did not run a standalone build against a failing update server. That needs the signing key and a forced network failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update checking reliability by handling check failures without disrupting scheduled retries.
  - Update checks can now retry automatically after a failed attempt.
  - Ensured the initial update check is scheduled consistently with recurring checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->