### PR TITLE
fix(OYASUMIVR-28): apply close-to-tray to the main window only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,9 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed OpenVR aborting when its settings interface was unavailable
 - Fixed stale subscriptions after closing the OSC script editor and Device Manager modal
 - Panic reports no longer include your Windows account name from embedded source paths
+- Fixed OyasumiVR's splash screen being hidden instead of closed while closing to the system tray
+  was enabled, which left OyasumiVR running without a window after you turned the option off and
+  closed the window
 
 ### Removed
 

--- a/src-core/src/system_tray/mod.rs
+++ b/src-core/src/system_tray/mod.rs
@@ -42,8 +42,16 @@ pub fn handle_window_events(window: &tauri::Window, event: &tauri::WindowEvent) 
     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
         let manager_guard = futures::executor::block_on(SYSTEMTRAY_MANAGER.lock());
         let manager = manager_guard.as_ref().unwrap();
-        handle_window_close_request(window, Some(api), manager.close_to_tray);
+        handle_window_close_request(
+            window,
+            Some(api),
+            close_to_tray_applies(window.label(), manager.close_to_tray),
+        );
     }
+}
+
+fn close_to_tray_applies(label: &str, close_to_tray: bool) -> bool {
+    close_to_tray && label == "main"
 }
 
 async fn on_tray_icon_event(_icon: &tauri::tray::TrayIcon, event: tauri::tray::TrayIconEvent) {
@@ -92,5 +100,18 @@ fn handle_window_close_request<R: Runtime>(
         }
     } else if api.is_none() {
         window.close().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn close_to_tray_applies_to_the_main_window_only() {
+        assert!(close_to_tray_applies("main", true));
+        assert!(!close_to_tray_applies("splashscreen", true));
+        assert!(!close_to_tray_applies("main", false));
+        assert!(!close_to_tray_applies("overlay", true));
     }
 }


### PR DESCRIPTION
Closing the splash screen hid it instead of destroying it while "Close to the system tray" was on. The hidden splash stayed a live application window, so a user who later turned the setting off and closed the main window could leave OyasumiVR running with only the tray Quit action left.

The app registers one window-event handler for every window, and that handler read the close-to-tray flag without checking the window label. `Window::close` raises `CloseRequested`, so preventing that event for the splash also skipped its destruction. The runtime exits only once its window store is empty, and the retained splash kept that store filled.

`handle_window_events` now passes the flag through `close_to_tray_applies`, which returns true for the `main` label only. I left the unreachable `api.is_none()` branch in `handle_window_close_request` alone, so the change stays one call site plus a test.

## Verification

I ran the debug build on Windows 11, drove the real window over CDP, and listed the process windows with `EnumWindows`.

Before the change, with the setting on, `splashscreen.html` stayed a live WebView2 target after startup, and the process owned two `Tauri Window` handles, one of them invisible. I then turned the setting off and closed the main window. The process kept running for at least 8 seconds with only the hidden splash left.

After the change, with the setting on, one window target and one `Tauri Window` handle remain after startup. Closing the main window hides it, and the process keeps running. I turned the setting off, closed the main window, and the process exited within 1 second.

`cargo test system_tray` covers the four label and flag combinations. `cargo clippy --all-targets` passes with no warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Closing secondary windows no longer sends them to the system tray when “close to tray” is enabled.
  - The close-to-tray setting now applies only to the main application window.
  - Closing the main window continues to follow the configured close-to-tray setting.
  - The splash screen now closes properly when the application is sent to the system tray, preventing it from remaining active without a visible window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->