### PR TITLE
fix(OYASUMIVR-22): clear Bigscreen Beyond fan safety when its setting is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 - Fixed a value you typed into a settings field being discarded when you left the page straight
   away. This also affected the OSC host and port, and the battery percentage and upright pose
   modals when you pressed Save immediately after typing
+- Fixed the Bigscreen Beyond fan staying locked at 100% after turning off the fan safety, while the
+  headset brightness was still above 100%
 
 ### Removed
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint": "ng lint",
     "test": "run-s test:node test:ui",
     "test:node": "node --experimental-strip-types --test \"src-shared-ts/src/*.test.ts\" \"scripts/*.test.ts\" \"src-ui/app/utils/*.test.ts\"",
-    "test:ui": "vitest run src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts",
+    "test:ui": "vitest run src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.spec.ts",
     "clean": "rimraf dist && rimraf src-overlay-sidecar/bin && rimraf src-overlay-sidecar/obj && rimraf src-overlay-ui/build && rimraf src-elevated-sidecar/target && rimraf src-privileged-launcher/target && rimraf tools/sign-elevated-sidecar/target && rimraf src-core/target && rimraf src-shared-rust/target && rimraf src-core/resources/elevated-sidecar && rimraf src-core/resources/privileged-launcher && rimraf src-core/resources/overlay-sidecar && rimraf src-core/resources/fonts",
     "tl": "node scripts/translation-utils.js",
     "tl:check-icu": "node scripts/check-icu.mjs",

--- a/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.spec.ts
+++ b/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.spec.ts
@@ -103,6 +103,8 @@ describe('BigscreenBeyondFanAutomationService fan safety', () => {
 
     context.brightness.next(120);
     await settleSafety();
+    context.brightness.next(130);
+    await settleSafety();
 
     expect(fanCommands).toEqual([60]);
   });

--- a/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.spec.ts
+++ b/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.spec.ts
@@ -1,0 +1,134 @@
+import { BehaviorSubject, Subject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppSettingsService } from '../app-settings.service';
+import type { AutomationConfigService } from '../automation-config.service';
+import type { EventLogService } from '../event-log.service';
+import type { SleepService } from '../sleep.service';
+import type { SleepPreparationService } from '../sleep-preparation.service';
+import type { HardwareBrightnessControlService } from '../brightness-control/hardware-brightness-control.service';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../../models/automations';
+import { APP_SETTINGS_DEFAULT, type AppSettings } from '../../models/settings';
+import { BigscreenBeyondFanAutomationService } from './bigscreen-beyond-fan-automation.service';
+
+const fanCommands: number[] = [];
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  warn: vi.fn(async () => {}),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string, args?: { speed: number }) => {
+    switch (command) {
+      case 'bigscreen_beyond_is_connected':
+        return true;
+      case 'bigscreen_beyond_get_saved_preferences':
+        return '';
+      case 'bigscreen_beyond_set_fan_speed':
+        fanCommands.push(args!.speed);
+        return undefined;
+      default:
+        return undefined;
+    }
+  }),
+}));
+
+function createService() {
+  const settings = new BehaviorSubject<AppSettings>({
+    ...structuredClone(APP_SETTINGS_DEFAULT),
+    bigscreenBeyondBrightnessFanSafety: false,
+  });
+  const brightness = new BehaviorSubject(50);
+  const hardwareBrightness = {
+    brightnessStream: brightness.asObservable(),
+    get brightness() {
+      return brightness.value;
+    },
+  };
+  const service = new BigscreenBeyondFanAutomationService(
+    {
+      configs: new BehaviorSubject(structuredClone(AUTOMATION_CONFIGS_DEFAULT)).asObservable(),
+    } as AutomationConfigService,
+    { mode: new BehaviorSubject(false).asObservable() } as SleepService,
+    { onSleepPreparation: new Subject<void>() } as unknown as SleepPreparationService,
+    { settings: settings.asObservable() } as AppSettingsService,
+    hardwareBrightness as unknown as HardwareBrightnessControlService,
+    { logEvent: vi.fn() } as unknown as EventLogService
+  );
+  const safetyActive: boolean[] = [];
+  service.fanSafetyActive.subscribe((active) => safetyActive.push(active));
+
+  const setFanSafety = (enabled: boolean) =>
+    settings.next({ ...settings.value, bigscreenBeyondBrightnessFanSafety: enabled });
+
+  return { brightness, safetyActive, service, setFanSafety };
+}
+
+// past the 100 ms throttle on the fan safety setting
+const settleSafety = () => vi.advanceTimersByTimeAsync(150);
+
+async function activateSafetyAt120(context: ReturnType<typeof createService>) {
+  await context.service.init();
+  await vi.advanceTimersByTimeAsync(600);
+  await context.service.setFanSpeed(60);
+  context.brightness.next(120);
+  context.setFanSafety(true);
+  await settleSafety();
+  expect(context.safetyActive.at(-1)).toBe(true);
+  fanCommands.length = 0;
+}
+
+describe('BigscreenBeyondFanAutomationService fan safety', () => {
+  beforeEach(() => {
+    fanCommands.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('restores the saved speed once when the setting is disabled above 100% brightness', async () => {
+    const context = createService();
+    await activateSafetyAt120(context);
+
+    context.setFanSafety(false);
+    await settleSafety();
+
+    expect(fanCommands).toEqual([60]);
+    expect(context.safetyActive.at(-1)).toBe(false);
+
+    context.brightness.next(120);
+    await settleSafety();
+
+    expect(fanCommands).toEqual([60]);
+  });
+
+  it('restores the saved speed when brightness returns to the safe range', async () => {
+    const context = createService();
+    await activateSafetyAt120(context);
+
+    context.brightness.next(90);
+    await settleSafety();
+
+    expect(fanCommands).toEqual([60]);
+    expect(context.safetyActive.at(-1)).toBe(false);
+  });
+
+  it('forces 100% again when the setting is re-enabled above 100% brightness', async () => {
+    const context = createService();
+    await activateSafetyAt120(context);
+
+    context.setFanSafety(false);
+    await settleSafety();
+    fanCommands.length = 0;
+    context.setFanSafety(true);
+    await settleSafety();
+
+    expect(fanCommands).toEqual([100]);
+    expect(context.safetyActive.at(-1)).toBe(true);
+  });
+});

--- a/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.ts
+++ b/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.ts
@@ -159,8 +159,8 @@ export class BigscreenBeyondFanAutomationService {
         this.setFanSpeed(100, false);
         this._fanSafetyActive.next(true);
       }
-      // Restore fan speed when brightness is back to safe range
-      if (this._fanSafetyActive.value && brightness <= 100) {
+      // Restore fan speed when the setting is disabled, or brightness is back to safe range
+      if (this._fanSafetyActive.value && (!fanSafety || brightness <= 100)) {
         this._fanSafetyActive.next(false);
         this.setFanSpeed(
           clamp(

--- a/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.ts
+++ b/src-ui/app/services/hmd-specific-automations/bigscreen-beyond-fan-automation.service.ts
@@ -159,7 +159,7 @@ export class BigscreenBeyondFanAutomationService {
         this.setFanSpeed(100, false);
         this._fanSafetyActive.next(true);
       }
-      // Restore fan speed when the setting is disabled, or brightness is back to safe range
+      // restore the saved fan speed
       if (this._fanSafetyActive.value && (!fanSafety || brightness <= 100)) {
         this._fanSafetyActive.next(false);
         this.setFanSpeed(

--- a/src-ui/app/views/dashboard-view/views/hmd-automations-view/tabs/hmd-automations-bigscreen-beyond-tab/hmd-automations-bigscreen-beyond-tab.component.ts
+++ b/src-ui/app/views/dashboard-view/views/hmd-automations-view/tabs/hmd-automations-bigscreen-beyond-tab/hmd-automations-bigscreen-beyond-tab.component.ts
@@ -16,8 +16,6 @@ import {
 
 import { APP_SETTINGS_DEFAULT, AppSettings } from '../../../../../../models/settings';
 import { hshrink } from '../../../../../../utils/animations';
-import { SET_BRIGHTNESS_OR_CCT_OPTIONS_DEFAULTS } from '../../../../../../services/brightness-control/brightness-control-models';
-import { HardwareBrightnessControlService } from '../../../../../../services/brightness-control/hardware-brightness-control.service';
 
 const MIN_SAFE_FAN_SPEED = 40;
 const AUTOMATION_ENABLE_KEYS = ['onSleepEnable', 'onSleepDisable', 'onSleepPreparation'];
@@ -49,7 +47,6 @@ export class HmdAutomationsBigscreenBeyondTabComponent implements OnInit {
     private automationConfigService: AutomationConfigService,
     private appSettingsService: AppSettingsService,
     private destroyRef: DestroyRef,
-    private hardwareBrightness: HardwareBrightnessControlService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -134,12 +131,6 @@ export class HmdAutomationsBigscreenBeyondTabComponent implements OnInit {
     this.appSettingsService.updateSettings({
       bigscreenBeyondBrightnessFanSafety: !this.appSettings.bigscreenBeyondBrightnessFanSafety,
     });
-    // Set brightness to same value to reset fan safety if needed
-    this.hardwareBrightness.setBrightness(
-      this.hardwareBrightness.brightness,
-      SET_BRIGHTNESS_OR_CCT_OPTIONS_DEFAULTS,
-      true
-    );
   }
 
   protected readonly MIN_SAFE_FAN_SPEED = MIN_SAFE_FAN_SPEED;

--- a/src-ui/app/views/dashboard-view/views/settings-brightness-cct-view/settings-brightness-cct-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-brightness-cct-view/settings-brightness-cct-view.component.ts
@@ -1,11 +1,9 @@
 import { Component, DestroyRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { APP_SETTINGS_DEFAULT, AppSettings } from '../../../../models/settings';
 import { AppSettingsService } from '../../../../services/app-settings.service';
-import { HardwareBrightnessControlService } from '../../../../services/brightness-control/hardware-brightness-control.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { VALVE_INDEX_HARDWARE_BRIGHTNESS_CONTROL_DRIVER_BOUNDS } from '../../../../services/brightness-control/hardware-brightness-drivers/valve-index-hardware-brightness-control-driver';
 import { BIGSCREEN_BEYOND_HARDWARE_BRIGHTNESS_CONTROL_DRIVER_BOUNDS } from '../../../../services/brightness-control/hardware-brightness-drivers/bigscreen-beyond-hardware-brightness-control-driver';
-import { SET_BRIGHTNESS_OR_CCT_OPTIONS_DEFAULTS } from '../../../../services/brightness-control/brightness-control-models';
 import { clamp } from '../../../../utils/number-utils';
 
 @Component({
@@ -20,8 +18,7 @@ export class SettingsBrightnessCctViewComponent implements OnInit {
 
   constructor(
     private appSettingsService: AppSettingsService,
-    private destroyRef: DestroyRef,
-    private hardwareBrightness: HardwareBrightnessControlService
+    private destroyRef: DestroyRef
   ) {}
 
   ngOnInit() {
@@ -56,12 +53,6 @@ export class SettingsBrightnessCctViewComponent implements OnInit {
     this.appSettingsService.updateSettings({
       bigscreenBeyondBrightnessFanSafety: !this.appSettings.bigscreenBeyondBrightnessFanSafety,
     });
-    // Set brightness to same value to reset fan safety if needed
-    this.hardwareBrightness.setBrightness(
-      this.hardwareBrightness.brightness,
-      SET_BRIGHTNESS_OR_CCT_OPTIONS_DEFAULTS,
-      true
-    );
   }
 
   toggleBigscreenBeyondUnsafeBrightness() {


### PR DESCRIPTION
Disabling the Bigscreen Beyond overdrive fan safety while brightness stayed above 100% left the fan pinned at 100% and the manual fan slider disabled. Only lowering brightness below 100% or restarting the app released it.

The restoration branch in `bigscreen-beyond-fan-automation.service.ts` tested brightness alone. With the setting disabled at brightness 120, neither the activation nor the restoration condition matched, so the latch stayed set. Both setting views tried to work around this by republishing the current brightness, which the safety stream drops as a duplicate.

The restoration branch now also fires when the setting itself turns off. The two views no longer republish brightness, so toggling the setting stops writing to the display and stops cancelling a running brightness transition.

Clearing the latch also restores MQTT fan availability, which reads the same flag.

## Verification

Checked on a connected Bigscreen Beyond (LHR-26C1815C), capped at 104% brightness rather than 120%:

1. Saved a manual fan speed of 60%, then raised hardware brightness to 104%.
2. Fan safety activated: fan went to 100% and the manual slider reported `pointer-events: none`.
3. Disabled fan safety with brightness still at 104%: fan returned to 60% and the slider reported `pointer-events: all`.
4. Lowered brightness back to 100% or below: the same restoration still works.

`bigscreen-beyond-fan-automation.service.spec.ts` covers the three service-level cases and is wired into `npm run test:ui`. Reverting the predicate to the old brightness-only condition fails two of them, and removing the latch clear fails three.

`ng build oyasumivr`, `ng lint`, and `npm test` pass.

## Reviewer note

`test:ui` names each spec file by hand, so a third spec would silently not run. That predates this branch and is tracked separately.
