### PR TITLE
fix(OYASUMIVR-24): recover sound playback without an app restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,9 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed controller and input origin labels breaking when a localized-name lookup failed
 - Fixed OpenVR aborting when its settings interface was unavailable
 - Fixed stale subscriptions after closing the OSC script editor and Device Manager modal
+- Fixed notification sounds staying silent for the rest of the session when no audio output device
+  was available while OyasumiVR started. Sounds now play again as soon as a device is available,
+  without restarting OyasumiVR
 - Panic reports no longer include your Windows account name from embedded source paths
 
 ### Removed

--- a/src-core/src/os/commands.rs
+++ b/src-core/src/os/commands.rs
@@ -13,22 +13,30 @@ use std::{env, path::PathBuf};
 use tauri_plugin_shell::{process::CommandEvent, Error, ShellExt};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::oneshot;
 use uuid::Uuid;
 
 #[tauri::command]
-pub async fn play_sound(name: String, volume: f32) {
+pub async fn play_sound(name: String, volume: f32) -> Result<(), String> {
     if volume == 0.0 {
-        return;
+        return Ok(());
     }
-    let guard = super::PLAY_SOUND_TX.lock().await;
-    let tx = match guard.as_ref() {
+    let tx = match super::PLAY_SOUND_TX.lock().await.clone() {
         Some(tx) => tx,
         None => {
             error!("[Core] Could not play sound, as sound player was not initialized");
-            return;
+            return Err(String::from("sound playback is not initialized"));
         }
     };
-    let _ = tx.send((name, volume)).await;
+    let (respond_tx, respond_rx) = oneshot::channel();
+    let worker_gone = || {
+        error!("[Core] Could not play sound, as the sound playback worker stopped");
+        String::from("the sound playback worker is not running")
+    };
+    tx.send((name, volume, respond_tx))
+        .await
+        .map_err(|_| worker_gone())?;
+    respond_rx.await.map_err(|_| worker_gone())?
 }
 
 #[tauri::command]

--- a/src-core/src/os/mod.rs
+++ b/src-core/src/os/mod.rs
@@ -8,7 +8,7 @@ use self::audio_devices::manager::AudioDeviceManager;
 use log::{error, info, warn};
 use rodio::buffer::SamplesBuffer;
 use rodio::source::Source;
-use rodio::{Decoder, DeviceSinkBuilder, Player};
+use rodio::{Decoder, DeviceSinkBuilder, MixerDeviceSink, Player};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
@@ -18,8 +18,8 @@ use std::os::windows::ffi::OsStringExt;
 use std::slice;
 use std::sync::LazyLock;
 use std::time::Duration;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::Mutex;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::{oneshot, Mutex};
 use windows::core::GUID;
 use windows::Win32::Foundation::ERROR_SUCCESS;
 use windows::Win32::System::Power::{
@@ -29,7 +29,8 @@ use windows::Win32::System::Power::{
 use winreg::enums::HKEY_CURRENT_USER;
 use winreg::RegKey;
 
-type PlaySoundSender = LazyLock<Mutex<Option<Sender<(String, f32)>>>>;
+type PlaySoundRequest = (String, f32, oneshot::Sender<Result<(), String>>);
+type PlaySoundSender = LazyLock<Mutex<Option<Sender<PlaySoundRequest>>>>;
 
 static PLAY_SOUND_TX: PlaySoundSender = LazyLock::new(Mutex::default);
 static AUDIO_DEVICE_MANAGER: LazyLock<Mutex<Option<AudioDeviceManager>>> =
@@ -84,58 +85,75 @@ fn decode_sound_file(path: &str) -> Result<SamplesBuffer, String> {
 }
 
 pub async fn init_sound_playback() {
-    // Create channels
-    let (tokio_tx, mut tokio_rx) = tokio::sync::mpsc::channel::<(String, f32)>(32);
-    let (std_tx, std_rx) = std::sync::mpsc::channel::<(String, f32)>();
+    let (tx, rx) = tokio::sync::mpsc::channel::<PlaySoundRequest>(32);
+    *PLAY_SOUND_TX.lock().await = Some(tx);
 
-    // Store the tokio sender
-    *PLAY_SOUND_TX.lock().await = Some(tokio_tx);
-
-    // Forward messages from tokio channel to std channel
     std::thread::spawn(move || {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            while let Some(msg) = tokio_rx.recv().await {
-                let _ = std_tx.send(msg);
-            }
+        run_playback_worker(rx, load_bundled_sounds(), || {
+            DeviceSinkBuilder::open_default_sink().map_err(|e| e.to_string())
         });
     });
+}
 
-    // Spawn standard thread to play sounds
-    std::thread::spawn(move || {
-        // Load and decode all sound files
-        let mut sounds = HashMap::new();
-        sounds_gen::SOUND_FILES.iter().for_each(|sound| {
-            let path = format!("resources/sounds/{sound}.ogg");
-            match decode_sound_file(&path) {
-                Ok(buffer) => {
-                    sounds.insert(String::from(*sound), buffer);
-                }
-                Err(e) => error!("[Core] Failed to load sound file ({path}): {e}"),
+fn load_bundled_sounds() -> HashMap<String, SamplesBuffer> {
+    let mut sounds = HashMap::new();
+    for sound in sounds_gen::SOUND_FILES {
+        let path = format!("resources/sounds/{sound}.ogg");
+        match decode_sound_file(&path) {
+            Ok(buffer) => {
+                sounds.insert(String::from(*sound), buffer);
             }
-        });
-
-        // Initialize output stream
-        let _stream = match DeviceSinkBuilder::open_default_sink() {
-            Ok(stream) => stream,
-            Err(e) => {
-                error!("[Core] Failed to initialize audio output stream: {e}");
-                return;
-            }
-        };
-
-        // Play sounds when requested
-        while let Ok((sound, volume)) = std_rx.recv() {
-            if let Some(buffer) = sounds.get(&sound) {
-                let sink = Player::connect_new(_stream.mixer());
-                sink.set_volume(volume);
-                sink.append(buffer.clone());
-                sink.detach();
-            } else {
-                error!("[Core] Sound not found: {sound}");
-            }
+            Err(e) => error!("[Core] Failed to load sound file ({path}): {e}"),
         }
-    });
+    }
+    sounds
+}
+
+/// An output sink the playback worker can send decoded audio to.
+trait SoundSink {
+    fn play(&self, buffer: SamplesBuffer, volume: f32);
+}
+
+impl SoundSink for MixerDeviceSink {
+    fn play(&self, buffer: SamplesBuffer, volume: f32) {
+        let player = Player::connect_new(self.mixer());
+        player.set_volume(volume);
+        player.append(buffer);
+        player.detach();
+    }
+}
+
+/// Runs until the sender is dropped, so a sink that cannot open yet never ends the worker.
+fn run_playback_worker<S: SoundSink>(
+    mut rx: Receiver<PlaySoundRequest>,
+    sounds: HashMap<String, SamplesBuffer>,
+    mut open_sink: impl FnMut() -> Result<S, String>,
+) {
+    let mut sink: Option<S> = None;
+    while let Some((sound, volume, respond)) = rx.blocking_recv() {
+        let result = match sounds.get(&sound) {
+            Some(buffer) => play_on_sink(&mut sink, &mut open_sink, buffer, volume),
+            None => Err(format!("sound not found: {sound}")),
+        };
+        if let Err(e) = &result {
+            error!("[Core] Could not play sound \"{sound}\": {e}");
+        }
+        let _ = respond.send(result);
+    }
+}
+
+fn play_on_sink<S: SoundSink>(
+    sink: &mut Option<S>,
+    open_sink: &mut impl FnMut() -> Result<S, String>,
+    buffer: &SamplesBuffer,
+    volume: f32,
+) -> Result<(), String> {
+    // acquire the sink on the first request, and again after every failed attempt
+    if sink.is_none() {
+        *sink = Some(open_sink()?);
+    }
+    sink.as_ref().unwrap().play(buffer.clone(), volume);
+    Ok(())
 }
 
 /// Must run before the first desktop notification, or Windows drops it.
@@ -302,6 +320,112 @@ fn get_friendly_name_for_windows_power_policy(scheme_guid: &GUID) -> Option<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::num::{NonZeroU16, NonZeroU32};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct FakeSink {
+        played: Arc<AtomicUsize>,
+    }
+
+    impl SoundSink for FakeSink {
+        fn play(&self, _buffer: SamplesBuffer, _volume: f32) {
+            self.played.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    async fn request(tx: &Sender<PlaySoundRequest>, sound: &str) -> Result<(), String> {
+        let (respond_tx, respond_rx) = oneshot::channel();
+        tx.send((String::from(sound), 1.0, respond_tx))
+            .await
+            .unwrap();
+        respond_rx.await.unwrap()
+    }
+
+    #[test]
+    fn playback_worker_retries_sink_acquisition_after_a_failure() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<PlaySoundRequest>(4);
+        let sounds = HashMap::from([(
+            String::from("test"),
+            SamplesBuffer::new(
+                NonZeroU16::new(1).unwrap(),
+                NonZeroU32::new(48_000).unwrap(),
+                vec![0.5f32; 16],
+            ),
+        )]);
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let played = Arc::new(AtomicUsize::new(0));
+
+        let worker = std::thread::spawn({
+            let attempts = attempts.clone();
+            let played = played.clone();
+            move || {
+                run_playback_worker(rx, sounds, move || {
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        Err(String::from("no usable sink"))
+                    } else {
+                        Ok(FakeSink {
+                            played: played.clone(),
+                        })
+                    }
+                })
+            }
+        });
+
+        test_runtime().block_on(async {
+            assert_eq!(
+                request(&tx, "test").await,
+                Err(String::from("no usable sink")),
+                "the first request must report the sink failure"
+            );
+            assert_eq!(
+                request(&tx, "test").await,
+                Ok(()),
+                "a later request must retry sink acquisition and play"
+            );
+            assert_eq!(
+                request(&tx, "test").await,
+                Ok(()),
+                "the acquired sink must be reused"
+            );
+            assert_eq!(
+                request(&tx, "missing").await,
+                Err(String::from("sound not found: missing")),
+                "an unknown sound must report an error"
+            );
+        });
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(played.load(Ordering::SeqCst), 2);
+
+        drop(tx);
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn play_sound_command_errors_when_the_worker_stopped() {
+        test_runtime().block_on(async {
+            let (tx, rx) = tokio::sync::mpsc::channel::<PlaySoundRequest>(1);
+            drop(rx);
+            *PLAY_SOUND_TX.lock().await = Some(tx);
+            assert_eq!(
+                commands::play_sound(String::from("pebbles"), 1.0).await,
+                Err(String::from("the sound playback worker is not running"))
+            );
+            *PLAY_SOUND_TX.lock().await = None;
+            assert_eq!(
+                commands::play_sound(String::from("pebbles"), 1.0).await,
+                Err(String::from("sound playback is not initialized"))
+            );
+        });
+    }
 
     #[test]
     fn bundled_sounds_decode_to_non_silent_samples() {

--- a/src-core/src/os/mod.rs
+++ b/src-core/src/os/mod.rs
@@ -109,7 +109,6 @@ fn load_bundled_sounds() -> HashMap<String, SamplesBuffer> {
     sounds
 }
 
-/// An output sink the playback worker can send decoded audio to.
 trait SoundSink {
     fn play(&self, buffer: SamplesBuffer, volume: f32);
 }

--- a/src-ui/app/services/notification.service.ts
+++ b/src-ui/app/services/notification.service.ts
@@ -62,10 +62,14 @@ export class NotificationService {
     if (volume > 0) {
       switch (sound.type) {
         case 'BUILT_IN':
-          await invoke('play_sound', {
-            name: sound.id,
-            volume,
-          });
+          try {
+            await invoke('play_sound', {
+              name: sound.id,
+              volume,
+            });
+          } catch (e) {
+            error(`[Notification] Could not play sound "${sound.id}": ${e}`);
+          }
           break;
         default:
           error(`[Notification] Unknown sound type: ${sound.type}`);


### PR DESCRIPTION
If no audio output device could open when OyasumiVR started, built-in notification
sounds stayed silent for the whole session. Attaching a working device changed
nothing, and the Test button in Notification Settings still behaved as though the
sound played. Only a restart brought sound back.

The playback thread opened the output sink once, before its request loop, and
returned when that failed. A second thread kept forwarding requests into the dead
channel, and the `play_sound` command discarded the send result, so the frontend
always saw success.

The worker now opens the sink on the first sound request, and again after every
failed attempt, so a device that appears later plays without a restart.
`play_sound` returns a `Result` and reports an unavailable sink or a stopped
worker. The notification service logs that failure instead of throwing at its
callers. The forwarding thread and its extra Tokio runtime are gone: the worker
reads the Tokio channel with `blocking_recv`.

## Tested

- `cargo test` in `src-core`: 62 pass, including two new ones. The first injects a
  sink opener that fails once and then succeeds, and asserts the worker survives
  the failure, retries, and plays. The second asserts `play_sound` returns an error
  when the worker is gone.
- `cargo clippy --all-targets` and `ng lint`: clean.
- Ran the dev build, pressed Test in Notification Settings, and played a sound from
  the sound picker. Both produced audio: the app's Windows audio session peaked at
  0.40 and 0.88.
- Reproduced the reported failure on a real machine. Stopping the Windows Audio
  service left zero active render endpoints. OyasumiVR started into that state and
  stayed responsive. Test logged `Could not play sound "pebbles": Could not find
  any output device` from both the core and the notification service. Starting the
  service again, without touching the running app, restored playback: the same
  process played the sound at its normal level, with an audio session peak of
  0.40230, equal to the baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Notification sounds now resume automatically when an audio output device becomes available after the app starts, without requiring a restart.
  - Audio playback retries after temporary device initialization failures.
  - Missing or unavailable sounds are handled more reliably, preventing playback failures from disrupting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->