### PR TITLE
fix(OYASUMIVR-25): clear the busy marker when a lighthouse power command fails

### DIFF
--- a/src-ui/app/services/lighthouse.service.spec.ts
+++ b/src-ui/app/services/lighthouse.service.spec.ts
@@ -2,6 +2,10 @@ import { BehaviorSubject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppSettingsService } from './app-settings.service';
 import type { LighthouseDevice } from '../models/lighthouse-device';
+import {
+  DevicePowerButtonComponent,
+  type DevicePowerState,
+} from '../components/device-power-button/device-power-button.component';
 
 const invoke = vi.fn();
 
@@ -19,6 +23,20 @@ function device(): LighthouseDevice {
     v1Timeout: null,
     transitioningToPowerState: undefined,
   };
+}
+
+// mirrors the mapping in DeviceListItemComponent
+function powerButtonFor(d: LighthouseDevice): DevicePowerButtonComponent {
+  const state: DevicePowerState = d.transitioningToPowerState
+    ? d.transitioningToPowerState === 'on'
+      ? 'turning-on'
+      : 'turning-off'
+    : d.powerState === 'on'
+      ? 'on'
+      : 'off';
+  const button = new DevicePowerButtonComponent();
+  button.powerState = state;
+  return button;
 }
 
 function makeService(d: LighthouseDevice) {
@@ -49,12 +67,15 @@ describe('LighthouseService.setPowerState', () => {
       () => 'resolved',
       (e: Error) => e.message
     );
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(powerButtonFor(d).canClick).toBe(false);
+    await vi.advanceTimersByTimeAsync(4500);
 
     expect(await settled).toBe('WRITE_FAILED');
     expect(invoke).toHaveBeenCalledTimes(4);
     expect(d.transitioningToPowerState).toBeUndefined();
     expect(emissions).toEqual([undefined, 'sleep', undefined]);
+    expect(powerButtonFor(d).canClick).toBe(true);
   });
 
   it('clears the transition marker once the device confirms the new state', async () => {

--- a/src-ui/app/services/lighthouse.service.spec.ts
+++ b/src-ui/app/services/lighthouse.service.spec.ts
@@ -1,0 +1,124 @@
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppSettingsService } from './app-settings.service';
+import type { LighthouseDevice } from '../models/lighthouse-device';
+
+const invoke = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+
+import { LighthouseService } from './lighthouse.service';
+
+function device(): LighthouseDevice {
+  return {
+    id: 'dev-1',
+    deviceName: 'LHB-1',
+    deviceType: 'lighthouseV2',
+    powerState: 'on',
+    v1Timeout: null,
+    transitioningToPowerState: undefined,
+  };
+}
+
+function makeService(d: LighthouseDevice) {
+  const appSettings = {
+    settings: new BehaviorSubject({ v1LighthouseIdentifiers: {} }),
+  } as unknown as AppSettingsService;
+  const service = new LighthouseService(appSettings);
+  service['_devices'].next([d]);
+  return service;
+}
+
+describe('LighthouseService.setPowerState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    invoke.mockReset();
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('clears the transition marker after every attempt fails, and still rejects', async () => {
+    invoke.mockRejectedValue(new Error('WRITE_FAILED'));
+    const d = device();
+    const service = makeService(d);
+    const emissions: (string | undefined)[] = [];
+    service.devices.subscribe((devices) => emissions.push(devices[0].transitioningToPowerState));
+
+    const settled = service.setPowerState(d, 'sleep').then(
+      () => 'resolved',
+      (e: Error) => e.message
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(await settled).toBe('WRITE_FAILED');
+    expect(invoke).toHaveBeenCalledTimes(4);
+    expect(d.transitioningToPowerState).toBeUndefined();
+    expect(emissions).toEqual([undefined, 'sleep', undefined]);
+  });
+
+  it('clears the transition marker once the device confirms the new state', async () => {
+    invoke.mockResolvedValue(undefined);
+    const d = device();
+    const service = makeService(d);
+
+    const settled = service.setPowerState(d, 'sleep');
+    d.powerState = 'sleep';
+    await vi.advanceTimersByTimeAsync(1000);
+    await settled;
+
+    expect(d.transitioningToPowerState).toBeUndefined();
+  });
+
+  it('clears the transition marker after the ten second confirmation timeout', async () => {
+    invoke.mockResolvedValue(undefined);
+    const d = device();
+    const service = makeService(d);
+
+    const settled = service.setPowerState(d, 'sleep');
+    await vi.advanceTimersByTimeAsync(10000);
+    await settled;
+
+    expect(d.transitioningToPowerState).toBeUndefined();
+  });
+
+  it('does not let an older failed operation clear a newer transition', async () => {
+    invoke.mockImplementation(async (_command: string, args: { powerState: string }) => {
+      if (args.powerState === 'sleep') throw new Error('WRITE_FAILED');
+    });
+    const d = device();
+    // start asleep, so the newer 'on' command cannot confirm before the older one settles
+    d.powerState = 'sleep';
+    const service = makeService(d);
+
+    const older = service.setPowerState(d, 'sleep').catch(() => 'failed');
+    const newer = service.setPowerState(d, 'on');
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(await older).toBe('failed');
+    expect(d.transitioningToPowerState).toBe('on');
+
+    d.powerState = 'on';
+    await vi.advanceTimersByTimeAsync(11000);
+    await newer;
+    expect(d.transitioningToPowerState).toBeUndefined();
+  });
+
+  it('does not let a forced operation clear a concurrent transition', async () => {
+    invoke.mockResolvedValue(undefined);
+    const d = device();
+    const service = makeService(d);
+
+    const normal = service.setPowerState(d, 'sleep');
+    const forced = service.setPowerState(d, 'on', true);
+    d.powerState = 'on';
+    await vi.advanceTimersByTimeAsync(1000);
+    await forced;
+
+    expect(d.transitioningToPowerState).toBe('sleep');
+
+    await vi.advanceTimersByTimeAsync(10000);
+    await normal;
+    expect(d.transitioningToPowerState).toBeUndefined();
+  });
+});

--- a/src-ui/app/services/lighthouse.service.ts
+++ b/src-ui/app/services/lighthouse.service.ts
@@ -131,7 +131,7 @@ export class LighthouseService {
       }
       v1Identifier = parseInt(this.v1Identifiers[device.id], 16);
     }
-    // Handle force flag
+    // handle force flag
     let transition: number | undefined;
     if (!force) {
       transition = ++this.lastTransitionId;
@@ -142,7 +142,7 @@ export class LighthouseService {
       this._devices.next(this._devices.value);
     }
     try {
-      // Set the power state
+      // set the power state
       await pRetry(
         () =>
           invoke('lighthouse_set_device_power_state', {
@@ -153,7 +153,7 @@ export class LighthouseService {
         3,
         500
       );
-      // Wait for state to change (timeout after 10 seconds)
+      // wait for state to change (timeout after 10 seconds)
       await firstValueFrom(
         merge(
           interval(100).pipe(
@@ -166,7 +166,7 @@ export class LighthouseService {
         ).pipe(take(1))
       );
     } finally {
-      // Only the transition that still owns the marker may clear it
+      // only the owning operation may clear the marker
       if (transition !== undefined && this.transitions[device.id] === transition) {
         delete this.transitions[device.id];
         device.transitioningToPowerState = undefined;

--- a/src-ui/app/services/lighthouse.service.ts
+++ b/src-ui/app/services/lighthouse.service.ts
@@ -56,6 +56,8 @@ export class LighthouseService {
   >([]);
   public readonly devices: Observable<LighthouseDevice[]> = this._devices.asObservable();
   private v1Identifiers: { [id: string]: string } = {};
+  private transitions: { [deviceId: string]: number } = {};
+  private lastTransitionId = 0;
 
   constructor(private appSettings: AppSettingsService) {}
 
@@ -130,37 +132,47 @@ export class LighthouseService {
       v1Identifier = parseInt(this.v1Identifiers[device.id], 16);
     }
     // Handle force flag
+    let transition: number | undefined;
     if (!force) {
+      transition = ++this.lastTransitionId;
+      this.transitions[device.id] = transition;
       device.transitioningToPowerState = ['on', 'sleep', 'standby'].includes(powerState)
         ? powerState
         : undefined;
       this._devices.next(this._devices.value);
     }
-    // Set the power state
-    await pRetry(
-      () =>
-        invoke('lighthouse_set_device_power_state', {
-          deviceId: device.id,
-          powerState,
-          v1Identifier,
-        }),
-      3,
-      500
-    );
-    // Wait for state to change (timeout after 10 seconds)
-    await firstValueFrom(
-      merge(
-        interval(100).pipe(
-          delay(500), // Wait 500ms before checking, to make sure the feedback in the UI lasts long enough
-          filter(() =>
-            this._devices.value.some((d) => d.id === device.id && d.powerState === powerState)
-          )
-        ),
-        of(null).pipe(delay(10000))
-      ).pipe(take(1))
-    );
-    device.transitioningToPowerState = undefined;
-    this._devices.next(this._devices.value);
+    try {
+      // Set the power state
+      await pRetry(
+        () =>
+          invoke('lighthouse_set_device_power_state', {
+            deviceId: device.id,
+            powerState,
+            v1Identifier,
+          }),
+        3,
+        500
+      );
+      // Wait for state to change (timeout after 10 seconds)
+      await firstValueFrom(
+        merge(
+          interval(100).pipe(
+            delay(500), // Wait 500ms before checking, to make sure the feedback in the UI lasts long enough
+            filter(() =>
+              this._devices.value.some((d) => d.id === device.id && d.powerState === powerState)
+            )
+          ),
+          of(null).pipe(delay(10000))
+        ).pipe(take(1))
+      );
+    } finally {
+      // Only the transition that still owns the marker may clear it
+      if (transition !== undefined && this.transitions[device.id] === transition) {
+        delete this.transitions[device.id];
+        device.transitioningToPowerState = undefined;
+        this._devices.next(this._devices.value);
+      }
+    }
   }
 
   private async handleStatusChange(event: LighthouseStatusChangedEvent) {


### PR DESCRIPTION
A lighthouse power command that failed every retry left the device's power button spinning and disabled. The only ways out were restarting OyasumiVR, resetting the lighthouse list, or a later command that succeeded.

`setPowerState` set the busy marker before it awaited the command, and cleared it only after that await returned. `pRetry` rethrows after its fourth attempt, so the rejection skipped the cleanup. No backend event clears the marker, because it is a frontend-only field.

The command and the confirmation wait now run inside a `try`, and the cleanup runs in `finally`. Each non-force call takes an operation id for the device, and the cleanup runs only while that call still owns the marker, so a late failure cannot clear a newer transition. The rejection still reaches the caller.

## Testing

`src-ui/app/services/lighthouse.service.spec.ts` covers five cases: four failing attempts, a confirmed success, the ten second confirmation timeout, an older failure that overlaps a newer request, and a forced command that overlaps a normal one. Reverting the fix fails two of them.

Checked against three Valve base stations:

- Command sent to a base station whose power was cut: the button went busy after 96 ms and became clickable again after 66 s, once all four backend attempts had timed out. Before this change it stayed disabled.
- Clicking that button again was accepted, and failed fast.
- Normal power off: busy after 97 ms, cleared after 1042 ms, base station asleep.
- Normal power on: busy after 99 ms, cleared after 12939 ms, base station on.

## Not included

A failed command still shows no message to the user. The rejection reaches callers unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved power-state transition handling for devices.
  - Transition indicators now remain accurate during overlapping operations and are cleared correctly after failures, confirmations, or timeouts.
  - Prevented older or concurrent operations from incorrectly clearing the status of a newer transition.

- **Tests**
  - Added coverage for successful, failed, timed-out, forced, and concurrent power-state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
