### PR TITLE
fix(OYASUMIVR-17): honor the current charging selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed charging power-off automation using an outdated device selection
+
 - Fixed outdated validation results overriding the current Lighthouse Console or MSI Afterburner path
 
 - Fixed the leave sound never playing when the leave notification was turned off

--- a/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.spec.ts
+++ b/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.spec.ts
@@ -99,6 +99,18 @@ describe('charging device selection', () => {
     expect(h.logEvent).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps one action when power-off capability changes while charging', async () => {
+    const h = await setup();
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    await Promise.resolve();
+    h.devices.next([{ ...a, isCharging: true, canPowerOff: false }, b]);
+    await Promise.resolve();
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    await Promise.resolve();
+    expect(h.powerOff).toHaveBeenCalledTimes(1);
+    expect(h.logEvent).toHaveBeenCalledTimes(1);
+  });
+
   it('discards a delayed transition after unplugging and replugging', async () => {
     const h = await setup();
     let finish!: (result: Awaited<ReturnType<typeof h.resolve>>) => void;

--- a/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.spec.ts
+++ b/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.spec.ts
@@ -1,0 +1,132 @@
+import { BehaviorSubject } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../../models/automations';
+import type { OVRDevice } from '../../models/ovr-device';
+import type { DeviceSelection } from '../../models/device-manager';
+import { TurnOffDevicesWhenChargingAutomationService } from './turn-off-devices-when-charging-automation.service';
+
+vi.mock('@tauri-apps/plugin-log', () => ({ info: vi.fn(), error: vi.fn() }));
+const a = {
+  index: 1,
+  serialNumber: 'A',
+  class: 'Controller',
+  canPowerOff: true,
+  isCharging: false,
+} as OVRDevice;
+const b = { ...a, index: 2, serialNumber: 'B' };
+const selection = (serial: string): DeviceSelection => ({
+  devices: [serial],
+  types: [],
+  tagIds: [],
+});
+type Dependencies = ConstructorParameters<typeof TurnOffDevicesWhenChargingAutomationService>;
+async function setup() {
+  const configs = new BehaviorSubject(structuredClone(AUTOMATION_CONFIGS_DEFAULT));
+  const devices = new BehaviorSubject([a, b]);
+  const select = (serial: string) =>
+    configs.next({
+      ...configs.value,
+      DEVICE_POWER_AUTOMATIONS: {
+        ...configs.value.DEVICE_POWER_AUTOMATIONS,
+        turnOffDevicesWhenCharging: selection(serial),
+      },
+    });
+  select('A');
+  const resolve = vi.fn(async (selected: DeviceSelection) => ({
+    ovrDevices: devices.value.filter((d) => selected.devices.includes(d.serialNumber!)),
+    lighthouseDevices: [],
+    knownDevices: [],
+  }));
+  const powerOff = vi.fn();
+  const logEvent = vi.fn();
+  const service = new TurnOffDevicesWhenChargingAutomationService(
+    { configs } as unknown as Dependencies[0],
+    { devices } as unknown as Dependencies[1],
+    { turnOffDevices: powerOff } as unknown as Dependencies[2],
+    { logEvent } as unknown as Dependencies[3],
+    {
+      getDevicesForSelection: resolve,
+      knownDevices: new BehaviorSubject([]),
+    } as unknown as Dependencies[4]
+  );
+  await service.init();
+  return { configs, devices, select, resolve, powerOff, logEvent };
+}
+
+describe('charging device selection', () => {
+  it.each([false, true])(
+    'excludes A after selecting B with reordered indexes: %s',
+    async (reorder) => {
+      const h = await setup();
+      h.select('B');
+      const charging = [{ ...a, isCharging: true }, b];
+      h.devices.next(reorder ? charging.reverse() : charging);
+      await Promise.resolve();
+      expect(h.powerOff).not.toHaveBeenCalled();
+      expect(h.logEvent).not.toHaveBeenCalled();
+      h.devices.next([a, { ...b, isCharging: true }]);
+      await Promise.resolve();
+      expect(h.powerOff).toHaveBeenCalledWith([{ ...b, isCharging: true }]);
+    }
+  );
+
+  it('discards a delayed result after the selection changes', async () => {
+    const h = await setup();
+    let finish!: (result: Awaited<ReturnType<typeof h.resolve>>) => void;
+    h.resolve.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    h.select('B');
+    finish({ ovrDevices: [a], lighthouseDevices: [], knownDevices: [] });
+    await Promise.resolve();
+    expect(h.powerOff).not.toHaveBeenCalled();
+  });
+
+  it('acts once per charging transition and rearms after unplugging', async () => {
+    const h = await setup();
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    await Promise.resolve();
+    expect(h.powerOff).toHaveBeenCalledTimes(1);
+    h.devices.next([a, b]);
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    await Promise.resolve();
+    expect(h.powerOff).toHaveBeenCalledTimes(2);
+    expect(h.logEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('discards a delayed transition after unplugging and replugging', async () => {
+    const h = await setup();
+    let finish!: (result: Awaited<ReturnType<typeof h.resolve>>) => void;
+    h.resolve.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    h.devices.next([a, b]);
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    await Promise.resolve();
+    finish({ ovrDevices: [a], lighthouseDevices: [], knownDevices: [] });
+    await Promise.resolve();
+    expect(h.powerOff).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not act on a disconnected device or a failed selection lookup', async () => {
+    const h = await setup();
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    h.devices.next([b]);
+    await Promise.resolve();
+    expect(h.powerOff).not.toHaveBeenCalled();
+    h.resolve.mockRejectedValueOnce(new Error('lookup failed'));
+    h.devices.next([{ ...a, isCharging: true }, b]);
+    await Promise.resolve();
+    expect(h.powerOff).not.toHaveBeenCalled();
+    expect(h.logEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
+++ b/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
@@ -19,6 +19,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
   config: DevicePowerAutomationsConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.DEVICE_POWER_AUTOMATIONS
   );
+  // retained object identity distinguishes separate charging sessions
   private chargingDevices: OVRDevice[] = [];
 
   constructor(
@@ -35,6 +36,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
       .subscribe((config) => (this.config = config));
 
     this.openvr.devices.subscribe((devices) => {
+      // forget charging sessions that ended
       this.chargingDevices = this.chargingDevices.filter((charging) =>
         devices.some((device) => device.serialNumber === charging.serialNumber && device.isCharging)
       );
@@ -44,6 +46,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
           device.canPowerOff &&
           !this.chargingDevices.some((charging) => charging.serialNumber === device.serialNumber)
         ) {
+          // resolve selection once per charging session
           this.chargingDevices.push(device);
           const selection = this.config.turnOffDevicesWhenCharging;
           let selected;
@@ -55,6 +58,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
             );
             return;
           }
+          // discard stale or unselected charging events
           if (
             !isEqual(selection, this.config.turnOffDevicesWhenCharging) ||
             !this.chargingDevices.includes(device) ||
@@ -63,6 +67,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
             )
           )
             return;
+          // record and request the power-off
           info(
             `[TurnOffDevicesWhenChargingAutomationService] Detected device being put on charger. Turning off device (${device.class}:${device.serialNumber})`
           );

--- a/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
+++ b/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { AutomationConfigService } from '../automation-config.service';
 import { OpenVRService } from '../openvr.service';
-import { combineLatest, distinctUntilChanged, map } from 'rxjs';
+import { map } from 'rxjs';
 import { AUTOMATION_CONFIGS_DEFAULT, DevicePowerAutomationsConfig } from '../../models/automations';
 import { LighthouseConsoleService } from '../lighthouse-console.service';
 import { error, info } from '@tauri-apps/plugin-log';
@@ -10,6 +10,7 @@ import { EventLogTurnedOffOpenVRDevices } from '../../models/event-log-entry';
 import { EventLogService } from '../event-log.service';
 import { DeviceManagerService } from '../device-manager.service';
 import { isEqual } from 'lodash';
+import { OVRDevice } from '../../models/ovr-device';
 
 @Injectable({
   providedIn: 'root',
@@ -18,8 +19,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
   config: DevicePowerAutomationsConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.DEVICE_POWER_AUTOMATIONS
   );
-  chargingDevices: number[] = [];
-  applicableDevices: number[] = [];
+  private chargingDevices: OVRDevice[] = [];
 
   constructor(
     private automationConfig: AutomationConfigService,
@@ -34,28 +34,38 @@ export class TurnOffDevicesWhenChargingAutomationService {
       .pipe(map((configs) => configs.DEVICE_POWER_AUTOMATIONS))
       .subscribe((config) => (this.config = config));
 
-    combineLatest([
-      this.openvr.devices.pipe(
-        map((devices) => devices.map((d) => d.index)),
-        distinctUntilChanged((a, b) => isEqual(a, b))
-      ),
-      this.deviceManager.knownDevices,
-    ]).subscribe(async () => {
-      const devices = await this.deviceManager.getDevicesForSelection(
-        this.config.turnOffDevicesWhenCharging
+    this.openvr.devices.subscribe((devices) => {
+      this.chargingDevices = this.chargingDevices.filter((charging) =>
+        devices.some(
+          (device) =>
+            device.serialNumber === charging.serialNumber && device.isCharging && device.canPowerOff
+        )
       );
-      this.applicableDevices = devices.ovrDevices.map((d) => d.index);
-    });
-
-    this.openvr.devices.subscribe(async (devices) => {
       devices.forEach(async (device) => {
         if (
           device.isCharging &&
           device.canPowerOff &&
-          !this.chargingDevices.includes(device.index)
+          !this.chargingDevices.some((charging) => charging.serialNumber === device.serialNumber)
         ) {
-          this.chargingDevices.push(device.index);
-          if (!this.applicableDevices.includes(device.index)) return;
+          this.chargingDevices.push(device);
+          const selection = this.config.turnOffDevicesWhenCharging;
+          let selected;
+          try {
+            selected = await this.deviceManager.getDevicesForSelection(selection);
+          } catch (cause) {
+            error(
+              `[TurnOffDevicesWhenChargingAutomationService] Could not resolve selection: ${cause}`
+            );
+            return;
+          }
+          if (
+            !isEqual(selection, this.config.turnOffDevicesWhenCharging) ||
+            !this.chargingDevices.includes(device) ||
+            !selected.ovrDevices.some(
+              (selectedDevice) => selectedDevice.serialNumber === device.serialNumber
+            )
+          )
+            return;
           info(
             `[TurnOffDevicesWhenChargingAutomationService] Detected device being put on charger. Turning off device (${device.class}:${device.serialNumber})`
           );
@@ -78,8 +88,6 @@ export class TurnOffDevicesWhenChargingAutomationService {
             })(),
           } as EventLogTurnedOffOpenVRDevices);
           this.lighthouse.turnOffDevices([device]);
-        } else if (!device.isCharging && this.chargingDevices.includes(device.index)) {
-          this.chargingDevices = this.chargingDevices.filter((d) => d !== device.index);
         }
       });
     });

--- a/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
+++ b/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
@@ -31,23 +31,28 @@ export class TurnOffDevicesWhenChargingAutomationService {
   ) {}
 
   async init() {
+    // keep power automation settings current as edits arrive
     this.automationConfig.configs
       .pipe(map((configs) => configs.DEVICE_POWER_AUTOMATIONS))
       .subscribe((config) => (this.config = config));
 
+    // check each openvr device update for newly charging devices
     this.openvr.devices.subscribe((devices) => {
-      // forget charging sessions that ended
+      // forget devices that disconnected or stopped charging
       this.chargingDevices = this.chargingDevices.filter((charging) =>
         devices.some((device) => device.serialNumber === charging.serialNumber && device.isCharging)
       );
+      // handle unprocessed charging devices that support power-off
       devices.forEach(async (device) => {
         if (
           device.isCharging &&
           device.canPowerOff &&
           !this.chargingDevices.some((charging) => charging.serialNumber === device.serialNumber)
         ) {
-          // resolve selection once per charging session
+          // mark this session before awaiting the selection lookup
           this.chargingDevices.push(device);
+
+          // resolve the current settings into selected devices
           const selection = this.config.turnOffDevicesWhenCharging;
           let selected;
           try {
@@ -58,7 +63,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
             );
             return;
           }
-          // discard stale or unselected charging events
+          // recheck settings, charging session, and membership after awaiting
           if (
             !isEqual(selection, this.config.turnOffDevicesWhenCharging) ||
             !this.chargingDevices.includes(device) ||

--- a/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
+++ b/src-ui/app/services/power-automations/turn-off-devices-when-charging-automation.service.ts
@@ -36,10 +36,7 @@ export class TurnOffDevicesWhenChargingAutomationService {
 
     this.openvr.devices.subscribe((devices) => {
       this.chargingDevices = this.chargingDevices.filter((charging) =>
-        devices.some(
-          (device) =>
-            device.serialNumber === charging.serialNumber && device.isCharging && device.canPowerOff
-        )
+        devices.some((device) => device.serialNumber === charging.serialNumber && device.isCharging)
       );
       devices.forEach(async (device) => {
         if (


### PR DESCRIPTION
Charging could power off a device after it was removed from the automation selection. Resolve membership for each charging transition and discard results after deselection, unplugging, or disconnection. Keep one action per charging transition when power-off capability changes.

Validation: 158 tests pass on the complete stack, frontend typecheck and targeted ESLint pass. Seven charging tests cover selection changes, delayed resolution, and one action per charging transition. Real desktop checks passed with simulated devices: removed A received no power-off, selected B received one, and repeated state and capability updates caused no duplicate action or event. Real controller power-off was not exercised.

Stack: based on #289.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when powering off selected devices during charging.
  - Device selections now stay accurate when devices are reordered, disconnected, reconnected, or change charging state.
  - Prevented outdated device information from triggering unintended power-off actions.
  - Added safer handling when device selection details cannot be retrieved, with errors recorded for troubleshooting.

- **Tests**
  - Expanded coverage for charging transitions, capability changes, stale results, disconnected devices, and selection lookup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
