### PR TITLE
fix(OYASUMIVR-26): refresh device selections after edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed device selections not refreshing immediately after tag or disabled-state changes
+
 - Fixed charging power-off automation using an outdated device selection
 
 - Fixed outdated validation results overriding the current Lighthouse Console or MSI Afterburner path

--- a/src-ui/app/services/device-manager.service.spec.ts
+++ b/src-ui/app/services/device-manager.service.spec.ts
@@ -1,0 +1,212 @@
+import '@angular/compiler';
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DeviceManagerService } from './device-manager.service';
+import { ShutdownAutomationsService } from './shutdown-automations.service';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../models/automations';
+import { APP_SETTINGS_DEFAULT } from '../models/settings';
+import type { DeviceManagerData, DeviceSelection, DMKnownDevice } from '../models/device-manager';
+import type { OVRDevice } from '../models/ovr-device';
+import type { LighthouseDevice } from '../models/lighthouse-device';
+
+const { get, invoke } = vi.hoisted(() => ({ get: vi.fn(), invoke: vi.fn() }));
+vi.mock('../globals', () => ({
+  SETTINGS_KEY_DEVICE_MANAGER: 'DEVICE_MANAGER',
+  SETTINGS_STORE: { get },
+}));
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/plugin-log', () => ({ error: vi.fn() }));
+
+const tag = { id: 'TAG_A', name: 'Selected', color: '#ffffff' };
+const selection: DeviceSelection = { devices: [], types: [], tagIds: [tag.id] };
+type DMDependencies = ConstructorParameters<typeof DeviceManagerService>;
+type ShutdownDependencies = ConstructorParameters<typeof ShutdownAutomationsService>;
+
+async function setup(kind: 'OVR' | 'LH' = 'OVR') {
+  const ovr = new BehaviorSubject<OVRDevice[]>(
+    kind === 'OVR'
+      ? ['A', 'B'].map(
+          (serialNumber, index) =>
+            ({
+              index,
+              serialNumber,
+              class: 'Controller',
+              canPowerOff: true,
+              isTurningOff: false,
+            }) as OVRDevice
+        )
+      : []
+  );
+  const lh = new BehaviorSubject<LighthouseDevice[]>(
+    kind === 'LH'
+      ? ['A', 'B'].map(
+          (id) => ({ id, powerState: 'on', deviceType: 'lighthouseV2' }) as LighthouseDevice
+        )
+      : []
+  );
+  const known = ['A', 'B'].map(
+    (id, index) =>
+      ({
+        id: `${kind}_${kind === 'OVR' ? 'Controller' : 'lighthouseV2'}_${id}`,
+        defaultName: id,
+        typeName: id,
+        deviceType: kind === 'OVR' ? 'CONTROLLER' : 'LIGHTHOUSE',
+        tagIds: index === 0 ? [tag.id] : [],
+        disabled: false,
+        lastSeen: 0,
+      }) as DMKnownDevice
+  );
+  get.mockResolvedValue({
+    version: 2,
+    knownDevices: known,
+    tags: [tag],
+  } satisfies DeviceManagerData);
+  const manager = new DeviceManagerService(
+    { devices: ovr } as unknown as DMDependencies[0],
+    { devices: lh } as unknown as DMDependencies[1]
+  );
+  await manager['loadData']();
+  return { manager, ovr, lh, known };
+}
+
+const mutations = {
+  disable: (manager: DeviceManagerService, known: DMKnownDevice[]) =>
+    manager.disableKnownDevice(known[0], true),
+  untag: (manager: DeviceManagerService, known: DMKnownDevice[]) =>
+    manager.removeTagFromKnownDevice(known[0], tag),
+  deleteTag: (manager: DeviceManagerService) => manager.deleteTag(tag.id),
+  addTag: (manager: DeviceManagerService, known: DMKnownDevice[]) =>
+    manager.addTagToKnownDevice(known[1], tag),
+};
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe.each(['OVR', 'LH'] as const)('%s selection membership', (kind) => {
+  it.each(Object.keys(mutations) as (keyof typeof mutations)[])(
+    'emits synchronously after %s with fixed physical IDs',
+    async (mutation) => {
+      const h = await setup(kind);
+      const seen: string[][] = [];
+      const sub = h.manager
+        .getDevicesForSelectionStream(selection)
+        .subscribe((result) => seen.push(result.knownDevices.map((d) => d.id)));
+      expect(seen).toEqual([[h.known[0].id]]);
+      mutations[mutation](h.manager, h.known);
+      expect(seen.at(-1)).toEqual(mutation === 'addTag' ? [h.known[0].id, h.known[1].id] : []);
+      expect(seen).toHaveLength(2);
+      sub.unsubscribe();
+    }
+  );
+
+  it.each(Object.keys(mutations) as (keyof typeof mutations)[])(
+    'shutdown immediately consumes %s without a physical emission',
+    async (mutation) => {
+      vi.useFakeTimers();
+      const h = await setup(kind);
+      const configs = new BehaviorSubject({
+        ...structuredClone(AUTOMATION_CONFIGS_DEFAULT),
+        SHUTDOWN_AUTOMATIONS: {
+          ...AUTOMATION_CONFIGS_DEFAULT.SHUTDOWN_AUTOMATIONS,
+          turnOffDevices: selection,
+          quitSteamVR: false,
+          powerDownWindows: false,
+          triggersEnabled: false,
+        },
+      });
+      const powerOff = vi.fn((devices: OVRDevice[]) =>
+        h.ovr.next(
+          h.ovr.value.map((d) =>
+            devices.some((selected) => selected.serialNumber === d.serialNumber)
+              ? { ...d, canPowerOff: false }
+              : d
+          )
+        )
+      );
+      const setPowerState = vi.fn(
+        (device: LighthouseDevice, state: LighthouseDevice['powerState']) =>
+          h.lh.next(h.lh.value.map((d) => (d.id === device.id ? { ...d, powerState: state } : d)))
+      );
+      const shutdown = new ShutdownAutomationsService(
+        { mode: new BehaviorSubject(false) } as unknown as ShutdownDependencies[0],
+        { configs } as unknown as ShutdownDependencies[1],
+        {
+          settingsSync: { ...APP_SETTINGS_DEFAULT, lighthousePowerControl: true },
+        } as ShutdownDependencies[2],
+        { devices: h.ovr } as unknown as ShutdownDependencies[3],
+        { turnOffDevices: powerOff } as unknown as ShutdownDependencies[4],
+        { devices: h.lh, setPowerState } as unknown as ShutdownDependencies[5],
+        { logEvent: vi.fn() } as unknown as ShutdownDependencies[6],
+        {} as ShutdownDependencies[7],
+        {
+          world: new BehaviorSubject({ players: [], loaded: false }),
+          vrchatProcessActive: new BehaviorSubject(false),
+        } as unknown as ShutdownDependencies[8],
+        h.manager
+      );
+      await shutdown.init();
+      expect(shutdown.getApplicableStages()).toEqual(['TURNING_OFF_DEVICES']);
+      mutations[mutation](h.manager, h.known);
+      expect(shutdown.getApplicableStages()).toEqual(
+        mutation === 'addTag' ? ['TURNING_OFF_DEVICES'] : []
+      );
+      const sequence = shutdown.runSequence('MANUAL');
+      await vi.advanceTimersByTimeAsync(3000);
+      await sequence;
+      if (mutation === 'addTag' && kind === 'OVR')
+        expect(powerOff.mock.calls[0][0].map((d) => d.serialNumber)).toEqual(['A', 'B']);
+      else expect(powerOff).not.toHaveBeenCalled();
+      if (mutation === 'addTag' && kind === 'LH')
+        expect(setPowerState.mock.calls.map(([d]) => d.id)).toEqual(['A', 'B']);
+      else expect(setPowerState).not.toHaveBeenCalled();
+      expect(invoke).not.toHaveBeenCalled();
+    }
+  );
+});
+
+it('suppresses nickname, tag appearance, and telemetry edits', async () => {
+  const h = await setup();
+  const emit = vi.fn();
+  const sub = h.manager.getDevicesForSelectionStream(selection).subscribe(emit);
+  h.manager.setNicknameForKnownDevice(h.known[0], 'New nickname');
+  h.manager.updateTag(tag.id, 'New label', '#000000');
+  h.ovr.next(h.ovr.value.map((d) => ({ ...d, battery: 50 })));
+  expect(emit).toHaveBeenCalledTimes(1);
+  sub.unsubscribe();
+});
+
+it.each(['type', 'individual', 'tag'] as const)(
+  'preserves disabled filtering and recovery for %s selection',
+  async (mode) => {
+    const h = await setup();
+    const selected: DeviceSelection =
+      mode === 'type'
+        ? { devices: [], types: ['CONTROLLER'], tagIds: [] }
+        : mode === 'individual'
+          ? { devices: ['OVR_Controller_A'], types: [], tagIds: [] }
+          : selection;
+    h.manager.disableKnownDevice(h.known[0], true);
+    const disabled = await h.manager.getDevicesForSelection(selected);
+    expect(disabled.ovrDevices.map((d) => d.serialNumber)).toEqual(mode === 'type' ? ['B'] : []);
+    h.manager.disableKnownDevice(h.known[0], false);
+    const enabled = await h.manager.getDevicesForSelection(selected);
+    expect(enabled.ovrDevices.map((d) => d.serialNumber)).toEqual(
+      mode === 'type' ? ['A', 'B'] : ['A']
+    );
+  }
+);
+
+it('refreshes when an OpenVR index is reused by another serial', async () => {
+  const h = await setup();
+  const seen: string[][] = [];
+  const sub = h.manager
+    .getDevicesForSelectionStream(selection)
+    .subscribe((result) => seen.push(result.ovrDevices.map((d) => d.serialNumber!)));
+  h.ovr.next([{ ...h.ovr.value[0], serialNumber: 'C' }, h.ovr.value[1]]);
+  expect(seen).toEqual([['A'], []]);
+  sub.unsubscribe();
+});

--- a/src-ui/app/services/device-manager.service.ts
+++ b/src-ui/app/services/device-manager.service.ts
@@ -182,19 +182,25 @@ export class DeviceManagerService {
     return this._observedDevices.value.includes(deviceId);
   }
 
+  /** Emits selection matches when device availability or membership changes. */
   public getDevicesForSelectionStream(selection: DeviceSelection): Observable<{
     lighthouseDevices: LighthouseDevice[];
     ovrDevices: OVRDevice[];
     knownDevices: DMKnownDevice[];
   }> {
+    // watch live devices alongside saved tags and disabled flags
     return combineLatest([this.openvr.devices, this.lighthouse.devices, this._data]).pipe(
+      // ignore telemetry, nicknames, and tag appearance changes
       distinctUntilChanged(isEqual, ([ovrDevices, lighthouseDevices, data]) => [
+        // compare openvr identities, including devices replacing reused indices
         ovrDevices.map(({ index, serialNumber, class: deviceClass }) => [
           index,
           serialNumber,
           deviceClass,
         ]),
+        // compare available base station identities
         lighthouseDevices.map((device) => device.id),
+        // compare saved fields that determine selection membership
         data.knownDevices.map(({ id, deviceType, tagIds, disabled }) => ({
           id,
           deviceType,
@@ -202,12 +208,14 @@ export class DeviceManagerService {
           disabled,
         })),
       ]),
+      // emit matching devices from these same input snapshots
       map(([ovrDevices, lighthouseDevices, data]) =>
         this.resolveSelection(selection, ovrDevices, lighthouseDevices, data.knownDevices)
       )
     );
   }
 
+  /** Returns one selection snapshot without retaining a subscription. */
   public async getDevicesForSelection(selection: DeviceSelection): Promise<{
     lighthouseDevices: LighthouseDevice[];
     ovrDevices: OVRDevice[];
@@ -232,7 +240,7 @@ export class DeviceManagerService {
       knownDevices: [],
     };
 
-    // resolve device types
+    // include enabled devices matching any selected type
     for (const type of selection.types) {
       result.knownDevices.push(...knownDevices.filter((d) => d.deviceType === type && !d.disabled));
       switch (type) {
@@ -297,13 +305,14 @@ export class DeviceManagerService {
       }
     }
 
-    // resolve device tags
+    // add enabled tagged devices without duplicating earlier matches
     for (const tagId of selection.tagIds) {
       const devices = knownDevices.filter((d) => d.tagIds.includes(tagId) && !d.disabled);
       for (const device of devices) {
         if (!result.knownDevices.find((d) => d.id === device.id)) {
           result.knownDevices.push(device);
         }
+        // match the saved device to its live counterpart
         const ovrDeviceId = this.getOpenVRIdForKnownDevice(device);
         const ovrDevice = openvrDevices.find((d) => d.serialNumber === ovrDeviceId);
         if (ovrDevice && !result.ovrDevices.find((d) => d.serialNumber === ovrDeviceId))
@@ -320,13 +329,14 @@ export class DeviceManagerService {
       }
     }
 
-    // resolve individual devices
+    // add explicitly selected devices, excluding disabled or unknown entries
     for (const deviceId of selection.devices) {
       const device = knownDevices.find((known) => known.id === deviceId);
       if (!device || device.disabled) continue;
       if (!result.knownDevices.find((d) => d.id === device.id)) {
         result.knownDevices.push(device);
       }
+      // match the saved device to its live counterpart
       const ovrDeviceId = this.getOpenVRIdForKnownDevice(device);
       const ovrDevice = openvrDevices.find((d) => d.serialNumber === ovrDeviceId);
       if (ovrDevice && !result.ovrDevices.find((d) => d.serialNumber === ovrDeviceId))

--- a/src-ui/app/services/device-manager.service.ts
+++ b/src-ui/app/services/device-manager.service.ts
@@ -187,16 +187,25 @@ export class DeviceManagerService {
     ovrDevices: OVRDevice[];
     knownDevices: DMKnownDevice[];
   }> {
-    return combineLatest([
-      this.openvr.devices.pipe(
-        map((devices) => devices.map((d) => d.index)),
-        distinctUntilChanged((a, b) => isEqual(a, b))
-      ),
-      this.lighthouse.devices.pipe(
-        map((devices) => devices.map((d) => d.id)),
-        distinctUntilChanged((a, b) => isEqual(a, b))
-      ),
-    ]).pipe(switchMap(() => this.getDevicesForSelection(selection)));
+    return combineLatest([this.openvr.devices, this.lighthouse.devices, this._data]).pipe(
+      distinctUntilChanged(isEqual, ([ovrDevices, lighthouseDevices, data]) => [
+        ovrDevices.map(({ index, serialNumber, class: deviceClass }) => [
+          index,
+          serialNumber,
+          deviceClass,
+        ]),
+        lighthouseDevices.map((device) => device.id),
+        data.knownDevices.map(({ id, deviceType, tagIds, disabled }) => ({
+          id,
+          deviceType,
+          tagIds,
+          disabled,
+        })),
+      ]),
+      map(([ovrDevices, lighthouseDevices, data]) =>
+        this.resolveSelection(selection, ovrDevices, lighthouseDevices, data.knownDevices)
+      )
+    );
   }
 
   public async getDevicesForSelection(selection: DeviceSelection): Promise<{
@@ -204,6 +213,15 @@ export class DeviceManagerService {
     ovrDevices: OVRDevice[];
     knownDevices: DMKnownDevice[];
   }> {
+    return firstValueFrom(this.getDevicesForSelectionStream(selection));
+  }
+
+  private resolveSelection(
+    selection: DeviceSelection,
+    openvrDevices: OVRDevice[],
+    lighthouseDevices: LighthouseDevice[],
+    knownDevices: DMKnownDevice[]
+  ) {
     const result: {
       lighthouseDevices: LighthouseDevice[];
       ovrDevices: OVRDevice[];
@@ -214,23 +232,23 @@ export class DeviceManagerService {
       knownDevices: [],
     };
 
-    // Device types
+    // resolve device types
     for (const type of selection.types) {
-      result.knownDevices.push(
-        ...this._data.value.knownDevices.filter((d) => d.deviceType === type && !d.disabled)
-      );
+      result.knownDevices.push(...knownDevices.filter((d) => d.deviceType === type && !d.disabled));
       switch (type) {
         case 'HMD':
         case 'CONTROLLER':
         case 'TRACKER': {
-          const devices = await firstValueFrom(this.openvr.devices);
+          const devices = openvrDevices;
           switch (type) {
             case 'HMD':
               result.ovrDevices.push(
                 ...devices
                   .filter((d) => d.class === 'HMD')
                   .filter((d) => {
-                    const knownDevice = this.getKnownDeviceById(this.getIdForOpenVRDevice(d));
+                    const knownDevice = knownDevices.find(
+                      (known) => known.id === this.getIdForOpenVRDevice(d)
+                    );
                     return !knownDevice?.disabled;
                   })
               );
@@ -240,7 +258,9 @@ export class DeviceManagerService {
                 ...devices
                   .filter((d) => d.class === 'Controller')
                   .filter((d) => {
-                    const knownDevice = this.getKnownDeviceById(this.getIdForOpenVRDevice(d));
+                    const knownDevice = knownDevices.find(
+                      (known) => known.id === this.getIdForOpenVRDevice(d)
+                    );
                     return !knownDevice?.disabled;
                   })
               );
@@ -250,7 +270,9 @@ export class DeviceManagerService {
                 ...devices
                   .filter((d) => d.class === 'GenericTracker')
                   .filter((d) => {
-                    const knownDevice = this.getKnownDeviceById(this.getIdForOpenVRDevice(d));
+                    const knownDevice = knownDevices.find(
+                      (known) => known.id === this.getIdForOpenVRDevice(d)
+                    );
                     return !knownDevice?.disabled;
                   })
               );
@@ -259,9 +281,10 @@ export class DeviceManagerService {
           break;
         }
         case 'LIGHTHOUSE': {
-          const _devices = await firstValueFrom(this.lighthouse.devices);
-          _devices.forEach((d) => {
-            const knownDevice = this.getKnownDeviceById(this.getIdForLighthouseDevice(d));
+          lighthouseDevices.forEach((d) => {
+            const knownDevice = knownDevices.find(
+              (known) => known.id === this.getIdForLighthouseDevice(d)
+            );
             if (!knownDevice?.disabled) result.lighthouseDevices.push(d);
           });
           break;
@@ -274,13 +297,9 @@ export class DeviceManagerService {
       }
     }
 
-    // Device tags
-    const openvrDevices = await firstValueFrom(this.openvr.devices);
-    const lighthouseDevices = await firstValueFrom(this.lighthouse.devices);
+    // resolve device tags
     for (const tagId of selection.tagIds) {
-      const devices = this._data.value.knownDevices.filter(
-        (d) => d.tagIds.includes(tagId) && !d.disabled
-      );
+      const devices = knownDevices.filter((d) => d.tagIds.includes(tagId) && !d.disabled);
       for (const device of devices) {
         if (!result.knownDevices.find((d) => d.id === device.id)) {
           result.knownDevices.push(device);
@@ -301,9 +320,9 @@ export class DeviceManagerService {
       }
     }
 
-    // Individual devices
+    // resolve individual devices
     for (const deviceId of selection.devices) {
-      const device = this.getKnownDeviceById(deviceId);
+      const device = knownDevices.find((known) => known.id === deviceId);
       if (!device || device.disabled) continue;
       if (!result.knownDevices.find((d) => d.id === device.id)) {
         result.knownDevices.push(device);


### PR DESCRIPTION
Disabling or retagging a device could leave shutdown using old selection membership. Resolve selections synchronously from current devices and Device Manager data, while suppressing unrelated metadata and telemetry updates.

Validation: 158 tests pass on the complete stack, frontend typecheck and targeted ESLint pass. New tests cover four membership edits for OpenVR devices and base stations, including the shutdown action path with mocked commands. Real desktop checks passed for all four edits with simulated controllers and fixed device telemetry. Real device power-off was not exercised.

Stack: based on #290.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Device selections now update immediately when devices are disabled, tagged, untagged, or deleted.
  - Selection results remain accurate when devices recover or when an OpenVR device index is reused by another device.
  - Filtering for device types, individual devices, and tags now behaves consistently.
  - Changes to nicknames, tags, and telemetry do not trigger unnecessary selection updates.

- **Tests**
  - Added comprehensive coverage for device selection updates and shutdown automation integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->