### PR TITLE
fix(OYASUMIVR-1): stop reporting a rejected console executable as working

### DIFF
--- a/src-ui/app/services/lighthouse-console.service.spec.ts
+++ b/src-ui/app/services/lighthouse-console.service.spec.ts
@@ -108,8 +108,9 @@ describe('LighthouseConsoleService.setConsolePath', () => {
     expect(await firstValueFrom(service.consoleStatus)).toBe('NOT_FOUND');
   });
 
-  it('leaves the power-off path unused while the status is UNKNOWN', async () => {
+  it('leaves the power-off path unused before any path is accepted', async () => {
     const service = await createService('unexpected');
+    expect(await firstValueFrom(service.consoleStatus)).toBe('NOT_FOUND');
     invoke.mockClear();
     await service.turnOffDevices([device]);
     expect(invoke).not.toHaveBeenCalled();

--- a/src-ui/app/services/lighthouse-console.service.spec.ts
+++ b/src-ui/app/services/lighthouse-console.service.spec.ts
@@ -1,0 +1,117 @@
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppSettingsService } from './app-settings.service';
+import type { OpenVRService } from './openvr.service';
+import { APP_SETTINGS_DEFAULT, type AppSettings } from '../models/settings';
+import type { OVRDevice } from '../models/ovr-device';
+import { LighthouseConsoleService } from './lighthouse-console.service';
+
+const invoke = vi.hoisted(() => vi.fn());
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/plugin-log', () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }));
+
+const PATH = 'C:\\stub\\lighthouse_console.exe';
+
+const device: OVRDevice = {
+  index: 1,
+  class: 'Controller',
+  serialNumber: 'SERIAL-1',
+  dongleId: 'DONGLE-1',
+  canPowerOff: true,
+  isTurningOff: false,
+} as OVRDevice;
+
+async function createService(stdout: string) {
+  const settings = new BehaviorSubject<AppSettings>({
+    ...APP_SETTINGS_DEFAULT,
+    lighthouseConsolePath: '',
+  });
+  const appSettings = {
+    settings: settings.asObservable(),
+    updateSettings: vi.fn(),
+  } as unknown as AppSettingsService;
+  const openvr = {
+    devices: new BehaviorSubject<OVRDevice[]>([device]).asObservable(),
+    onDeviceUpdate: vi.fn(),
+  } as unknown as OpenVRService;
+  const service = new LighthouseConsoleService(appSettings, openvr);
+  // let the constructor's init() settle before the test drives the service
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  invoke.mockImplementation(async () => ({ stdout, stderr: '', status: 0 }));
+  return service;
+}
+
+describe('LighthouseConsoleService.setConsolePath', () => {
+  beforeEach(() => invoke.mockReset());
+
+  it('keeps INVALID_EXECUTABLE as the final status for an unexpected banner', async () => {
+    const service = await createService('unexpected');
+    await service.setConsolePath(PATH, false);
+    expect(await firstValueFrom(service.consoleStatus)).toBe('INVALID_EXECUTABLE');
+  });
+
+  it('keeps INVALID_EXECUTABLE for empty output', async () => {
+    const service = await createService('');
+    await service.setConsolePath(PATH, false);
+    expect(await firstValueFrom(service.consoleStatus)).toBe('INVALID_EXECUTABLE');
+  });
+
+  it('emits no SUCCESS at any point for an unexpected banner', async () => {
+    const service = await createService('unexpected');
+    const seen: string[] = [];
+    const sub = service.consoleStatus.subscribe((s) => seen.push(s));
+    await service.setConsolePath(PATH, false);
+    sub.unsubscribe();
+    expect(seen).not.toContain('SUCCESS');
+    expect(seen.at(-1)).toBe('INVALID_EXECUTABLE');
+  });
+
+  it('does not run the executable for power-off after a rejected path', async () => {
+    const service = await createService('unexpected');
+    await service.setConsolePath(PATH, false);
+    invoke.mockClear();
+    await service.turnOffDevices([device]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('still reports SUCCESS for a matching banner', async () => {
+    const service = await createService('Version:  lighthouse_console.exe 1.0\nmore');
+    await service.setConsolePath(PATH, false);
+    expect(await firstValueFrom(service.consoleStatus)).toBe('SUCCESS');
+  });
+
+  it('recovers to SUCCESS after a rejected path', async () => {
+    const service = await createService('unexpected');
+    await service.setConsolePath(PATH, false);
+    invoke.mockImplementation(async () => ({
+      stdout: 'Version:  lighthouse_console.exe 1.0',
+      stderr: '',
+      status: 0,
+    }));
+    await service.setConsolePath(PATH, false);
+    expect(await firstValueFrom(service.consoleStatus)).toBe('SUCCESS');
+  });
+
+  it('runs the executable for power-off once the path is accepted', async () => {
+    const service = await createService('Version:  lighthouse_console.exe 1.0');
+    await service.setConsolePath(PATH, false);
+    invoke.mockClear();
+    await service.turnOffDevices([device]);
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it('reports NOT_FOUND for a path with the wrong filename', async () => {
+    const service = await createService('unexpected');
+    await service.setConsolePath('C:\\stub\\other.exe', false);
+    expect(await firstValueFrom(service.consoleStatus)).toBe('NOT_FOUND');
+  });
+
+  it('leaves the power-off path unused while the status is UNKNOWN', async () => {
+    const service = await createService('unexpected');
+    invoke.mockClear();
+    await service.turnOffDevices([device]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -92,6 +92,7 @@ export class LighthouseConsoleService {
       !stdoutLines[0].trim().startsWith('Version:  lighthouse_console.exe')
     ) {
       this._consoleStatus.next('INVALID_EXECUTABLE');
+      return;
     }
     this._consoleStatus.next('SUCCESS');
   }

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -61,7 +61,6 @@ export class LighthouseConsoleService {
       this._consoleStatus.next('NOT_FOUND');
       return;
     }
-    // Get output
     let stdout;
     try {
       stdout = (
@@ -85,7 +84,6 @@ export class LighthouseConsoleService {
       this._consoleStatus.next('UNKNOWN_ERROR');
       return;
     }
-    // Check output
     const stdoutLines = stdout.split('\n');
     if (
       !stdoutLines.length ||


### PR DESCRIPTION
Picking a `lighthouse_console.exe` that starts but prints an unexpected first line showed the green "has been found and is working correctly" alert. OyasumiVR also cleared the "Lighthouse Console Unavailable" warning from the message center and kept device power-off enabled, so turning off controllers and trackers failed against a path the app called healthy.

`setConsolePath` emitted `INVALID_EXECUTABLE` and then fell through to the `SUCCESS` emission on the next line. `consoleStatus` is a `BehaviorSubject`, so `SUCCESS` became the retained value immediately and every consumer read it. The invalid-signature branch now returns.

## Verification

`npm run test`, `npm run lint`, and `npx ng build oyasumivr` pass.

`src-ui/app/services/lighthouse-console.service.spec.ts` is new: 9 tests over both sides of that branch, the power-off guard, and the recovery path. Removing the one-line fix fails 4 of them.

Manual run in the desktop app, with a stub `lighthouse_console.exe` that prints a different first line:

- General Settings shows the red "could not be verified as working" alert.
- The message center keeps the "Lighthouse Console Unavailable" warning.
- Clicking power-off on a controller runs nothing. The stub recorded every invocation and stayed empty.
- Swapping in a stub that prints the expected banner makes the same click run it with `/serial <dongleId> poweroff`.
- Setting the path back to the real SteamVR executable restores the green alert and clears the warning.

## Left out

The event log still records "Turned off a controller" after a blocked power-off. All three call sites log that event without checking whether anything ran, which predates this change and applies to `NOT_FOUND` and the other failure statuses too. It has its own ticket.

Overlapping validations can still leave a stale status. `setConsolePath` does not sequence its calls, so a slow probe of a valid path finishing after a fast probe of a rejected one leaves `SUCCESS`, and power-off then runs the rejected executable. I reproduced this, it predates this change, and it has its own ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved executable validation when configuring the Lighthouse Console path.
  - Invalid executables are now rejected immediately when their version header is incorrect, ensuring the service reports the correct status and avoids further processing.

- **Tests**
  - Expanded automated coverage for executable validation, status transitions, recovery behavior, path errors, and power-off execution safeguards.
  - Included Lighthouse Console service tests in the UI test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

