### PR TITLE
fix(OYASUMIVR-6): keep the binding widget polling after a failed query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed notification sounds staying silent for the rest of the session when no audio output device
   was available while OyasumiVR started. Sounds now play again as soon as a device is available,
   without restarting OyasumiVR
+- Fixed the controller binding indicator in General Settings showing blank or outdated information
+  after a failed binding lookup, until you navigated away from the settings and back
 - Panic reports no longer include your Windows account name from embedded source paths
 - Fixed OyasumiVR's splash screen being hidden instead of closed while closing to the system tray
   was enabled, which left OyasumiVR running without a window after you turned the option off and

--- a/src-core/src/openvr/commands.rs
+++ b/src-core/src/openvr/commands.rs
@@ -239,7 +239,7 @@ pub async fn openvr_reregister_manifest() -> Result<(), String> {
 pub async fn openvr_get_binding_origins(
     action_set_key: String,
     action_key: String,
-) -> Vec<BindingOriginData> {
+) -> Result<Vec<BindingOriginData>, String> {
     let mut input_ctx = super::OVR_INPUT_CONTEXT.lock().await;
     // Get action set by name
     let action_set = match input_ctx
@@ -248,22 +248,22 @@ pub async fn openvr_get_binding_origins(
         .find(|a| a.name == action_set_key)
     {
         Some(action_set) => action_set.handle,
-        None => return vec![],
+        None => return Err(String::from("ACTION_SET_NOT_FOUND")),
     };
     // Get action by name
     let action = match input_ctx.actions.iter().find(|a| a.name == action_key) {
         Some(action) => action.handle,
-        None => return vec![],
+        None => return Err(String::from("ACTION_NOT_FOUND")),
     };
     // Get the input service
     let context = OVR_CONTEXT.lock().await;
     let mut input = match context.as_ref() {
         Some(context) => context.input_mngr(),
-        None => return vec![],
+        None => return Err(String::from("OPENVR_NOT_INITIALIZED")),
     };
     if let Err(e) = input.update_actions(input_ctx.active_sets.as_mut_slice()) {
         error!("[Core] Failed to update actions: {e}");
-        return vec![];
+        return Err(String::from("UPDATE_ACTIONS_FAILED"));
     }
     // Get all of the origins for this action
     let origins: Vec<u64> = match input.get_action_origins(action_set, action) {
@@ -274,7 +274,7 @@ pub async fn openvr_get_binding_origins(
             .collect(),
         Err(e) => {
             error!("[Core] Failed to get action origins: {e}");
-            return vec![];
+            return Err(String::from("GET_ACTION_ORIGINS_FAILED"));
         }
     };
     // get localized labels for each origin
@@ -312,7 +312,7 @@ pub async fn openvr_get_binding_origins(
             Ok(result) => result,
             Err(e) => {
                 error!("[Core] Failed to get action binding info: {e}");
-                return vec![];
+                return Err(String::from("GET_ACTION_BINDING_INFO_FAILED"));
             }
         };
     match assemble_binding_origins(
@@ -322,10 +322,10 @@ pub async fn openvr_get_binding_origins(
         &localized_input_sources,
         &binding_infos,
     ) {
-        Some(data) => data,
+        Some(data) => Ok(data),
         None => {
             error!("[Core] OpenVR returned incomplete binding origin data");
-            vec![]
+            Err(String::from("INCOMPLETE_BINDING_DATA"))
         }
     }
 }

--- a/src-core/src/openvr/commands.rs
+++ b/src-core/src/openvr/commands.rs
@@ -239,7 +239,7 @@ pub async fn openvr_reregister_manifest() -> Result<(), String> {
 pub async fn openvr_get_binding_origins(
     action_set_key: String,
     action_key: String,
-) -> Option<Vec<BindingOriginData>> {
+) -> Vec<BindingOriginData> {
     let mut input_ctx = super::OVR_INPUT_CONTEXT.lock().await;
     // Get action set by name
     let action_set = match input_ctx
@@ -248,22 +248,22 @@ pub async fn openvr_get_binding_origins(
         .find(|a| a.name == action_set_key)
     {
         Some(action_set) => action_set.handle,
-        None => return None,
+        None => return vec![],
     };
     // Get action by name
     let action = match input_ctx.actions.iter().find(|a| a.name == action_key) {
         Some(action) => action.handle,
-        None => return None,
+        None => return vec![],
     };
     // Get the input service
     let context = OVR_CONTEXT.lock().await;
     let mut input = match context.as_ref() {
         Some(context) => context.input_mngr(),
-        None => return None,
+        None => return vec![],
     };
     if let Err(e) = input.update_actions(input_ctx.active_sets.as_mut_slice()) {
         error!("[Core] Failed to update actions: {e}");
-        return None;
+        return vec![];
     }
     // Get all of the origins for this action
     let origins: Vec<u64> = match input.get_action_origins(action_set, action) {
@@ -274,7 +274,7 @@ pub async fn openvr_get_binding_origins(
             .collect(),
         Err(e) => {
             error!("[Core] Failed to get action origins: {e}");
-            return None;
+            return vec![];
         }
     };
     // get localized labels for each origin
@@ -307,21 +307,14 @@ pub async fn openvr_get_binding_origins(
     );
 
     // Get extra information about each binding
-    let result = {
-        let result: Vec<ovr::sys::InputBindingInfo_t> = match input.get_action_binding_info(action)
-        {
+    let binding_infos: Vec<ovr::sys::InputBindingInfo_t> =
+        match input.get_action_binding_info(action) {
             Ok(result) => result,
             Err(e) => {
                 error!("[Core] Failed to get action binding info: {e}");
-                return None;
+                return vec![];
             }
         };
-        Some(result)
-    };
-    let binding_infos = match result {
-        Some(infos) => infos,
-        None => return None,
-    };
     match assemble_binding_origins(
         origins.len(),
         &localized_controller_types,
@@ -329,10 +322,10 @@ pub async fn openvr_get_binding_origins(
         &localized_input_sources,
         &binding_infos,
     ) {
-        Some(data) => Some(data),
+        Some(data) => data,
         None => {
             error!("[Core] OpenVR returned incomplete binding origin data");
-            Some(vec![])
+            vec![]
         }
     }
 }

--- a/src-ui/app/components/controller-binding/controller-binding.component.html
+++ b/src-ui/app/components/controller-binding/controller-binding.component.html
@@ -38,7 +38,7 @@
       </div>
     </div>
   }
-  @if (!error) {
+  @if (!error && activeBinding) {
     <div class="text-wrapper">
       <div class="line0">{{ activeBinding?.localizedControllerType }}</div>
       <div class="line1"

--- a/src-ui/app/components/controller-binding/controller-binding.component.spec.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.spec.ts
@@ -1,0 +1,110 @@
+import '@angular/compiler';
+import type { DestroyRef } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OVRActionBinding } from '../../models/ovr-action-binding';
+import type { OVRDevice } from '../../models/ovr-device';
+import { OVRInputEventAction, OVRInputEventActionSet } from '../../models/ovr-input-event';
+import { OpenVRInputService } from '../../services/openvr-input.service';
+import type { OpenVRService, OpenVRStatus } from '../../services/openvr.service';
+import { ControllerBindingComponent } from './controller-binding.component';
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/plugin-log', () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+const binding: OVRActionBinding = {
+  devicePathName: '/user/hand/right',
+  inputPathName: '/input/a',
+  inputSourceType: 'button',
+  localizedControllerType: 'Index Controller',
+  localizedHand: 'Right Hand',
+  localizedInputSource: 'A Button',
+  modeName: 'button',
+  slotName: 'click',
+};
+
+function controller(index: number, role: 'LeftHand' | 'RightHand'): OVRDevice {
+  return { battery: 1, class: 'Controller', role, index, pose: {}, isTurningOff: false };
+}
+
+function createComponent() {
+  const status = new BehaviorSubject<OpenVRStatus>('INITIALIZED');
+  const devices = new BehaviorSubject<OVRDevice[]>([
+    controller(1, 'LeftHand'),
+    controller(2, 'RightHand'),
+  ]);
+  const openvr = {
+    status,
+    devices,
+    isDashboardVisible: vi.fn(async () => false),
+  } as unknown as OpenVRService;
+  const destroyRef = { onDestroy: () => () => {} } as unknown as DestroyRef;
+  const component = new ControllerBindingComponent(
+    new OpenVRInputService(openvr),
+    openvr,
+    destroyRef
+  );
+  component.actionKey = OVRInputEventAction.OpenOverlay;
+  return component;
+}
+
+describe('ControllerBindingComponent', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    invoke.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps polling after a failed query and shows the next valid response', async () => {
+    invoke.mockResolvedValueOnce(null).mockResolvedValue([binding]);
+    const component = createComponent();
+
+    component.ngOnInit();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(component.activeBinding).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(component.activeBinding).toEqual(binding);
+  });
+
+  it('keeps polling after a rejected query', async () => {
+    invoke.mockRejectedValueOnce('OPENVR_NOT_INITIALIZED').mockResolvedValue([binding]);
+    const component = createComponent();
+
+    component.ngOnInit();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(component.activeBinding).toEqual(binding);
+  });
+});
+
+describe('OpenVRInputService', () => {
+  beforeEach(() => invoke.mockReset());
+
+  it('drops bindings without a usable slot name', async () => {
+    invoke.mockResolvedValue([binding, { ...binding, slotName: 'null' }]);
+    const status = new BehaviorSubject<OpenVRStatus>('INITIALIZED');
+    const service = new OpenVRInputService({ status } as unknown as OpenVRService);
+
+    const bindings = await service.getActionBindings(
+      OVRInputEventActionSet.Main,
+      OVRInputEventAction.OpenOverlay
+    );
+
+    expect(bindings).toEqual([binding]);
+  });
+});

--- a/src-ui/app/components/controller-binding/controller-binding.component.spec.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.spec.ts
@@ -90,6 +90,23 @@ describe('ControllerBindingComponent', () => {
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(component.activeBinding).toEqual(binding);
   });
+
+  it('ignores a slow query that settles after a newer one', async () => {
+    let failSlowQuery: (reason: unknown) => void = () => {};
+    invoke
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => (failSlowQuery = reject)))
+      .mockResolvedValue([binding]);
+    const component = createComponent();
+
+    component.ngOnInit();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(component.activeBinding).toEqual(binding);
+
+    failSlowQuery('SLOW_FAILURE');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(component.activeBinding).toEqual(binding);
+  });
 });
 
 describe('OpenVRInputService', () => {

--- a/src-ui/app/components/controller-binding/controller-binding.component.spec.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.spec.ts
@@ -107,6 +107,18 @@ describe('ControllerBindingComponent', () => {
 
     expect(component.activeBinding).toEqual(binding);
   });
+
+  it('still shows a response when every query outlasts the interval', async () => {
+    invoke.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([binding]), 1500))
+    );
+    const component = createComponent();
+
+    component.ngOnInit();
+    await vi.advanceTimersByTimeAsync(5500);
+
+    expect(component.activeBinding).toEqual(binding);
+  });
 });
 
 describe('OpenVRInputService', () => {

--- a/src-ui/app/components/controller-binding/controller-binding.component.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.ts
@@ -1,11 +1,12 @@
 import { Component, DestroyRef, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { OVRInputEventAction, OVRInputEventActionSet } from '../../models/ovr-input-event';
-import { OpenVRInputService } from 'src-ui/app/services/openvr-input.service';
+import { OpenVRInputService } from '../../services/openvr-input.service';
 import { filter, firstValueFrom, interval, pairwise, startWith, switchMap, tap } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OVRActionBinding } from '../../models/ovr-action-binding';
 import { OpenVRService, OpenVRStatus } from '../../services/openvr.service';
 import { fadeDown } from '../../utils/animations';
+import { warn } from '@tauri-apps/plugin-log';
 
 @Component({
   selector: 'app-controller-binding',
@@ -111,7 +112,10 @@ export class ControllerBindingComponent implements OnInit {
         }
         error = 'UNKNOWN';
       }
-    })();
+    })().catch((e) => {
+      error = 'UNKNOWN';
+      warn(`[ControllerBinding] Failed to refresh bindings, retrying next tick: ${e}`);
+    });
     this.error = error;
     this.bindings.splice(0, this.bindings.length);
     this.bindings.push(...bindings);

--- a/src-ui/app/components/controller-binding/controller-binding.component.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.ts
@@ -31,6 +31,7 @@ export class ControllerBindingComponent implements OnInit {
   protected hasRightHand = false;
   protected hasLeftHand = false;
   protected dropdownOpen = false;
+  private refreshGeneration = 0;
 
   get activeBinding(): OVRActionBinding | undefined {
     return this.bindings.length ? this.bindings[0] : undefined;
@@ -78,6 +79,7 @@ export class ControllerBindingComponent implements OnInit {
   }
 
   private async refreshBindings() {
+    const generation = ++this.refreshGeneration;
     let error = undefined;
     let bindings: OVRActionBinding[] = [];
     let status: OpenVRStatus | undefined = undefined;
@@ -116,6 +118,8 @@ export class ControllerBindingComponent implements OnInit {
       error = 'UNKNOWN';
       warn(`[ControllerBinding] Failed to refresh bindings, retrying next tick: ${e}`);
     });
+    // a slower refresh must not overwrite what a newer one already displayed
+    if (generation !== this.refreshGeneration) return;
     this.error = error;
     this.bindings.splice(0, this.bindings.length);
     this.bindings.push(...bindings);

--- a/src-ui/app/components/controller-binding/controller-binding.component.ts
+++ b/src-ui/app/components/controller-binding/controller-binding.component.ts
@@ -32,6 +32,7 @@ export class ControllerBindingComponent implements OnInit {
   protected hasLeftHand = false;
   protected dropdownOpen = false;
   private refreshGeneration = 0;
+  private appliedGeneration = 0;
 
   get activeBinding(): OVRActionBinding | undefined {
     return this.bindings.length ? this.bindings[0] : undefined;
@@ -119,7 +120,8 @@ export class ControllerBindingComponent implements OnInit {
       warn(`[ControllerBinding] Failed to refresh bindings, retrying next tick: ${e}`);
     });
     // a slower refresh must not overwrite what a newer one already displayed
-    if (generation !== this.refreshGeneration) return;
+    if (generation < this.appliedGeneration) return;
+    this.appliedGeneration = generation;
     this.error = error;
     this.bindings.splice(0, this.bindings.length);
     this.bindings.push(...bindings);


### PR DESCRIPTION
The controller binding indicator in General Settings stopped refreshing after one failed binding query. It kept a blank or stale binding until you navigated away and back.

`openvr_get_binding_origins` returned `Option<Vec<BindingOriginData>>`, and Tauri serializes `None` as `null`. The frontend typed the response as an array and called `filter` on it. That type error rejected the query and escaped the `switchMap` inner stream. It closed the one-second polling subscription until Angular destroyed the component.

The command now returns `Result<Vec<BindingOriginData>, String>`, which is what the other commands in this file already do. Each recoverable failure carries its own code and rejects the invoke, so a failed lookup and an action with no bindings are no longer the same value. `refreshBindings` catches an error from a single iteration, sets the unknown-error state, and lets the next tick retry.

Catching that error also let a refresh write its result after a newer refresh had already written one, so a slow query could flip a valid binding back to the error state. A refresh now applies its result only when no newer refresh applied one first.

The widget also logged `Missing translation for 'comp.controller-binding.slot.null'` on every mount, because it rendered its text block before the first poll returned a binding. That block now waits for a binding.

Verification:

- `npm run test`, `npx ng lint`, `cargo check`, `cargo test`, and `ng build oyasumivr` pass.
- `controller-binding.component.spec.ts` drives the real input service with a mocked `invoke` across four failure and timing cases. Each test fails if you remove the code it covers.
- I ran the dev app against live SteamVR with Index controllers. The widget under Settings, General Settings shows `Index Controller / Right Hand System / Click`, and its dropdown opens. Calling the command with an unknown action set rejects with `ACTION_SET_NOT_FOUND` instead of resolving `null`.
