### PR TITLE
fix(OYASUMIVR-47): play the leave sound without a leave notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed the leave sound never playing when the leave notification was turned off
 - Fixed the sunset and sunrise brightness automations running when your headset reconnected while
   sleep mode was on, even with "Only while sleep mode is disabled" enabled
 - Fixed clicks and slider drags failing when both controllers pointed at the VR overlay

--- a/src-ui/app/services/join-notifications.service.spec.ts
+++ b/src-ui/app/services/join-notifications.service.spec.ts
@@ -1,0 +1,83 @@
+import { BehaviorSubject, Subject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TranslocoService } from '@jsverse/transloco';
+import type { AutomationConfigService } from './automation-config.service';
+import type { NotificationService } from './notification.service';
+import type { SleepService } from './sleep.service';
+import type { VRChatService } from './vrchat-api/vrchat.service';
+import type { VRChatLogService } from './vrchat-log.service';
+import { AUTOMATION_CONFIGS_DEFAULT, type AutomationConfigs } from '../models/automations';
+import type { VRChatLogEvent } from '../models/vrchat-log-event';
+import { JoinNotificationsService } from './join-notifications.service';
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+
+function configs(overrides: Partial<AutomationConfigs['JOIN_NOTIFICATIONS']>): AutomationConfigs {
+  const configs = structuredClone(AUTOMATION_CONFIGS_DEFAULT);
+  Object.assign(configs.JOIN_NOTIFICATIONS, { enabled: true }, overrides);
+  return configs;
+}
+
+function createService(overrides: Partial<AutomationConfigs['JOIN_NOTIFICATIONS']>) {
+  const logEvents = new Subject<VRChatLogEvent>();
+  const send = vi.fn(async () => null);
+  const playSoundConfig = vi.fn(async () => {});
+  const service = new JoinNotificationsService(
+    { configs: new BehaviorSubject(configs(overrides)) } as unknown as AutomationConfigService,
+    { mode: new BehaviorSubject(false) } as unknown as SleepService,
+    {
+      user: new BehaviorSubject({ displayName: 'Me' }),
+      world: new BehaviorSubject({ players: [], loaded: true, instanceId: 'instance' }),
+      vrchatProcessActive: new BehaviorSubject(true),
+      listFriends: async () => [],
+    } as unknown as VRChatService,
+    { send, playSoundConfig } as unknown as NotificationService,
+    { logEvents } as unknown as VRChatLogService,
+    { translate: () => 'message' } as unknown as TranslocoService
+  );
+  return { service, logEvents, send, playSoundConfig };
+}
+
+// the queue delays each entry by 500ms before it fires
+async function emit(
+  harness: ReturnType<typeof createService>,
+  type: 'OnPlayerJoined' | 'OnPlayerLeft'
+) {
+  await harness.service.init();
+  harness.logEvents.next({ type, displayName: 'Other' } as VRChatLogEvent);
+  await vi.advanceTimersByTimeAsync(1000);
+}
+
+describe('JoinNotificationsService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('plays the leave sound when only the leave sound mode selects the player', async () => {
+    const harness = createService({ leaveNotification: 'DISABLED', leaveSoundMode: 'EVERYONE' });
+    await emit(harness, 'OnPlayerLeft');
+    expect(harness.playSoundConfig).toHaveBeenCalledTimes(1);
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when neither leave mode selects the player', async () => {
+    const harness = createService({ leaveNotification: 'DISABLED', leaveSoundMode: 'DISABLED' });
+    await emit(harness, 'OnPlayerLeft');
+    expect(harness.playSoundConfig).not.toHaveBeenCalled();
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+
+  it('sends the leave notification when only the leave notification selects the player', async () => {
+    const harness = createService({ leaveNotification: 'EVERYONE', leaveSoundMode: 'DISABLED' });
+    await emit(harness, 'OnPlayerLeft');
+    expect(harness.send).toHaveBeenCalledTimes(1);
+    expect(harness.playSoundConfig).not.toHaveBeenCalled();
+  });
+
+  it('plays the join sound when only the join sound mode selects the player', async () => {
+    const harness = createService({ joinNotification: 'DISABLED', joinSoundMode: 'EVERYONE' });
+    await emit(harness, 'OnPlayerJoined');
+    expect(harness.playSoundConfig).toHaveBeenCalledTimes(1);
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+});

--- a/src-ui/app/services/join-notifications.service.ts
+++ b/src-ui/app/services/join-notifications.service.ts
@@ -134,7 +134,6 @@ export class JoinNotificationsService {
           }
           // Send sound
           if (val.sound) {
-            // TODO: Play the sound
             switch (val.type) {
               case 'join':
                 await this.notification.playSoundConfig(this.config.joinSound);
@@ -214,7 +213,7 @@ export class JoinNotificationsService {
     const sound = this.appliesForPlayer(this.config.leaveSoundMode, displayName);
 
     // Stop here if no notification or sound
-    if (!notification) return;
+    if (!notification && !sound) return;
 
     // World player count check
     if (this.config.onlyWhenLeftAlone) {


### PR DESCRIPTION
OyasumiVR played the leave sound only when the leave notification was also enabled. With the notification off, the sound never played.

`JoinNotificationsService.onPlayerLeft` computed both the notification and the sound flag, then returned early on the notification alone. The join path guards on both, so the leave guard dropped every sound-only leave before it reached the queue. The leave guard now returns early only when the notification and the sound both exclude the player.

A new spec covers the join and leave paths of `JoinNotificationsService`.

Verification:

- `npm test` (70 tests), `ng lint`, and `tsc --noEmit` pass on develop as of a2b27b80.
- I ran the desktop app with Leave Notifications set to For Nobody and Leave Sounds set to For everyone. I then fed a player leave through the VRChat log. The leave sound played and no leave notification appeared.
- With the guard reverted, the same leave played no sound. The join path played its sound in both runs.
