### PR TITLE
fix(OYASUMIVR-9): await update installation and allow retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed duplicate update installations and allowed retries after installation or restart failures
+
 - Fixed switching from advanced to simple brightness mode not restoring the saved brightness
 
 - Fixed device selections not refreshing immediately after tag or disabled-state changes

--- a/src-ui/app/components/update-modal/update-modal.component.ts
+++ b/src-ui/app/components/update-modal/update-modal.component.ts
@@ -26,7 +26,9 @@ export class UpdateModalComponent
 {
   update?: Update;
   currentVersion = '';
-  installing = false;
+  get installing() {
+    return this.updateService.installing();
+  }
 
   constructor(
     private updateService: UpdateService,
@@ -48,11 +50,9 @@ export class UpdateModalComponent
 
   async install() {
     if (this.installing) return;
-    this.installing = true;
     try {
       await this.updateService.installUpdate();
     } finally {
-      this.installing = false;
       this.cdr.markForCheck();
     }
   }

--- a/src-ui/app/components/update-modal/update-modal.component.ts
+++ b/src-ui/app/components/update-modal/update-modal.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  OnInit,
-  ChangeDetectionStrategy,
-} from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Update } from '@tauri-apps/plugin-updater';
 import { BaseModalComponent } from 'src-ui/app/components/base-modal/base-modal.component';
 import { UpdateService } from '../../services/update.service';
@@ -52,8 +47,14 @@ export class UpdateModalComponent
   }
 
   async install() {
+    if (this.installing) return;
     this.installing = true;
-    await this.updateService.installUpdate();
+    try {
+      await this.updateService.installUpdate();
+    } finally {
+      this.installing = false;
+      this.cdr.markForCheck();
+    }
   }
 
   protected readonly FLAVOUR = FLAVOUR;

--- a/src-ui/app/services/update.service.spec.ts
+++ b/src-ui/app/services/update.service.spec.ts
@@ -52,6 +52,49 @@ afterEach(() => {
 });
 
 describe('update installation lifecycle', () => {
+  it('shares a pending installation and handles its failure once', async () => {
+    const h = await setup();
+    const first = h.service.installUpdate();
+    const second = h.service.installUpdate();
+    expect(second).toBe(first);
+    expect(h.service.installing()).toBe(true);
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(1);
+    h.download.reject(new Error('download failed'));
+    await Promise.all([first, second]);
+    expect(h.service.installing()).toBe(false);
+    expect(h.addModal).toHaveBeenCalledTimes(1);
+    h.downloadAndInstall.mockResolvedValueOnce();
+    await h.service.installUpdate();
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps recreated settings and another modal busy during installation', async () => {
+    const h = await setup();
+    const first = h.service.installUpdate();
+    type Dependencies = ConstructorParameters<typeof SettingsUpdatesViewComponent>;
+    const recreated = new SettingsUpdatesViewComponent(
+      h.service,
+      {} as Dependencies[1],
+      {} as Dependencies[2],
+      {} as Dependencies[3],
+      {} as Dependencies[4]
+    );
+    recreated['updateAvailable'] = { checked: true, update: h.update };
+    const modal = new UpdateModalComponent(h.service, {
+      markForCheck: vi.fn(),
+    } as unknown as ConstructorParameters<typeof UpdateModalComponent>[1]);
+    expect(recreated['updateOrCheckInProgress']).toBe(true);
+    expect(modal.installing).toBe(true);
+    await recreated.updateOrCheck();
+    await modal.install();
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(1);
+    h.download.reject(new Error('download failed'));
+    await first;
+    expect(recreated['updateOrCheckInProgress']).toBe(false);
+    expect(modal.installing).toBe(false);
+    expect(h.addModal).toHaveBeenCalledTimes(1);
+  });
+
   it('waits for installation and relaunch before settling', async () => {
     const h = await setup();
     const restart = deferred();

--- a/src-ui/app/services/update.service.spec.ts
+++ b/src-ui/app/services/update.service.spec.ts
@@ -1,0 +1,154 @@
+import '@angular/compiler';
+import { of } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { UpdateService } from './update.service';
+import { UpdateModalComponent } from '../components/update-modal/update-modal.component';
+import { SettingsUpdatesViewComponent } from '../views/dashboard-view/views/settings-updates-view/settings-updates-view.component';
+import type { Update } from '@tauri-apps/plugin-updater';
+
+const { relaunch, check } = vi.hoisted(() => ({ relaunch: vi.fn(), check: vi.fn() }));
+vi.mock('@tauri-apps/plugin-updater', () => ({ check }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch }));
+vi.mock('@tauri-apps/plugin-log', () => ({ info: vi.fn(), error: vi.fn() }));
+vi.mock('../../build', () => ({ FLAVOUR: 'STANDALONE' }));
+vi.mock('src-ui/build', () => ({ FLAVOUR: 'STANDALONE' }));
+vi.mock('../components/confirm-modal/confirm-modal.component', () => ({
+  ConfirmModalComponent: class {},
+}));
+vi.mock('src-ui/app/components/base-modal/base-modal.component', () => ({
+  BaseModalComponent: class {
+    close() {}
+  },
+}));
+vi.mock('src-ui/app/utils/animations', () => ({ hshrink: () => [] }));
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function setup() {
+  const download = deferred();
+  const downloadAndInstall = vi.fn(() => download.promise);
+  const update = { downloadAndInstall, version: '2', currentVersion: '1' } as unknown as Update;
+  check.mockResolvedValue(update);
+  relaunch.mockResolvedValue(undefined);
+  const addModal = vi.fn(() => of({}));
+  const service = new UpdateService({ addModal } as unknown as ConstructorParameters<
+    typeof UpdateService
+  >[0]);
+  await service.checkForUpdate();
+  return { service, download, downloadAndInstall, addModal, update };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetAllMocks();
+});
+
+describe('update installation lifecycle', () => {
+  it('waits for installation and relaunch before settling', async () => {
+    const h = await setup();
+    const restart = deferred();
+    relaunch.mockReturnValueOnce(restart.promise);
+    const settled = vi.fn();
+    const installing = h.service.installUpdate().then(settled);
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+    h.download.resolve();
+    await Promise.resolve();
+    expect(relaunch).toHaveBeenCalledTimes(1);
+    expect(settled).not.toHaveBeenCalled();
+    restart.resolve();
+    await installing;
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(h.addModal).not.toHaveBeenCalled();
+  });
+
+  it('handles an asynchronous installation failure once and permits retry', async () => {
+    const h = await setup();
+    const installing = h.service.installUpdate();
+    h.download.reject(new Error('download failed'));
+    await installing;
+    expect(h.addModal).toHaveBeenCalledTimes(1);
+    expect(relaunch).not.toHaveBeenCalled();
+    h.downloadAndInstall.mockResolvedValueOnce();
+    await h.service.installUpdate();
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(2);
+    expect(relaunch).toHaveBeenCalledTimes(1);
+    expect(h.addModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles relaunch rejection through the existing error modal', async () => {
+    const h = await setup();
+    relaunch.mockRejectedValueOnce(new Error('restart failed'));
+    const installing = h.service.installUpdate();
+    h.download.resolve();
+    await installing;
+    expect(h.addModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when there is no update', async () => {
+    const h = await setup();
+    check.mockResolvedValueOnce(null);
+    await h.service.checkForUpdate();
+    await h.service.installUpdate();
+    expect(h.downloadAndInstall).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it('keeps settings busy past one second, suppresses another click, and permits retry', async () => {
+    vi.useFakeTimers();
+    const h = await setup();
+    type Dependencies = ConstructorParameters<typeof SettingsUpdatesViewComponent>;
+    const settings = new SettingsUpdatesViewComponent(
+      h.service,
+      {} as Dependencies[1],
+      {} as Dependencies[2],
+      {} as Dependencies[3],
+      {} as Dependencies[4]
+    );
+    settings['updateAvailable'] = { checked: true, update: h.update };
+    const installing = settings.updateOrCheck();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(settings['updateOrCheckInProgress']).toBe(true);
+    await settings.updateOrCheck();
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(1);
+    h.download.reject(new Error('download failed'));
+    await installing;
+    expect(settings['updateOrCheckInProgress']).toBe(false);
+    expect(h.addModal).toHaveBeenCalledTimes(1);
+    h.downloadAndInstall.mockResolvedValueOnce();
+    const retry = settings.updateOrCheck();
+    await vi.advanceTimersByTimeAsync(1000);
+    await retry;
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(2);
+    expect(settings['updateOrCheckInProgress']).toBe(false);
+  });
+
+  it('clears modal busy state after failure and marks the OnPush view for checking', async () => {
+    const h = await setup();
+    const markForCheck = vi.fn();
+    const modal = new UpdateModalComponent(h.service, {
+      markForCheck,
+    } as unknown as ConstructorParameters<typeof UpdateModalComponent>[1]);
+    const installing = modal.install();
+    expect(modal.installing).toBe(true);
+    await modal.install();
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(1);
+    h.download.reject(new Error('download failed'));
+    await installing;
+    expect(modal.installing).toBe(false);
+    expect(markForCheck).toHaveBeenCalledTimes(1);
+    h.downloadAndInstall.mockResolvedValueOnce();
+    await modal.install();
+    expect(h.downloadAndInstall).toHaveBeenCalledTimes(2);
+    expect(modal.installing).toBe(false);
+  });
+});

--- a/src-ui/app/services/update.service.ts
+++ b/src-ui/app/services/update.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { BehaviorSubject, filter, interval, switchMap, take } from 'rxjs';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { ConfirmModalComponent } from '../components/confirm-modal/confirm-modal.component';
@@ -16,6 +16,8 @@ export class UpdateService {
     checked: false,
   });
   public updateAvailable = this._updateAvailable.asObservable();
+  readonly installing = signal(false);
+  private pendingInstallation?: Promise<void>;
 
   constructor(private modalService: ModalService) {}
 
@@ -76,9 +78,19 @@ export class UpdateService {
     }
   }
 
-  async installUpdate() {
+  installUpdate(): Promise<void> {
+    if (this.pendingInstallation) return this.pendingInstallation;
     const update = this._updateAvailable.value?.update;
-    if (!update) return;
+    if (!update) return Promise.resolve();
+    this.installing.set(true);
+    this.pendingInstallation = this.performInstallation(update).finally(() => {
+      this.pendingInstallation = undefined;
+      this.installing.set(false);
+    });
+    return this.pendingInstallation;
+  }
+
+  private async performInstallation(update: Update) {
     info(`[Update] Installing update...`);
     try {
       await update.downloadAndInstall();

--- a/src-ui/app/services/update.service.ts
+++ b/src-ui/app/services/update.service.ts
@@ -81,17 +81,9 @@ export class UpdateService {
     if (!update) return;
     info(`[Update] Installing update...`);
     try {
-      update.downloadAndInstall((event) => {
-        switch (event.event) {
-          case 'Started':
-          case 'Progress':
-            break;
-          case 'Finished':
-            info(`[Update] Update complete. Relaunching...`);
-            relaunch();
-            return;
-        }
-      });
+      await update.downloadAndInstall();
+      info(`[Update] Update complete. Relaunching...`);
+      await relaunch();
     } catch (e) {
       info(`[Update] Update error occurred: ${e}`);
       this.modalService

--- a/src-ui/app/views/dashboard-view/views/settings-updates-view/settings-updates-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-updates-view/settings-updates-view.component.ts
@@ -23,7 +23,10 @@ export class SettingsUpdatesViewComponent implements OnInit {
   protected updateAvailable: { checked: boolean; update?: Update } = { checked: false };
   protected version = '';
   protected changelog: SafeHtml = '';
-  protected updateOrCheckInProgress = false;
+  private requestInProgress = false;
+  protected get updateOrCheckInProgress() {
+    return this.requestInProgress || this.update.installing();
+  }
   protected FLAVOUR = FLAVOUR;
 
   constructor(
@@ -66,11 +69,11 @@ export class SettingsUpdatesViewComponent implements OnInit {
 
   async updateOrCheck() {
     if (this.updateOrCheckInProgress) return;
-    this.updateOrCheckInProgress = true;
+    this.requestInProgress = true;
     await Promise.allSettled([
       this.updateAvailable.update ? this.update.installUpdate() : this.update.checkForUpdate(false),
       new Promise((resolve) => setTimeout(resolve, 1000)),
     ]);
-    this.updateOrCheckInProgress = false;
+    this.requestInProgress = false;
   }
 }


### PR DESCRIPTION
Update failures escaped the error handler, and controls could become available while installation was still running. Share one pending installation across callers, await installation and relaunch, and restore controls after failure.

Validation: 158 tests pass on the complete stack, frontend typecheck and targeted ESLint pass. Deferred updater tests cover pending work, failure feedback, duplicate clicks, recreated Settings views, retry, and relaunch failure through the service and both callers. Real desktop modal and Settings checks passed with a simulated updater, including navigation during a pending install, retry, and relaunch failure. No live installation ran. A dev rebuild interrupted the final Settings restart-error dismissal; modal restart-error recovery and Settings install-error recovery passed.

Stack: based on #292.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation reliability by handling download, installation, and restart failures consistently.
  * Prevented duplicate installation attempts while an update is already in progress.
  * Ensured update screens and dialogs accurately display installation progress and clear their busy state after success or failure.
  * Allowed users to retry after unsuccessful update checks or installations.
  * Improved behavior when no update is available or restarting after installation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
