### PR TITLE
fix(OYASUMIVR-4): reject unavailable polar solar times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Automatic sunrise and sunset lookup no longer saves a false clock time during polar day or night
+
 - Fixed manually entered MSI Afterburner paths not being saved
 
 - Fixed duplicate update installations and allowed retries after installation or restart failures

--- a/src-core/src/commands/time.rs
+++ b/src-core/src/commands/time.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[tauri::command]
 pub async fn get_sunrise_sunset_time() -> Result<(String, String), String> {
+    // locate the current public address for solar calculations
     let ip = match public_ip::addr().await {
         Some(ip) => ip,
         None => return Err("IP_LOOKUP_FAILED".to_string()),
@@ -22,18 +23,54 @@ pub async fn get_sunrise_sunset_time() -> Result<(String, String), String> {
         }
         Err(_) => return Err("LOCATION_LOOKUP_FAILED".to_string()),
     };
+    // calculate today's events at the resolved coordinates
     let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(n) => n.as_millis() as i64,
         Err(_) => return Err("TIME_LOOKUP_FAILED".to_string()),
     };
     let sun_data = suncalc::get_times(suncalc::Timestamp(now), latitude, longitude, None);
-    let sunrise = sun_data.sunrise.0;
-    let sunset = sun_data.sunset.0;
-    let sunrise_utc = Utc.timestamp_millis_opt(sunrise).unwrap();
-    let sunset_utc = Utc.timestamp_millis_opt(sunset).unwrap();
-    let sunrise_local = Local.from_utc_datetime(&sunrise_utc.naive_utc());
-    let sunset_local = Local.from_utc_datetime(&sunset_utc.naive_utc());
-    let sunrise = sunrise_local.format("%H:%M").to_string();
-    let sunset = sunset_local.format("%H:%M").to_string();
+    // return local schedule times only for nearby events
+    let sunrise = local_hh_mm(sun_data.sunrise.0, now)
+        .ok_or_else(|| "SOLAR_EVENT_UNAVAILABLE".to_string())?;
+    let sunset =
+        local_hh_mm(sun_data.sunset.0, now).ok_or_else(|| "SOLAR_EVENT_UNAVAILABLE".to_string())?;
     Ok((sunrise, sunset))
+}
+
+fn local_hh_mm(timestamp_ms: i64, now_ms: i64) -> Option<String> {
+    if timestamp_ms.abs_diff(now_ms) > 48 * 3_600_000 {
+        return None;
+    }
+    let utc = Utc.timestamp_millis_opt(timestamp_ms).single()?;
+    Some(utc.with_timezone(&Local).format("%H:%M").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solar_times_require_a_nearby_valid_timestamp() {
+        let now = 1_787_486_400_000;
+        assert_eq!(local_hh_mm(0, now), None);
+        for hours in [-48, -47, 0, 47, 48] {
+            let timestamp = now + hours * 3_600_000;
+            let expected = Utc
+                .timestamp_millis_opt(timestamp)
+                .unwrap()
+                .with_timezone(&Local)
+                .format("%H:%M")
+                .to_string();
+            assert_eq!(local_hh_mm(timestamp, now), Some(expected));
+        }
+        for timestamp in [
+            now - 49 * 3_600_000,
+            now + 49 * 3_600_000,
+            i64::MIN,
+            i64::MAX,
+        ] {
+            assert_eq!(local_hh_mm(timestamp, now), None);
+        }
+        assert_eq!(local_hh_mm(i64::MAX, i64::MAX), None);
+    }
 }


### PR DESCRIPTION
Automatic sunrise and sunset lookup could save a false clock time during polar day or night. Reject events outside 48 hours of the lookup time and preserve local-time formatting for valid events.

The Rust timestamp regression and 13 existing brightness automation tests pass. In the desktop app, simulated unavailable events preserved saved times, and successful responses updated sunrise and sunset. Hardware writes were simulated during verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic sunrise and sunset lookups so polar day/night conditions no longer save an incorrect clock time.
  * Unavailable, invalid, or excessively distant solar events are now reported as unavailable instead of producing invalid times.

* **Tests**
  * Added coverage for nearby, distant, extreme, and invalid solar timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->