### PR TITLE
fix(OYASUMIVR-12): restore brightness on return to simple mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed switching from advanced to simple brightness mode not restoring the saved brightness
+
 - Fixed device selections not refreshing immediately after tag or disabled-state changes
 
 - Fixed charging power-off automation using an outdated device selection

--- a/src-ui/app/services/brightness-control/simple-brightness-control.service.spec.ts
+++ b/src-ui/app/services/brightness-control/simple-brightness-control.service.spec.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import { AUTOMATION_CONFIGS_DEFAULT } from '../../models/automations';
 import { SimpleBrightnessControlService } from './simple-brightness-control.service';
@@ -15,7 +15,7 @@ async function setup(advancedMode = false) {
   const hardware = {
     driverIsAvailable: new BehaviorSubject(false),
     brightnessBounds: new BehaviorSubject([20, 100]),
-    setBrightness: vi.fn(async () => {}),
+    setBrightness: vi.fn<Dependencies[1]['setBrightness']>().mockResolvedValue(undefined),
     cancelActiveTransition: vi.fn(),
   };
   const software = {
@@ -94,6 +94,50 @@ describe('simple brightness mode changes', () => {
     h.software.setBrightness.mockClear();
     h.hardware.driverIsAvailable.next(false);
     await Promise.resolve();
+    expect(h.software.setBrightness).not.toHaveBeenCalled();
+    expect(h.hardware.setBrightness).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    'discards a pending restore after mode changes, including return to simple: %s',
+    async (returnToSimple) => {
+      const h = await setup();
+      h.hardware.driverIsAvailable.next(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await h.service.setBrightness(40);
+      h.mode(true);
+      let finish!: () => void;
+      h.software.setBrightness.mockImplementationOnce(
+        () => new Promise<void>((resolve) => (finish = resolve))
+      );
+      h.mode(false);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      h.mode(true);
+      await h.hardware.setBrightness(80);
+      if (returnToSimple) {
+        h.mode(false);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      h.hardware.setBrightness.mockClear();
+      finish();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(h.hardware.setBrightness).not.toHaveBeenCalled();
+    }
+  );
+
+  it('discards a restore that was waiting for hardware bounds', async () => {
+    const h = await setup();
+    h.hardware.driverIsAvailable.next(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    h.mode(true);
+    const bounds = new Subject<number[]>();
+    h.hardware.brightnessBounds = bounds as BehaviorSubject<number[]>;
+    h.software.setBrightness.mockClear();
+    h.hardware.setBrightness.mockClear();
+    h.mode(false);
+    h.mode(true);
+    bounds.next([20, 100]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(h.software.setBrightness).not.toHaveBeenCalled();
     expect(h.hardware.setBrightness).not.toHaveBeenCalled();
   });

--- a/src-ui/app/services/brightness-control/simple-brightness-control.service.spec.ts
+++ b/src-ui/app/services/brightness-control/simple-brightness-control.service.spec.ts
@@ -1,0 +1,100 @@
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../../models/automations';
+import { SimpleBrightnessControlService } from './simple-brightness-control.service';
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/plugin-log', () => ({ info: vi.fn(), warn: vi.fn() }));
+type Dependencies = ConstructorParameters<typeof SimpleBrightnessControlService>;
+
+async function setup(advancedMode = false) {
+  const configs = new BehaviorSubject({
+    ...structuredClone(AUTOMATION_CONFIGS_DEFAULT),
+    BRIGHTNESS_AUTOMATIONS: { ...AUTOMATION_CONFIGS_DEFAULT.BRIGHTNESS_AUTOMATIONS, advancedMode },
+  });
+  const hardware = {
+    driverIsAvailable: new BehaviorSubject(false),
+    brightnessBounds: new BehaviorSubject([20, 100]),
+    setBrightness: vi.fn(async () => {}),
+    cancelActiveTransition: vi.fn(),
+  };
+  const software = {
+    setBrightness: vi.fn<Dependencies[2]['setBrightness']>().mockResolvedValue(undefined),
+    cancelActiveTransition: vi.fn(),
+  };
+  const service = new SimpleBrightnessControlService(
+    { configs } as unknown as Dependencies[0],
+    hardware as unknown as Dependencies[1],
+    software as unknown as Dependencies[2]
+  );
+  const cancel = vi.spyOn(service, 'cancelActiveTransition');
+  await service.init();
+  const mode = (value: boolean) =>
+    configs.next({
+      ...configs.value,
+      BRIGHTNESS_AUTOMATIONS: { ...configs.value.BRIGHTNESS_AUTOMATIONS, advancedMode: value },
+    });
+  return { configs, hardware, software, service, cancel, mode };
+}
+
+describe('simple brightness mode changes', () => {
+  it('reapplies the stored value exactly once when returning from advanced mode', async () => {
+    const h = await setup();
+    await h.service.setBrightness(40);
+    h.mode(true);
+    await h.software.setBrightness(80);
+    h.software.setBrightness.mockClear();
+    h.mode(false);
+    await Promise.resolve();
+    h.mode(false);
+    expect(h.software.setBrightness).toHaveBeenCalledExactlyOnceWith(40, {
+      cancelActiveTransition: true,
+      logReason: null,
+    });
+    expect(h.service.brightness).toBe(40);
+    expect(h.hardware.cancelActiveTransition).toHaveBeenCalledTimes(2);
+    expect(h.software.cancelActiveTransition).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([false, true])('ignores unrelated edits while advanced mode is %s', async (advanced) => {
+    const h = await setup(advanced);
+    h.configs.next({
+      ...h.configs.value,
+      DEVICE_POWER_AUTOMATIONS: {
+        ...h.configs.value.DEVICE_POWER_AUTOMATIONS,
+        enabled: !h.configs.value.DEVICE_POWER_AUTOMATIONS.enabled,
+      },
+    });
+    h.mode(advanced);
+    expect(h.cancel).not.toHaveBeenCalled();
+    expect(h.hardware.cancelActiveTransition).not.toHaveBeenCalled();
+    expect(h.software.cancelActiveTransition).not.toHaveBeenCalled();
+    expect(h.software.setBrightness).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    'initializes advanced mode %s without applying brightness',
+    async (advanced) => {
+      const h = await setup(advanced);
+      expect(await firstValueFrom(h.service.advancedMode)).toBe(advanced);
+      expect(h.cancel).not.toHaveBeenCalled();
+      expect(h.software.setBrightness).not.toHaveBeenCalled();
+    }
+  );
+
+  it('preserves hardware availability mapping in simple mode', async () => {
+    const h = await setup();
+    await h.service.setBrightness(40);
+    h.hardware.driverIsAvailable.next(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(h.software.setBrightness).toHaveBeenLastCalledWith(100, expect.anything());
+    expect(h.hardware.setBrightness).toHaveBeenLastCalledWith(40, expect.anything());
+    h.mode(true);
+    h.hardware.setBrightness.mockClear();
+    h.software.setBrightness.mockClear();
+    h.hardware.driverIsAvailable.next(false);
+    await Promise.resolve();
+    expect(h.software.setBrightness).not.toHaveBeenCalled();
+    expect(h.hardware.setBrightness).not.toHaveBeenCalled();
+  });
+});

--- a/src-ui/app/services/brightness-control/simple-brightness-control.service.ts
+++ b/src-ui/app/services/brightness-control/simple-brightness-control.service.ts
@@ -28,6 +28,7 @@ import { listen } from '@tauri-apps/api/event';
 })
 export class SimpleBrightnessControlService {
   private _advancedMode = new BehaviorSubject(false);
+  private modeGeneration = 0;
   private _brightness: BehaviorSubject<number> = new BehaviorSubject<number>(100);
   private _activeTransition = new BehaviorSubject<BrightnessTransitionTask | undefined>(undefined);
   public readonly activeTransition = this._activeTransition.asObservable();
@@ -59,6 +60,7 @@ export class SimpleBrightnessControlService {
         skip(1)
       )
       .subscribe(async (advancedMode) => {
+        this.modeGeneration++;
         this.cancelActiveTransition();
         this.hardwareBrightnessControl.cancelActiveTransition();
         this.softwareBrightnessControl.cancelActiveTransition();
@@ -135,6 +137,7 @@ export class SimpleBrightnessControlService {
   ) {
     const opt = { ...SET_BRIGHTNESS_OR_CCT_OPTIONS_DEFAULTS, ...(options ?? {}) };
     percentage = clamp(percentage, 0, 100);
+    const modeGeneration = this.modeGeneration;
     if (opt.cancelActiveTransition) this.cancelActiveTransition();
     this._brightness.next(percentage);
     if (opt.logReason) {
@@ -165,10 +168,12 @@ export class SimpleBrightnessControlService {
       }
     }
     // Set brightnesses
+    if (modeGeneration !== this.modeGeneration) return;
     await this.softwareBrightnessControl.setBrightness(softwareBrightness, {
       cancelActiveTransition: true,
       logReason: null,
     });
+    if (modeGeneration !== this.modeGeneration) return;
     if (this.hardwareBrightnessDriverAvailable) {
       await this.hardwareBrightnessControl.setBrightness(hardwareBrightness, {
         cancelActiveTransition: true,

--- a/src-ui/app/services/brightness-control/simple-brightness-control.service.ts
+++ b/src-ui/app/services/brightness-control/simple-brightness-control.service.ts
@@ -50,11 +50,12 @@ export class SimpleBrightnessControlService {
     await listen<number>('setSimpleBrightness', async (event) => {
       await this.setBrightness(event.payload, { cancelActiveTransition: true });
     });
-    // Set brightness when switching to simple mode
+    // apply brightness on mode changes
     this.automationConfigService.configs
       .pipe(
-        map((configs) => configs.BRIGHTNESS_AUTOMATIONS),
-        tap((config) => this._advancedMode.next(config.advancedMode)),
+        map((configs) => configs.BRIGHTNESS_AUTOMATIONS.advancedMode),
+        distinctUntilChanged(),
+        tap((advancedMode) => this._advancedMode.next(advancedMode)),
         skip(1)
       )
       .subscribe(async (advancedMode) => {

--- a/src-ui/app/services/brightness-control/simple-brightness-control.service.ts
+++ b/src-ui/app/services/brightness-control/simple-brightness-control.service.ts
@@ -28,7 +28,7 @@ import { listen } from '@tauri-apps/api/event';
 })
 export class SimpleBrightnessControlService {
   private _advancedMode = new BehaviorSubject(false);
-  private modeGeneration = 0;
+  private _modeGeneration = 0;
   private _brightness: BehaviorSubject<number> = new BehaviorSubject<number>(100);
   private _activeTransition = new BehaviorSubject<BrightnessTransitionTask | undefined>(undefined);
   public readonly activeTransition = this._activeTransition.asObservable();
@@ -60,7 +60,7 @@ export class SimpleBrightnessControlService {
         skip(1)
       )
       .subscribe(async (advancedMode) => {
-        this.modeGeneration++;
+        this._modeGeneration++;
         this.cancelActiveTransition();
         this.hardwareBrightnessControl.cancelActiveTransition();
         this.softwareBrightnessControl.cancelActiveTransition();
@@ -137,7 +137,7 @@ export class SimpleBrightnessControlService {
   ) {
     const opt = { ...SET_BRIGHTNESS_OR_CCT_OPTIONS_DEFAULTS, ...(options ?? {}) };
     percentage = clamp(percentage, 0, 100);
-    const modeGeneration = this.modeGeneration;
+    const modeGeneration = this._modeGeneration;
     if (opt.cancelActiveTransition) this.cancelActiveTransition();
     this._brightness.next(percentage);
     if (opt.logReason) {
@@ -168,12 +168,12 @@ export class SimpleBrightnessControlService {
       }
     }
     // Set brightnesses
-    if (modeGeneration !== this.modeGeneration) return;
+    if (modeGeneration !== this._modeGeneration) return;
     await this.softwareBrightnessControl.setBrightness(softwareBrightness, {
       cancelActiveTransition: true,
       logReason: null,
     });
-    if (modeGeneration !== this.modeGeneration) return;
+    if (modeGeneration !== this._modeGeneration) return;
     if (this.hardwareBrightnessDriverAvailable) {
       await this.hardwareBrightnessControl.setBrightness(hardwareBrightness, {
         cancelActiveTransition: true,


### PR DESCRIPTION
Returning from advanced to simple mode left the applied brightness unchanged. Observe the mode boolean, reapply the stored simple value on return, and ignore unrelated configuration edits. Discard pending simple-mode writes after another mode change.

Validation: 158 tests pass on the complete stack, frontend typecheck and targeted ESLint pass. Nine tests cover mode changes, unrelated edits, initial state, and hardware brightness mapping. Real desktop checks passed for mode restoration, uninterrupted transitions after unrelated edits, and cancellation on a mode change. A delayed restore did not overwrite a newer advanced hardware setting. Headset commands were simulated.

Stack: based on #291.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Switching from advanced to simple brightness mode now restores the saved brightness value.
  - Prevented outdated or pending brightness changes from being applied after a mode switch.
  - Brightness restoration now waits for hardware limits when necessary and is canceled safely if the mode changes again.

- **Tests**
  - Added coverage for interrupted brightness restoration scenarios, including hardware-bound delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
