### PR TITLE
fix(OYASUMIVR-11): keep typed settings values on navigation and save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,9 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed OyasumiVR's splash screen being hidden instead of closed while closing to the system tray
   was enabled, which left OyasumiVR running without a window after you turned the option off and
   closed the window
+- Fixed a value you typed into a settings field being discarded when you left the page straight
+  away. This also affected the OSC host and port, and the battery percentage and upright pose
+  modals when you pressed Save immediately after typing
 
 ### Removed
 

--- a/src-ui/app/components/slider-setting/slider-setting.component.ts
+++ b/src-ui/app/components/slider-setting/slider-setting.component.ts
@@ -17,6 +17,7 @@ import { debounceTime, Subject } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SliderComponent, SliderStyle } from '../slider/slider.component';
 import { clamp, ensurePrecision, floatPrecision } from '../../utils/number-utils';
+import { flushOnDestroy } from '../../utils/rxjs-utils';
 
 @Component({
   selector: 'app-slider-setting',
@@ -64,24 +65,27 @@ export class SliderSettingComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit(): void {
+    flushOnDestroy(this.input$, this.destroyRef);
     this.input$
       .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
-      .subscribe((strValue) => {
-        let value = parseFloat(strValue);
-        if (!Number.isFinite(value)) return;
-        const precision = Math.max(floatPrecision(this.min), floatPrecision(this.step));
-        const quotient = (value - this.min) / this.step;
-        const epsilon = Number.EPSILON * 4 * Math.max(1, Math.abs(quotient));
-        value = clamp(
-          ensurePrecision(Math.round(quotient + epsilon) * this.step + this.min, precision),
-          this.min,
-          this.max
-        );
-        if (value === this.value) return;
-        this.value = value;
-        this.valueChange.emit(value);
-        this.cdr.markForCheck();
-      });
+      .subscribe((strValue) => this.commitInput(strValue));
+  }
+
+  private commitInput(strValue: string) {
+    let value = parseFloat(strValue);
+    if (!Number.isFinite(value)) return;
+    const precision = Math.max(floatPrecision(this.min), floatPrecision(this.step));
+    const quotient = (value - this.min) / this.step;
+    const epsilon = Number.EPSILON * 4 * Math.max(1, Math.abs(quotient));
+    value = clamp(
+      ensurePrecision(Math.round(quotient + epsilon) * this.step + this.min, precision),
+      this.min,
+      this.max
+    );
+    if (value === this.value) return;
+    this.value = value;
+    this.valueChange.emit(value);
+    this.cdr.markForCheck();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -90,6 +94,7 @@ export class SliderSettingComponent implements OnInit, OnChanges {
   }
 
   onInputBlur() {
+    this.commitInput(this.inputEl!.nativeElement.value);
     this.inputEl!.nativeElement.value = this.value.toString();
   }
 

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
@@ -14,6 +14,7 @@ import {
   throttleTime,
 } from 'rxjs';
 import { OscService } from 'src-ui/app/services/osc.service';
+import { flushOnDestroy } from 'src-ui/app/utils/rxjs-utils';
 import { isEqual, pick } from 'lodash';
 
 @Component({
@@ -58,6 +59,7 @@ export class SettingsOscViewComponent implements OnInit {
       });
 
     // Setup debounced validation for custom target host
+    flushOnDestroy(this.customTargetHostChangeSubject, this.destroyRef);
     this.customTargetHostChangeSubject
       .pipe(
         tap(() => (this.customTargetHostValidationState = 'pending')),
@@ -77,6 +79,7 @@ export class SettingsOscViewComponent implements OnInit {
       });
 
     // Setup debounced validation for custom target port
+    flushOnDestroy(this.customTargetPortChangeSubject, this.destroyRef);
     this.customTargetPortChangeSubject
       .pipe(
         tap(() => (this.customTargetPortValidationState = 'pending')),

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
@@ -14,7 +14,6 @@ import {
   throttleTime,
 } from 'rxjs';
 import { OscService } from 'src-ui/app/services/osc.service';
-import { flushOnDestroy } from 'src-ui/app/utils/rxjs-utils';
 import { isEqual, pick } from 'lodash';
 
 @Component({
@@ -58,8 +57,17 @@ export class SettingsOscViewComponent implements OnInit {
         this.oscServerEnabled = settings.oscServerEnabled;
       });
 
+    // flush a pending value on destroy, valid only: an invalid one disables the CUSTOM target
+    this.destroyRef.onDestroy(() => {
+      if (this.isValidHostname(this.oscCustomTargetHost)) {
+        this.customTargetHostChangeSubject.complete();
+      }
+      if (this.isValidPort(this.oscCustomTargetPort)) {
+        this.customTargetPortChangeSubject.complete();
+      }
+    });
+
     // Setup debounced validation for custom target host
-    flushOnDestroy(this.customTargetHostChangeSubject, this.destroyRef);
     this.customTargetHostChangeSubject
       .pipe(
         tap(() => (this.customTargetHostValidationState = 'pending')),
@@ -79,7 +87,6 @@ export class SettingsOscViewComponent implements OnInit {
       });
 
     // Setup debounced validation for custom target port
-    flushOnDestroy(this.customTargetPortChangeSubject, this.destroyRef);
     this.customTargetPortChangeSubject
       .pipe(
         tap(() => (this.customTargetPortValidationState = 'pending')),

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
@@ -14,6 +14,7 @@ import {
   throttleTime,
 } from 'rxjs';
 import { OscService } from 'src-ui/app/services/osc.service';
+import { flushOnDestroy } from 'src-ui/app/utils/rxjs-utils';
 import { isEqual, pick } from 'lodash';
 
 @Component({
@@ -41,6 +42,8 @@ export class SettingsOscViewComponent implements OnInit {
   // Alerts
   protected showVRCTargetWarning = false;
 
+  private destroyed = false;
+
   constructor(
     private destroyRef: DestroyRef,
     private settingsService: AppSettingsService,
@@ -57,15 +60,10 @@ export class SettingsOscViewComponent implements OnInit {
         this.oscServerEnabled = settings.oscServerEnabled;
       });
 
-    // flush a pending value on destroy, valid only: an invalid one disables the CUSTOM target
-    this.destroyRef.onDestroy(() => {
-      if (this.isValidHostname(this.oscCustomTargetHost)) {
-        this.customTargetHostChangeSubject.complete();
-      }
-      if (this.isValidPort(this.oscCustomTargetPort)) {
-        this.customTargetPortChangeSubject.complete();
-      }
-    });
+    // must precede the flush hooks below, which run in registration order
+    this.destroyRef.onDestroy(() => (this.destroyed = true));
+    flushOnDestroy(this.customTargetHostChangeSubject, this.destroyRef);
+    flushOnDestroy(this.customTargetPortChangeSubject, this.destroyRef);
 
     // Setup debounced validation for custom target host
     this.customTargetHostChangeSubject
@@ -80,7 +78,7 @@ export class SettingsOscViewComponent implements OnInit {
           this.settingsService.updateSettings({
             oscCustomTargetHost: host,
           });
-        } else {
+        } else if (!this.destroyed) {
           this.setTargetEnabled('CUSTOM', false);
           this.customTargetHostValidationState = 'invalid';
         }
@@ -99,7 +97,7 @@ export class SettingsOscViewComponent implements OnInit {
           this.settingsService.updateSettings({
             oscCustomTargetPort: port,
           });
-        } else {
+        } else if (!this.destroyed) {
           this.setTargetEnabled('CUSTOM', false);
           this.customTargetPortValidationState = 'invalid';
         }


### PR DESCRIPTION
OyasumiVR discarded a typed settings value if you left the page immediately. Three cases:

- The shared numeric input, used for notification volume and maximum headset brightness among others. Navigate away within 300 ms and the value is gone.
- The custom OSC host and port. Navigate away within 500 ms and the value is gone.
- The battery-percentage and upright-pose modals. Type a value, click Save, and the modal stores the old one.

Each debounced subject held the only pending copy of the typed text. Component destruction unsubscribed without completing the subject, so `debounceTime` dropped the value. The repository already provides `flushOnDestroy` for exactly this, and several components call it.

The slider and both OSC inputs now register `flushOnDestroy` before they subscribe. The slider also commits its current text on blur. That covers the modals, because clicking Save blurs the input before the click handler reads the value.

The OSC subscribers needed one more guard. Their else branch turns the custom OSC target off, so flushing a half-typed host such as `192.168.1.` on destroy would disable a target you had configured. A `destroyed` flag now guards that branch alone. The hook that sets it is registered before the flush hooks, which run in registration order. The flush itself stays unconditional, so the decision reads the value the subscriber received instead of a field the settings subscription can overwrite at any time.

## Verification

I drove each case through the real app window over WebView2 CDP.

| Case | Typed | Left after | Result |
| --- | --- | --- | --- |
| Notification volume | 137 | 69 ms | kept |
| OSC host | 127.0.0.2 | 39 ms | kept |
| OSC port | 9002 | 36 ms | kept |
| Battery threshold, Save | 42 | 13 ms | kept |

All four lose the value on the parent commit, so the checks do exercise the change.

The abandoned-invalid paths, run with the custom OSC target enabled:

| Case | Left after | Result |
| --- | --- | --- |
| OSC host `192.168.1.` | 55 ms | target stays on, host unchanged |
| OSC port cleared | 16 ms | target stays on, port unchanged |
| OSC host 127.0.0.2 | 17 ms | persisted |

I also checked the paths this could break. Blur still clamps an over-maximum value to the maximum, blank text still leaves the value alone, and dragging the slider still commits.

`ng lint`, `ng build oyasumivr`, and `npm run test` (53 passing) pass. A throwaway vitest harness drove the two component classes with fake timers. 21 of 21 pass, and a control against the intermediate commit fails exactly the 4 cases that cover the OSC guard. I did not commit the harness.
