### PR TITLE
fix(OYASUMIVR-68): save typed MSI Afterburner paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed manually entered MSI Afterburner paths not being saved
+
 - Fixed duplicate update installations and allowed retries after installation or restart failures
 
 - Fixed switching from advanced to simple brightness mode not restoring the saved brightness

--- a/src-ui/app/views/dashboard-view/views/gpu-automations-view/msi-afterburner-pane/msi-afterburner-pane.component.html
+++ b/src-ui/app/views/dashboard-view/views/gpu-automations-view/msi-afterburner-pane/msi-afterburner-pane.component.html
@@ -11,7 +11,7 @@
         <input
           type="text"
           [value]="config.msiAfterburnerPath"
-          (keyup)="msiAfterburnerPathInputChange.next(msiAfterburnerPathInput.value)"
+          (input)="msiAfterburnerPathInputChange.next(msiAfterburnerPathInput.value)"
           #msiAfterburnerPathInput
         />
       </div>

--- a/src-ui/app/views/dashboard-view/views/gpu-automations-view/msi-afterburner-pane/msi-afterburner-pane.component.spec.ts
+++ b/src-ui/app/views/dashboard-view/views/gpu-automations-view/msi-afterburner-pane/msi-afterburner-pane.component.spec.ts
@@ -1,0 +1,148 @@
+import '@angular/compiler';
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MsiAfterburnerPaneComponent } from './msi-afterburner-pane.component';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../../../../../models/automations';
+import type { ExecutableReferenceStatus } from '../../../../../models/settings';
+
+const openFile = vi.hoisted(() => vi.fn());
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: openFile }));
+type Dependencies = ConstructorParameters<typeof MsiAfterburnerPaneComponent>;
+const typed = 'C:\\typed\\MSIAfterburner.exe';
+const browsed = 'C:\\browsed\\MSIAfterburner.exe';
+
+function setup() {
+  const callbacks = new Set<() => void>();
+  const destroy = {
+    destroyed: false,
+    onDestroy: (callback: () => void) => {
+      callbacks.add(callback);
+      return () => callbacks.delete(callback);
+    },
+    run: () => {
+      destroy.destroyed = true;
+      [...callbacks].forEach((callback) => callback());
+    },
+  };
+  const config = new BehaviorSubject(structuredClone(AUTOMATION_CONFIGS_DEFAULT.MSI_AFTERBURNER));
+  const status = new BehaviorSubject<ExecutableReferenceStatus>('UNKNOWN');
+  const setPath = vi.fn(async (path: string) =>
+    config.next({ ...config.value, msiAfterburnerPath: path })
+  );
+  const gpu = {
+    msiAfterburnerConfig: config,
+    msiAfterburnerStatus: status,
+    setMSIAfterburnerPath: setPath,
+    setMSIAfterburnerProfileOnSleepEnable: vi.fn(),
+    setMSIAfterburnerProfileOnSleepDisable: vi.fn(),
+  };
+  const component = new MsiAfterburnerPaneComponent(
+    gpu as unknown as Dependencies[0],
+    destroy as unknown as Dependencies[1]
+  );
+  component.ngOnInit();
+  return { component, config, status, setPath, destroy, gpu };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.resetAllMocks();
+});
+
+describe('MSI path input', () => {
+  it('saves the latest input after 500ms and forwards validation status', async () => {
+    const h = setup();
+    h.component.msiAfterburnerPathInputChange.next('C:\\partial');
+    await vi.advanceTimersByTimeAsync(400);
+    h.component.msiAfterburnerPathInputChange.next(typed);
+    await vi.advanceTimersByTimeAsync(499);
+    expect(h.setPath).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(h.setPath).toHaveBeenCalledExactlyOnceWith(typed);
+    expect(h.config.value.msiAfterburnerPath).toBe(typed);
+    h.status.next('CHECKING');
+    expect(h.component.msiAfterburnerPathAlert?.loadingIndicator).toBe(true);
+    h.status.next('SUCCESS');
+    expect(h.component.msiAfterburnerPathAlert?.type).toBe('SUCCESS');
+    h.status.next('INVALID_SIGNATURE');
+    expect(h.component.msiAfterburnerPathAlert?.type).toBe('ERROR');
+    h.destroy.run();
+  });
+
+  it('flushes pending input once when navigating away', async () => {
+    const h = setup();
+    h.component.msiAfterburnerPathInputChange.next(typed);
+    await vi.advanceTimersByTimeAsync(100);
+    h.destroy.run();
+    expect(h.setPath).toHaveBeenCalledExactlyOnceWith(typed);
+    expect(h.config.value.msiAfterburnerPath).toBe(typed);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.setPath).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([false, true])(
+    'Browse supersedes pending text, including immediate navigation: %s',
+    async (navigate) => {
+      const h = setup();
+      h.component.msiAfterburnerPathInputChange.next(typed);
+      openFile.mockResolvedValueOnce(browsed);
+      await h.component.browseForMsiAfterburner();
+      expect(h.setPath).toHaveBeenCalledExactlyOnceWith(browsed);
+      if (navigate) h.destroy.run();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(h.config.value.msiAfterburnerPath).toBe(browsed);
+      expect(h.setPath).toHaveBeenCalledTimes(1);
+      if (!navigate) h.destroy.run();
+    }
+  );
+
+  it('retains pending text when Browse is cancelled', async () => {
+    const h = setup();
+    h.component.msiAfterburnerPathInputChange.next(typed);
+    openFile.mockResolvedValueOnce(null);
+    await h.component.browseForMsiAfterburner();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.setPath).toHaveBeenCalledExactlyOnceWith(typed);
+    h.destroy.run();
+  });
+
+  it('accepts text entered after a Browse selection', async () => {
+    const h = setup();
+    openFile.mockResolvedValueOnce(browsed);
+    await h.component.browseForMsiAfterburner();
+    h.component.msiAfterburnerPathInputChange.next(typed);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.setPath.mock.calls.map(([path]) => path)).toEqual([browsed, typed]);
+    h.destroy.run();
+  });
+
+  it('ignores a Browse result returned after navigation', async () => {
+    const h = setup();
+    let finish!: (path: string) => void;
+    openFile.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finish = resolve;
+      })
+    );
+    h.component.msiAfterburnerPathInputChange.next(typed);
+    const browsing = h.component.browseForMsiAfterburner();
+    h.destroy.run();
+    finish(browsed);
+    await browsing;
+    expect(h.setPath).toHaveBeenCalledExactlyOnceWith(typed);
+  });
+
+  it('saves an empty path and preserves profile selection behavior', async () => {
+    const h = setup();
+    h.component.msiAfterburnerPathInputChange.next('');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.setPath).toHaveBeenCalledExactlyOnceWith('');
+    h.component.changeProfile('ON_ENABLE', h.component.profileOptions[2]);
+    h.component.changeProfile('ON_DISABLE', h.component.profileOptions[3]);
+    expect(h.gpu.setMSIAfterburnerProfileOnSleepEnable).toHaveBeenCalledWith(2);
+    expect(h.gpu.setMSIAfterburnerProfileOnSleepDisable).toHaveBeenCalledWith(3);
+    h.destroy.run();
+  });
+});

--- a/src-ui/app/views/dashboard-view/views/gpu-automations-view/msi-afterburner-pane/msi-afterburner-pane.component.ts
+++ b/src-ui/app/views/dashboard-view/views/gpu-automations-view/msi-afterburner-pane/msi-afterburner-pane.component.ts
@@ -1,5 +1,5 @@
 import { Component, DestroyRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, filter, Subject } from 'rxjs';
 import {
   APP_SETTINGS_DEFAULT,
   AppSettings,
@@ -15,6 +15,7 @@ import {
 import { vshrink } from '../../../../../utils/animations';
 import { SelectBoxItem } from '../../../../../components/select-box/select-box.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { flushOnDestroy } from '../../../../../utils/rxjs-utils';
 
 @Component({
   selector: 'app-msi-afterburner-pane',
@@ -31,7 +32,7 @@ export class MsiAfterburnerPaneComponent implements OnInit {
     type: 'INFO' | 'SUCCESS' | 'ERROR';
     loadingIndicator?: boolean;
   };
-  msiAfterburnerPathInputChange: Subject<string> = new Subject();
+  msiAfterburnerPathInputChange: Subject<string | null> = new Subject();
   appSettings: AppSettings = structuredClone(APP_SETTINGS_DEFAULT);
   config: MSIAfterburnerAutomationConfig = structuredClone(
     AUTOMATION_CONFIGS_DEFAULT.MSI_AFTERBURNER
@@ -68,6 +69,15 @@ export class MsiAfterburnerPaneComponent implements OnInit {
     this.gpuAutomations.msiAfterburnerStatus
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((status) => this.processMSIAfterburnerStatus(status));
+    flushOnDestroy(this.msiAfterburnerPathInputChange, this.destroyRef);
+    this.msiAfterburnerPathInputChange
+      .pipe(
+        distinctUntilChanged(),
+        debounceTime(500),
+        filter((path): path is string => path !== null),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((path) => this.gpuAutomations.setMSIAfterburnerPath(path));
   }
 
   processMSIAfterburnerStatus(status: ExecutableReferenceStatus) {
@@ -105,7 +115,10 @@ export class MsiAfterburnerPaneComponent implements OnInit {
         },
       ],
     });
-    if (path && typeof path === 'string') await this.gpuAutomations.setMSIAfterburnerPath(path);
+    if (path && typeof path === 'string' && !this.destroyRef.destroyed) {
+      this.msiAfterburnerPathInputChange.next(null);
+      await this.gpuAutomations.setMSIAfterburnerPath(path);
+    }
   }
 
   changeProfile(event: 'ON_DISABLE' | 'ON_ENABLE', item: SelectBoxItem) {


### PR DESCRIPTION
Typing or pasting an MSI Afterburner path now saves and validates it after 500ms. Navigation flushes pending text, and Browse replaces queued text without a later overwrite.

Validation: 158 tests pass on the complete stack, frontend and new-test typechecks, Angular template compilation, and targeted ESLint pass. Eight new component tests cover debounce, navigation, Browse ordering and cancellation, alerts, and profile selection. Real desktop checks passed for typing, paste, navigation, native Browse, cancellation, and profile selection. Executable responses were simulated; no GPU profile was applied.

Stack: based on #293.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Manually entered MSI Afterburner paths now save reliably.
  - Path changes are captured while typing, including the latest text before leaving the screen.
  - Selecting a path through Browse now correctly takes precedence over pending text.
  - Cancelled or delayed Browse actions no longer overwrite newer entries.
  - Empty MSI Afterburner paths can be saved when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->