### PR TITLE
fix(OYASUMIVR-75): reject obsolete executable validations

### DIFF
--- a/src-ui/app/services/executable-validation.spec.ts
+++ b/src-ui/app/services/executable-validation.spec.ts
@@ -1,0 +1,198 @@
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTOMATION_CONFIGS_DEFAULT,
+  type MSIAfterburnerAutomationConfig,
+} from '../models/automations';
+import { APP_SETTINGS_DEFAULT, type AppSettings } from '../models/settings';
+import type { OVRDevice } from '../models/ovr-device';
+import { LighthouseConsoleService } from './lighthouse-console.service';
+import { GpuAutomationsService } from './gpu-automations.service';
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/plugin-log', () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }));
+
+function deferred() {
+  let resolve!: (value: unknown) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createLighthouse() {
+  vi.spyOn(LighthouseConsoleService.prototype, 'init').mockResolvedValue();
+  const settings = new BehaviorSubject({ ...APP_SETTINGS_DEFAULT });
+  const device = { index: 1, serialNumber: 'S1', dongleId: 'D1', canPowerOff: true } as OVRDevice;
+  const service = new LighthouseConsoleService(
+    {
+      settings,
+      updateSettings: (patch: Partial<AppSettings>) =>
+        settings.next({ ...settings.value, ...patch }),
+    } as unknown as ConstructorParameters<typeof LighthouseConsoleService>[0],
+    {
+      devices: new BehaviorSubject([device]),
+      onDeviceUpdate: vi.fn(),
+    } as unknown as ConstructorParameters<typeof LighthouseConsoleService>[1]
+  );
+  return {
+    filename: 'lighthouse_console.exe',
+    success: { stdout: 'Version:  lighthouse_console.exe 1.0' },
+    failure: 'NOT_FOUND',
+    set: (path: string) => service.setConsolePath(path),
+    status: service.consoleStatus,
+    configure: (path: string) => settings.next({ ...settings.value, lighthouseConsolePath: path }),
+    act: () => service.turnOffDevices([device]),
+    actionCall: (path: string) => [
+      'run_command',
+      { command: path, args: ['/serial', 'D1', 'poweroff'] },
+    ],
+  };
+}
+
+function createMSI() {
+  const configs = new BehaviorSubject(structuredClone(AUTOMATION_CONFIGS_DEFAULT));
+  const configure = (path: string) =>
+    configs.next({
+      ...configs.value,
+      MSI_AFTERBURNER: { ...configs.value.MSI_AFTERBURNER, msiAfterburnerPath: path },
+    });
+  const service = new GpuAutomationsService(
+    {
+      configs,
+      updateAutomationConfig: async (
+        _key: string,
+        patch: Partial<MSIAfterburnerAutomationConfig>
+      ) => configure(patch.msiAfterburnerPath!),
+    } as unknown as ConstructorParameters<typeof GpuAutomationsService>[0],
+    {} as ConstructorParameters<typeof GpuAutomationsService>[1],
+    {} as ConstructorParameters<typeof GpuAutomationsService>[2],
+    {} as ConstructorParameters<typeof GpuAutomationsService>[3],
+    { logEvent: vi.fn() } as unknown as ConstructorParameters<typeof GpuAutomationsService>[4]
+  );
+  return {
+    filename: 'MSIAfterburner.exe',
+    success: true,
+    failure: 'ExeNotFound',
+    set: (path: string) => service.setMSIAfterburnerPath(path),
+    status: service.msiAfterburnerStatus,
+    configure,
+    act: () => service.setMSIAfterburnerProfile(1, 'SLEEP_MODE_ENABLED'),
+    actionCall: (path: string) => [
+      'msi_afterburner_set_profile',
+      { executablePath: path, profile: 1 },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  invoke.mockReset();
+});
+
+describe.each([
+  ['lighthouse', createLighthouse],
+  ['MSI', createMSI],
+] as const)('%s executable validation', (_name, create) => {
+  it.each([true, false])(
+    'keeps the newest failure when the older probe finishes first: %s',
+    async (olderFirst) => {
+      const harness = create();
+      const older = deferred();
+      const newer = deferred();
+      invoke.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+      const first = harness.set(`C:\\old\\${harness.filename}`);
+      await Promise.resolve();
+      const second = harness.set(`C:\\new\\${harness.filename}`);
+      await Promise.resolve();
+      if (olderFirst) {
+        older.resolve(harness.success);
+        await first;
+        expect(await firstValueFrom(harness.status)).toBe('CHECKING');
+      }
+      newer.reject(harness.failure);
+      await second;
+      if (!olderFirst) {
+        older.resolve(harness.success);
+        await first;
+      }
+      expect(await firstValueFrom(harness.status)).toBe('NOT_FOUND');
+      invoke.mockClear();
+      await harness.act();
+      expect(invoke).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([true, false])(
+    'keeps the newest success when the older probe finishes first: %s',
+    async (olderFirst) => {
+      const harness = create();
+      const older = deferred();
+      const newer = deferred();
+      const path = `C:\\new\\${harness.filename}`;
+      invoke.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+      const first = harness.set(`C:\\old\\${harness.filename}`);
+      await Promise.resolve();
+      const second = harness.set(path);
+      await Promise.resolve();
+      if (olderFirst) {
+        older.reject(harness.failure);
+        await first;
+        expect(await firstValueFrom(harness.status)).toBe('CHECKING');
+      }
+      newer.resolve(harness.success);
+      await second;
+      if (!olderFirst) {
+        older.reject(harness.failure);
+        await first;
+      }
+      expect(await firstValueFrom(harness.status)).toBe('SUCCESS');
+      invoke.mockClear();
+      invoke.mockResolvedValue(harness.success);
+      await harness.act();
+      expect(invoke.mock.calls).toEqual([harness.actionCall(path)]);
+    }
+  );
+
+  it('blocks actions while a replacement validation is pending', async () => {
+    const harness = create();
+    invoke.mockResolvedValue(harness.success);
+    await harness.set(`C:\\old\\${harness.filename}`);
+    const pending = deferred();
+    invoke.mockReturnValueOnce(pending.promise);
+    const validation = harness.set(`C:\\new\\${harness.filename}`);
+    await Promise.resolve();
+    invoke.mockClear();
+    await harness.act();
+    expect(invoke).not.toHaveBeenCalled();
+    pending.resolve(harness.success);
+    await validation;
+  });
+
+  it('does not authorize a configured path that has not been validated', async () => {
+    const harness = create();
+    invoke.mockResolvedValue(harness.success);
+    await harness.set(`C:\\old\\${harness.filename}`);
+    harness.configure(`C:\\new\\${harness.filename}`);
+    invoke.mockClear();
+    await harness.act();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+it('does not let an old MSI profile failure replace a newer validation', async () => {
+  const harness = createMSI();
+  invoke.mockResolvedValue(true);
+  await harness.set('C:\\old\\MSIAfterburner.exe');
+  const pending = deferred();
+  invoke.mockReturnValueOnce(pending.promise);
+  const action = harness.act();
+  await harness.set('C:\\new\\MSIAfterburner.exe');
+  pending.reject('ExeNotFound');
+  await action;
+  expect(await firstValueFrom(harness.status)).toBe('SUCCESS');
+});

--- a/src-ui/app/services/gpu-automations.service.ts
+++ b/src-ui/app/services/gpu-automations.service.ts
@@ -57,6 +57,8 @@ export class GpuAutomationsService {
     new BehaviorSubject<ExecutableReferenceStatus>('UNKNOWN');
   public msiAfterburnerStatus: Observable<ExecutableReferenceStatus> =
     this._msiAfterburnerStatus.asObservable();
+  private msiValidationGeneration = 0;
+  private validatedMSIPath: string | undefined;
 
   constructor(
     private automationConfig: AutomationConfigService,
@@ -357,7 +359,9 @@ export class GpuAutomationsService {
       await error(`[GpuAutomations] Attempted to set invalid MSI Afterburner profile (${index})`);
       return;
     }
-    if (this._msiAfterburnerStatus.value !== 'SUCCESS') {
+    const path = this.currentMSIAfterburnerConfig.msiAfterburnerPath;
+    const generation = this.msiValidationGeneration;
+    if (this._msiAfterburnerStatus.value !== 'SUCCESS' || this.validatedMSIPath !== path) {
       await warn(
         `[GpuAutomations] Could not set MSI Afterburner profile as no valid installation is currently configured`
       );
@@ -365,7 +369,7 @@ export class GpuAutomationsService {
     }
     try {
       await invoke<boolean>('msi_afterburner_set_profile', {
-        executablePath: this.currentMSIAfterburnerConfig.msiAfterburnerPath,
+        executablePath: path,
         profile: index,
       });
       this.eventLog.logEvent({
@@ -374,6 +378,11 @@ export class GpuAutomationsService {
         reason,
       } as EventLogMsiAfterburnerProfileSet);
     } catch (e) {
+      if (
+        generation !== this.msiValidationGeneration ||
+        path !== this.currentMSIAfterburnerConfig.msiAfterburnerPath
+      )
+        return;
       if (typeof e === 'string') {
         this.handleMSIAfterburnerError(e);
       } else {
@@ -385,23 +394,26 @@ export class GpuAutomationsService {
   }
 
   async setMSIAfterburnerPath(path: string, save = true) {
+    const generation = ++this.msiValidationGeneration;
+    this.validatedMSIPath = undefined;
+    this._msiAfterburnerStatus.next('CHECKING');
     if (save)
       await this.automationConfig.updateAutomationConfig<MSIAfterburnerAutomationConfig>(
         'MSI_AFTERBURNER',
         { msiAfterburnerPath: path }
       );
-    this._msiAfterburnerStatus.next('CHECKING');
+    if (generation !== this.msiValidationGeneration) return;
     if (!path.endsWith('MSIAfterburner.exe')) {
       this._msiAfterburnerStatus.next('NOT_FOUND');
       return;
     }
-    // Try running it
     try {
       await invoke<boolean>('msi_afterburner_set_profile', {
         executablePath: path,
         profile: 0, // Profile 0 for testing without actually setting a profile
       });
     } catch (e) {
+      if (generation !== this.msiValidationGeneration) return;
       if (typeof e === 'string') {
         this.handleMSIAfterburnerError(e);
       } else {
@@ -410,6 +422,8 @@ export class GpuAutomationsService {
       }
       return;
     }
+    if (generation !== this.msiValidationGeneration) return;
+    this.validatedMSIPath = path;
     this._msiAfterburnerStatus.next('SUCCESS');
   }
 

--- a/src-ui/app/services/lighthouse-console.service.spec.ts
+++ b/src-ui/app/services/lighthouse-console.service.spec.ts
@@ -30,7 +30,9 @@ async function createService(stdout: string) {
   });
   const appSettings = {
     settings: settings.asObservable(),
-    updateSettings: vi.fn(),
+    updateSettings: vi.fn((patch: Partial<AppSettings>) =>
+      settings.next({ ...settings.value, ...patch })
+    ),
   } as unknown as AppSettingsService;
   const openvr = {
     devices: new BehaviorSubject<OVRDevice[]>([device]).asObservable(),
@@ -96,7 +98,7 @@ describe('LighthouseConsoleService.setConsolePath', () => {
 
   it('runs the executable for power-off once the path is accepted', async () => {
     const service = await createService('Version:  lighthouse_console.exe 1.0');
-    await service.setConsolePath(PATH, false);
+    await service.setConsolePath(PATH);
     invoke.mockClear();
     await service.turnOffDevices([device]);
     expect(invoke).toHaveBeenCalledOnce();

--- a/src-ui/app/services/lighthouse-console.service.ts
+++ b/src-ui/app/services/lighthouse-console.service.ts
@@ -16,6 +16,8 @@ export class LighthouseConsoleService {
     new BehaviorSubject<ExecutableReferenceStatus>('UNKNOWN');
   public consoleStatus: Observable<ExecutableReferenceStatus> = this._consoleStatus.asObservable();
   private powerOffQueue: Promise<void> = Promise.resolve();
+  private validationGeneration = 0;
+  private validatedPath: string | undefined;
 
   constructor(
     private appSettings: AppSettingsService,
@@ -56,6 +58,8 @@ export class LighthouseConsoleService {
 
   async setConsolePath(path: string, save = true) {
     if (save) this.appSettings.updateSettings({ lighthouseConsolePath: path });
+    const generation = ++this.validationGeneration;
+    this.validatedPath = undefined;
     this._consoleStatus.next('CHECKING');
     if (!path.endsWith('lighthouse_console.exe')) {
       this._consoleStatus.next('NOT_FOUND');
@@ -74,6 +78,7 @@ export class LighthouseConsoleService {
         })
       ).stdout;
     } catch (e) {
+      if (generation !== this.validationGeneration) return;
       if (
         typeof e === 'string' &&
         ['NOT_FOUND', 'PERMISSION_DENIED', 'INVALID_FILENAME'].includes(e)
@@ -84,6 +89,7 @@ export class LighthouseConsoleService {
       this._consoleStatus.next('UNKNOWN_ERROR');
       return;
     }
+    if (generation !== this.validationGeneration) return;
     const stdoutLines = stdout.split('\n');
     if (
       !stdoutLines.length ||
@@ -92,6 +98,7 @@ export class LighthouseConsoleService {
       this._consoleStatus.next('INVALID_EXECUTABLE');
       return;
     }
+    this.validatedPath = path;
     this._consoleStatus.next('SUCCESS');
   }
 
@@ -112,7 +119,9 @@ export class LighthouseConsoleService {
   private async runTurnOffDevices(deviceSerialNumbers: string[]) {
     const settings = await firstValueFrom(this.appSettings.settings);
     const lighthouseConsolePath = settings.lighthouseConsolePath;
-    if (this._consoleStatus.value !== 'SUCCESS') return;
+    const generation = this.validationGeneration;
+    if (this._consoleStatus.value !== 'SUCCESS' || this.validatedPath !== lighthouseConsolePath)
+      return;
     // resolve the devices as they are now, not as the caller saw them
     const requestedSerials = new Set(deviceSerialNumbers);
     const ovrDevices = (await firstValueFrom(this.openvr.devices)).filter(
@@ -125,6 +134,7 @@ export class LighthouseConsoleService {
     );
     // sequential on purpose: parallel poweroffs can crash SteamVR
     for (const [index, device] of ovrDevices.entries()) {
+      if (generation !== this.validationGeneration) return;
       this.openvr.onDeviceUpdate(Object.assign({}, device, { isTurningOff: true }));
       info(`[Lighthouse] Turning off device ${device.class}:${device.serialNumber}`);
       try {


### PR DESCRIPTION
Lighthouse and MSI Afterburner could report success from an older probe after the configured path failed validation. Ignore obsolete results and require actions to use the accepted path.

Validation: 105 tests pass, frontend typecheck and targeted ESLint pass. Deferred-probe tests cover both completion orders, pending validation, and delayed MSI action failures. Real desktop checks passed for both overlapping validation orders in both fields, using simulated executable responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation reliability when paths are changed while checks are still in progress.
  * Prevented outdated validation results from overriding newer results.
  * Blocked device actions until the currently configured path has been successfully validated.
  * Prevented stale validation failures from affecting newer MSI Afterburner configurations.
  * Improved safety when console settings change during device power-off operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->