### PR TITLE
fix(OYASUMIVR-14): apply the sleep-mode guard on hmd reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed the sunset and sunrise brightness automations running when your headset reconnected while
+  sleep mode was on, even with "Only while sleep mode is disabled" enabled
 - Fixed clicks and slider drags failing when both controllers pointed at the VR overlay
 - Fixed queued controller and tracker power-off requests targeting the wrong device when SteamVR
   reused its device index

--- a/src-ui/app/services/brightness-cct-automation.service.spec.ts
+++ b/src-ui/app/services/brightness-cct-automation.service.spec.ts
@@ -1,0 +1,280 @@
+import { BehaviorSubject } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import type { AutomationConfigService } from './automation-config.service';
+import type { SleepService } from './sleep.service';
+import {
+  AUTOMATION_CONFIGS_DEFAULT,
+  type BrightnessAutomationsConfig,
+  type BrightnessEvent,
+} from '../models/automations';
+import { BrightnessCctAutomationService } from './brightness-cct-automation.service';
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  error: vi.fn(async () => {}),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => ['07:00', '19:00']),
+}));
+
+type Overrides = Partial<BrightnessAutomationsConfig>;
+
+function buildConfig(overrides: Overrides = {}): BrightnessAutomationsConfig {
+  const config = structuredClone(AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS);
+  config.AT_SUNSET.enabled = true;
+  config.AT_SUNSET.activationTime = '19:00';
+  config.AT_SUNRISE.enabled = true;
+  config.AT_SUNRISE.activationTime = '07:00';
+  return Object.assign(config, structuredClone(overrides));
+}
+
+function createService(config: BrightnessAutomationsConfig, sleepMode: boolean) {
+  const configs = new BehaviorSubject({ BRIGHTNESS_AUTOMATIONS: config });
+  // the selection reads only the config and sleep observables; the control services stay unused
+  const unused = {} as never;
+  return new BrightnessCctAutomationService(
+    { configs: configs.asObservable() } as unknown as AutomationConfigService,
+    { mode: new BehaviorSubject(sleepMode).asObservable() } as unknown as SleepService,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused
+  );
+}
+
+async function decideAt(
+  config: BrightnessAutomationsConfig,
+  sleepMode: boolean,
+  hour: number
+): Promise<{ brightness?: BrightnessEvent; cct?: BrightnessEvent }> {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2026, 0, 15, hour, 0, 0));
+  try {
+    const result = await createService(config, sleepMode).determineHmdConnectAutomations();
+    return { brightness: result.brightnessAutomation, cct: result.cctAutomation };
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+const sleepEnableOn = {
+  SLEEP_MODE_ENABLE: {
+    ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_ENABLE,
+    enabled: true,
+  },
+} satisfies Overrides;
+
+const sleepDisableOn = {
+  SLEEP_MODE_DISABLE: {
+    ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.SLEEP_MODE_DISABLE,
+    enabled: true,
+  },
+} satisfies Overrides;
+
+const SUNSET_HOUR = 20;
+const SUNRISE_HOUR = 8;
+
+interface Case {
+  name: string;
+  overrides: Overrides;
+  sleepMode: boolean;
+  hour: number;
+  brightness?: BrightnessEvent;
+  cct?: BrightnessEvent;
+}
+
+const cases: Case[] = [
+  {
+    name: 'excludes a guarded sunset while sleep mode is on, on both channels',
+    overrides: sleepEnableOn,
+    sleepMode: true,
+    hour: SUNSET_HOUR,
+    brightness: 'SLEEP_MODE_ENABLE',
+    cct: 'SLEEP_MODE_ENABLE',
+  },
+  {
+    name: 'keeps a guarded sunset while sleep mode is off',
+    overrides: sleepDisableOn,
+    sleepMode: false,
+    hour: SUNSET_HOUR,
+    brightness: 'AT_SUNSET',
+    cct: 'AT_SUNSET',
+  },
+  {
+    name: 'keeps an unguarded sunset while sleep mode is on',
+    overrides: {
+      ...sleepEnableOn,
+      AT_SUNSET: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNSET,
+        enabled: true,
+        activationTime: '19:00',
+        onlyWhenSleepDisabled: false,
+      },
+    },
+    sleepMode: true,
+    hour: SUNSET_HOUR,
+    brightness: 'AT_SUNSET',
+    cct: 'AT_SUNSET',
+  },
+  {
+    name: 'excludes a guarded sunrise while sleep mode is on, on both channels',
+    overrides: sleepEnableOn,
+    sleepMode: true,
+    hour: SUNRISE_HOUR,
+    brightness: 'SLEEP_MODE_ENABLE',
+    cct: 'SLEEP_MODE_ENABLE',
+  },
+  {
+    name: 'keeps an unguarded sunrise while sleep mode is on',
+    overrides: {
+      ...sleepEnableOn,
+      AT_SUNRISE: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNRISE,
+        enabled: true,
+        activationTime: '07:00',
+        onlyWhenSleepDisabled: false,
+      },
+    },
+    sleepMode: true,
+    hour: SUNRISE_HOUR,
+    brightness: 'AT_SUNRISE',
+    cct: 'AT_SUNRISE',
+  },
+  {
+    name: 'keeps a guarded sunrise while sleep mode is off',
+    overrides: sleepDisableOn,
+    sleepMode: false,
+    hour: SUNRISE_HOUR,
+    brightness: 'AT_SUNRISE',
+    cct: 'AT_SUNRISE',
+  },
+  {
+    name: 'leaves the HMD connect brightness override and falls back on the free channel',
+    overrides: {
+      ...sleepEnableOn,
+      HMD_CONNECT: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.HMD_CONNECT,
+        enabled: true,
+        changeColorTemperature: false,
+      },
+    },
+    sleepMode: true,
+    hour: SUNSET_HOUR,
+    brightness: 'HMD_CONNECT',
+    cct: 'SLEEP_MODE_ENABLE',
+  },
+  {
+    name: 'leaves the free channel on sunset when sleep mode is off',
+    overrides: {
+      ...sleepDisableOn,
+      HMD_CONNECT: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.HMD_CONNECT,
+        enabled: true,
+        changeColorTemperature: false,
+      },
+    },
+    sleepMode: false,
+    hour: SUNSET_HOUR,
+    brightness: 'HMD_CONNECT',
+    cct: 'AT_SUNSET',
+  },
+  {
+    name: 'selects no event when the guard excludes sunset and no sleep event is enabled',
+    overrides: {},
+    sleepMode: true,
+    hour: SUNSET_HOUR,
+    brightness: undefined,
+    cct: undefined,
+  },
+  {
+    name: 'falls back on both channels when a guarded sunset changes brightness only',
+    overrides: {
+      ...sleepEnableOn,
+      AT_SUNSET: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNSET,
+        enabled: true,
+        activationTime: '19:00',
+        changeColorTemperature: false,
+      },
+    },
+    sleepMode: true,
+    hour: SUNSET_HOUR,
+    brightness: 'SLEEP_MODE_ENABLE',
+    cct: 'SLEEP_MODE_ENABLE',
+  },
+  {
+    name: 'excludes a guarded sunrise selected by inverted activation times',
+    overrides: {
+      ...sleepEnableOn,
+      AT_SUNRISE: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNRISE,
+        enabled: true,
+        activationTime: '22:00',
+      },
+      AT_SUNSET: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNSET,
+        enabled: true,
+        activationTime: '06:00',
+      },
+    },
+    sleepMode: true,
+    hour: 23,
+    brightness: 'SLEEP_MODE_ENABLE',
+    cct: 'SLEEP_MODE_ENABLE',
+  },
+  {
+    name: 'keeps an unguarded sunset selected by inverted activation times',
+    overrides: {
+      ...sleepEnableOn,
+      AT_SUNRISE: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNRISE,
+        enabled: true,
+        activationTime: '22:00',
+      },
+      AT_SUNSET: {
+        ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS.AT_SUNSET,
+        enabled: true,
+        activationTime: '06:00',
+        onlyWhenSleepDisabled: false,
+      },
+    },
+    sleepMode: true,
+    hour: 10,
+    brightness: 'AT_SUNSET',
+    cct: 'AT_SUNSET',
+  },
+];
+
+describe('BrightnessCctAutomationService HMD connect selection', () => {
+  for (const testCase of cases) {
+    it(testCase.name, async () => {
+      const result = await decideAt(
+        buildConfig(testCase.overrides),
+        testCase.sleepMode,
+        testCase.hour
+      );
+      expect(result).toEqual({ brightness: testCase.brightness, cct: testCase.cct });
+    });
+  }
+
+  it('still offers a guarded solar event as a potential automation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15, SUNSET_HOUR, 0, 0));
+    try {
+      const service = createService(buildConfig(sleepEnableOn), true);
+      const result = await service.determineHmdConnectAutomations();
+      expect(result.brightnessAutomation).toBe('SLEEP_MODE_ENABLE');
+      expect(result.potentialBrightnessAutomations).toContain('AT_SUNSET');
+      expect(result.potentialBrightnessAutomations).toContain('AT_SUNRISE');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src-ui/app/services/brightness-cct-automation.service.ts
+++ b/src-ui/app/services/brightness-cct-automation.service.ts
@@ -330,7 +330,6 @@ export class BrightnessCctAutomationService {
         activeAutomation = sunsetEnabled && options.currentTime >= sunsetTime ? 'AT_SUNSET' : null;
       }
 
-      // the sleep-mode guard makes a solar event ineligible, as it does on the scheduled trigger
       if (activeAutomation && options.sleepMode && config[activeAutomation].onlyWhenSleepDisabled)
         activeAutomation = null;
 

--- a/src-ui/app/services/brightness-cct-automation.service.ts
+++ b/src-ui/app/services/brightness-cct-automation.service.ts
@@ -296,7 +296,7 @@ export class BrightnessCctAutomationService {
     if (sunriseEnabled || sunsetEnabled) {
       // Determine if the sunrise and sunset times are inverted (sunset time is earlier than sunrise time)
       // and which automation to use based on the current time
-      let activeAutomation: BrightnessEvent | null = null;
+      let activeAutomation: 'AT_SUNRISE' | 'AT_SUNSET' | null = null;
 
       if (sunriseTime !== null && sunsetTime !== null) {
         // Both times available - similar to original logic
@@ -329,6 +329,10 @@ export class BrightnessCctAutomationService {
         // Use sunset automation after sunset time (until midnight)
         activeAutomation = sunsetEnabled && options.currentTime >= sunsetTime ? 'AT_SUNSET' : null;
       }
+
+      // the sleep-mode guard makes a solar event ineligible, as it does on the scheduled trigger
+      if (activeAutomation && options.sleepMode && config[activeAutomation].onlyWhenSleepDisabled)
+        activeAutomation = null;
 
       // Apply the active automation if any
       if (activeAutomation) {


### PR DESCRIPTION
When the HMD reconnected while sleep mode stayed on, OyasumiVR could apply the "At sunset" or "At sunrise" brightness and color temperature even when that event had "Only while sleep mode is disabled" turned on. It overwrote the sleep values with no transition and no event-log entry.

The reconnect decision received the sleep state but never read each solar event's `onlyWhenSleepDisabled` flag. Only the scheduled minute trigger checked it, so the two paths used different rules.

The reconnect decision now drops the time-selected sunset or sunrise candidate while sleep mode is on and that event carries the guard. Selection falls through to the sleep-mode event, or to no event. Per-channel priority is unchanged.

The guard sits after time selection rather than inside the enabled flags. Those flags also choose between the configured activation time and the automatic one, so folding the guard in would shift the active window and could change which event the other channel selects.

## Verification

`npm test`, `tsc -p tsconfig.app.json --noEmit`, eslint, and prettier pass.

`src-ui/app/services/brightness-cct-automation.service.spec.ts` is new and named in the `test:ui` script. Its 13 table-driven cases cover sunrise and sunset, brightness and color temperature, both sleep states, the guard both ways, HMD-connect channel overrides, inverted activation times, and the potential-automations list. All 13 pass. Seven fail against the selection as it stood before the fix.

In the running app, the brightness automations list marks which event fires on HMD connect, from the same decision. With "At sunset" enabled and its guard on:

- sleep mode off: "At sunset" is the active event.
- sleep mode on: "At sunset" drops to potential, and "When I go to sleep" becomes active.
- guard turned off, sleep mode still on: "At sunset" is active again.

The apply path needs a real headset reconnect, which I did not perform. It consumes this decision without filtering it further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sunrise and sunset brightness automations marked “Only while sleep mode is disabled” from running when a headset reconnects during sleep mode.
  - Ensured brightness and color temperature automation selection respects sleep-mode settings consistently.

- **Tests**
  - Added coverage for sleep-mode safeguards, headset reconnection behavior, guarded and unguarded solar events, and inverted activation times.

- **Documentation**
  - Added an unreleased changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->