### PR TITLE
fix(OYASUMIVR-8): resolve custom OSC hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed custom OSC targets rejecting hostnames such as localhost
+
 - Fixed OpenVR device caches retaining records after a session ends
 
 - Automatic sunrise and sunset lookup no longer saves a false clock time during polar day or night

--- a/src-core/src/osc/commands.rs
+++ b/src-core/src/osc/commands.rs
@@ -4,9 +4,10 @@ use oyasumivr_oscquery::OSCMethod;
 use rosc::{encoder, OscMessage, OscPacket, OscType};
 use serde::{Deserialize, Serialize};
 use std::{
-    net::{SocketAddrV4, UdpSocket},
+    net::{SocketAddr, SocketAddrV4, UdpSocket},
     str::FromStr,
     sync::LazyLock,
+    time::Duration,
 };
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -169,28 +170,34 @@ pub async fn osc_send_command(
 
 #[tauri::command]
 pub async fn osc_valid_addr(addr: String) -> bool {
-    SocketAddrV4::from_str(addr.as_str()).is_ok()
+    resolve_osc_address(&addr).await.is_ok()
+}
+
+async fn resolve_osc_address(addr: &str) -> Result<SocketAddr, String> {
+    tokio::time::timeout(Duration::from_secs(5), tokio::net::lookup_host(addr))
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .and_then(|mut addresses| addresses.find(SocketAddr::is_ipv4))
+        .ok_or_else(|| "INVALID_ADDRESS".to_string())
 }
 
 async fn osc_send(addr: String, osc_addr: String, data: Vec<OscType>) -> Result<bool, String> {
-    // Get socket
+    // resolve an IPv4 destination before locking the sender
+    let to_addr = resolve_osc_address(&addr).await?;
+
     let socket_guard = OSC_SEND_SOCKET.lock().await;
     let socket = match socket_guard.as_ref() {
         Some(socket) => socket,
         None => return Err(String::from("NO_SOCKET")),
     };
-    // Parse address
-    let to_addr = match SocketAddrV4::from_str(addr.as_str()) {
-        Ok(addr) => addr,
-        Err(_) => return Err(String::from("INVALID_ADDRESS")),
-    };
-    // Construct message
+    // encode the address and typed arguments into one packet
     let msg_buf = encoder::encode(&OscPacket::Message(OscMessage {
         addr: osc_addr.clone(),
         args: data.clone(),
     }))
     .unwrap();
-    // Send message
+    // send the packet through the shared IPv4 socket
     if socket.send_to(&msg_buf, to_addr).is_err() {
         error!(
             "[Core] Failed to send OSC message (addr={addr}, osc_addr={osc_addr}, data={data:?})"
@@ -198,6 +205,57 @@ async fn osc_send(addr: String, osc_addr: String, data: Vec<OscType>) -> Result<
         return Err(String::from("SENDING_ERROR"));
     }
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolves_ipv4_hosts_and_sends_a_loopback_packet() {
+        for host in ["127.0.0.1", "localhost"] {
+            assert!(osc_valid_addr(format!("{host}:9000")).await);
+            assert!(resolve_osc_address(&format!("{host}:9000"))
+                .await
+                .unwrap()
+                .is_ipv4());
+        }
+        #[cfg(windows)]
+        assert!(osc_valid_addr(format!("{}:9000", std::env::var("COMPUTERNAME").unwrap())).await);
+        for addr in [
+            "no-port",
+            "invalid host:9000",
+            "[::1]:9000",
+            "localhost:65536",
+            "oyasumivr-no-such-host.invalid:9000",
+        ] {
+            assert!(!osc_valid_addr(addr.into()).await);
+        }
+
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        receiver
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        *OSC_SEND_SOCKET.lock().await = Some(UdpSocket::bind("127.0.0.1:0").unwrap());
+        let result = osc_send(
+            format!("localhost:{}", receiver.local_addr().unwrap().port()),
+            "/oyasumi/test".into(),
+            vec![OscType::Int(7)],
+        )
+        .await;
+        *OSC_SEND_SOCKET.lock().await = None;
+        assert_eq!(result, Ok(true));
+        let mut buffer = [0; 128];
+        let (size, _) = receiver.recv_from(&mut buffer).unwrap();
+        let (_, packet) = rosc::decoder::decode_udp(&buffer[..size]).unwrap();
+        assert_eq!(
+            packet,
+            OscPacket::Message(OscMessage {
+                addr: "/oyasumi/test".into(),
+                args: vec![OscType::Int(7)]
+            })
+        );
+    }
 }
 
 #[tauri::command]

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.spec.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.spec.ts
@@ -1,0 +1,112 @@
+import '@angular/compiler';
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { APP_SETTINGS_DEFAULT } from '../../../../models/settings';
+import { SettingsOscViewComponent } from './settings-osc-view.component';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+class TestComponent extends SettingsOscViewComponent {
+  editHost(host: string) {
+    this.customTargetHostChangeSubject.next(host);
+  }
+  get validity() {
+    return this.customTargetHostValidationState;
+  }
+}
+
+function setup() {
+  const callbacks = new Set<() => void>();
+  const destroy = {
+    destroyed: false,
+    onDestroy: (callback: () => void) => {
+      callbacks.add(callback);
+      return () => callbacks.delete(callback);
+    },
+    run: () => {
+      destroy.destroyed = true;
+      [...callbacks].forEach((callback) => callback());
+    },
+  };
+  const updateSettings = vi.fn(async () => {});
+  type Dependencies = ConstructorParameters<typeof SettingsOscViewComponent>;
+  const component = new TestComponent(
+    destroy as Dependencies[0],
+    {
+      settings: new BehaviorSubject(structuredClone(APP_SETTINGS_DEFAULT)),
+      updateSettings,
+    } as unknown as Dependencies[1],
+    { vrchatOscAddress: new BehaviorSubject(null) } as unknown as Dependencies[2]
+  );
+  void component.ngOnInit();
+  return { component, updateSettings, destroy };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.resetAllMocks();
+});
+
+it('persists a trimmed localhost only after backend acceptance', async () => {
+  vi.mocked(invoke).mockResolvedValue(true);
+  const h = setup();
+  h.component.editHost(' localhost ');
+  expect(h.component.validity).toBe('pending');
+  expect(h.updateSettings).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(500);
+  expect(invoke).toHaveBeenCalledExactlyOnceWith('osc_valid_addr', { addr: 'localhost:1' });
+  expect(h.component.validity).toBe('valid');
+  expect(h.updateSettings).toHaveBeenCalledExactlyOnceWith({ oscCustomTargetHost: 'localhost' });
+  h.destroy.run();
+});
+
+it.each([false, new Error('native failure')])(
+  'does not save a rejected host: %s',
+  async (result) => {
+    if (result instanceof Error) vi.mocked(invoke).mockRejectedValue(result);
+    else vi.mocked(invoke).mockResolvedValue(result);
+    const h = setup();
+    h.component.editHost('unresolvable.invalid');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.component.validity).toBe('invalid');
+    expect(h.updateSettings).not.toHaveBeenCalledWith({
+      oscCustomTargetHost: 'unresolvable.invalid',
+    });
+    expect(h.updateSettings).toHaveBeenCalledWith({ oscTargets: ['VRCHAT_OSCQUERY'] });
+    h.destroy.run();
+  }
+);
+
+it('ignores an old response as soon as a new host is typed', async () => {
+  let resolveOld!: (value: boolean) => void;
+  vi.mocked(invoke).mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        resolveOld = resolve;
+      })
+  );
+  vi.mocked(invoke).mockResolvedValueOnce(true);
+  const h = setup();
+  h.component.editHost('old.local');
+  await vi.advanceTimersByTimeAsync(500);
+  h.component.editHost('localhost');
+  resolveOld(false);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(h.component.validity).toBe('pending');
+  expect(h.updateSettings).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(500);
+  expect(h.updateSettings).toHaveBeenCalledExactlyOnceWith({ oscCustomTargetHost: 'localhost' });
+  h.destroy.run();
+});
+
+it('finishes validation for a valid edit flushed on navigation', async () => {
+  vi.mocked(invoke).mockResolvedValue(true);
+  const h = setup();
+  h.component.editHost('localhost');
+  h.destroy.run();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(h.updateSettings).toHaveBeenCalledExactlyOnceWith({ oscCustomTargetHost: 'localhost' });
+});

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.spec.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.spec.ts
@@ -110,3 +110,40 @@ it('finishes validation for a valid edit flushed on navigation', async () => {
   await vi.advanceTimersByTimeAsync(0);
   expect(h.updateSettings).toHaveBeenCalledExactlyOnceWith({ oscCustomTargetHost: 'localhost' });
 });
+
+it('ignores a successful old lookup after navigation and a newer edit', async () => {
+  let resolveOld!: (value: boolean) => void;
+  vi.mocked(invoke).mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        resolveOld = resolve;
+      })
+  );
+  vi.mocked(invoke).mockResolvedValueOnce(true);
+  const old = setup();
+  old.component.editHost('old.local');
+  await vi.advanceTimersByTimeAsync(500);
+  old.destroy.run();
+  const current = setup();
+  current.component.editHost('localhost');
+  await vi.advanceTimersByTimeAsync(500);
+  resolveOld(true);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(old.updateSettings).not.toHaveBeenCalled();
+  expect(current.updateSettings).toHaveBeenCalledExactlyOnceWith({
+    oscCustomTargetHost: 'localhost',
+  });
+  current.destroy.run();
+});
+
+it.each(['localhost.', 'vrchat_pc', '10.0.0.5.example.test'])(
+  'uses backend acceptance for %s',
+  async (host) => {
+    vi.mocked(invoke).mockResolvedValue(true);
+    const h = setup();
+    h.component.editHost(host);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.updateSettings).toHaveBeenCalledExactlyOnceWith({ oscCustomTargetHost: host });
+    h.destroy.run();
+  }
+);

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
@@ -44,7 +44,8 @@ export class SettingsOscViewComponent implements OnInit {
   protected showVRCTargetWarning = false;
 
   private destroyed = false;
-  private hostValidationGeneration = 0;
+  // host edits share a generation across navigation-created views
+  private static hostValidationGeneration = 0;
 
   constructor(
     private destroyRef: DestroyRef,
@@ -71,20 +72,20 @@ export class SettingsOscViewComponent implements OnInit {
     this.customTargetHostChangeSubject
       .pipe(
         tap(() => {
-          this.hostValidationGeneration++;
+          SettingsOscViewComponent.hostValidationGeneration++;
           this.customTargetHostValidationState = 'pending';
         }),
         debounceTime(500),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async (host) => {
-        const generation = this.hostValidationGeneration;
+        const generation = SettingsOscViewComponent.hostValidationGeneration;
         host = host.trim();
         // resolve the host independently of the port field
         const valid =
-          this.isValidHostname(host) &&
+          !!host &&
           (await invoke<boolean>('osc_valid_addr', { addr: `${host}:1` }).catch(() => false));
-        if (generation !== this.hostValidationGeneration) return;
+        if (generation !== SettingsOscViewComponent.hostValidationGeneration) return;
 
         // save only the latest accepted host, including navigation flushes
         if (valid) {
@@ -158,36 +159,6 @@ export class SettingsOscViewComponent implements OnInit {
     this.settingsService.updateSettings({
       oscTargets: [...this.oscTargets],
     });
-  }
-
-  private isValidHostname(host: string): boolean {
-    if (!host || !host.trim()) {
-      return false;
-    }
-
-    const trimmedHost = host.trim();
-
-    // Check if it's a valid IPv4 address
-    const ipv4Regex =
-      /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-    if (ipv4Regex.test(trimmedHost)) {
-      return true;
-    }
-
-    // If it looks like an IP address but failed the IPv4 test, reject it (probably false)
-    const looksLikeIp = /^\d+\.\d+\.\d+\.\d+/.test(trimmedHost);
-    if (looksLikeIp) {
-      return false;
-    }
-
-    // Check if it's a valid hostname/domain name
-    const hostnameRegex =
-      /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
-    if (hostnameRegex.test(trimmedHost) && trimmedHost.length <= 253) {
-      return true;
-    }
-
-    return false;
   }
 
   private isValidPort(port: number): boolean {

--- a/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/settings-osc-view/settings-osc-view.component.ts
@@ -1,8 +1,8 @@
 import { Component, DestroyRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { vshrink } from 'src-ui/app/utils/animations';
-import { AppSettingsService } from 'src-ui/app/services/app-settings.service';
-import { APP_SETTINGS_DEFAULT, OSCTarget } from 'src-ui/app/models/settings';
+import { vshrink } from '../../../../utils/animations';
+import { AppSettingsService } from '../../../../services/app-settings.service';
+import { APP_SETTINGS_DEFAULT, OSCTarget } from '../../../../models/settings';
 import {
   asyncScheduler,
   combineLatest,
@@ -13,9 +13,10 @@ import {
   tap,
   throttleTime,
 } from 'rxjs';
-import { OscService } from 'src-ui/app/services/osc.service';
-import { flushOnDestroy } from 'src-ui/app/utils/rxjs-utils';
+import { OscService } from '../../../../services/osc.service';
+import { flushOnDestroy } from '../../../../utils/rxjs-utils';
 import { isEqual, pick } from 'lodash';
+import { invoke } from '@tauri-apps/api/core';
 
 @Component({
   selector: 'app-settings-osc-view',
@@ -43,6 +44,7 @@ export class SettingsOscViewComponent implements OnInit {
   protected showVRCTargetWarning = false;
 
   private destroyed = false;
+  private hostValidationGeneration = 0;
 
   constructor(
     private destroyRef: DestroyRef,
@@ -65,15 +67,27 @@ export class SettingsOscViewComponent implements OnInit {
     flushOnDestroy(this.customTargetHostChangeSubject, this.destroyRef);
     flushOnDestroy(this.customTargetPortChangeSubject, this.destroyRef);
 
-    // Setup debounced validation for custom target host
+    // each host edit supersedes pending DNS validation
     this.customTargetHostChangeSubject
       .pipe(
-        tap(() => (this.customTargetHostValidationState = 'pending')),
+        tap(() => {
+          this.hostValidationGeneration++;
+          this.customTargetHostValidationState = 'pending';
+        }),
         debounceTime(500),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((host) => {
-        if (this.isValidHostname(host)) {
+      .subscribe(async (host) => {
+        const generation = this.hostValidationGeneration;
+        host = host.trim();
+        // resolve the host independently of the port field
+        const valid =
+          this.isValidHostname(host) &&
+          (await invoke<boolean>('osc_valid_addr', { addr: `${host}:1` }).catch(() => false));
+        if (generation !== this.hostValidationGeneration) return;
+
+        // save only the latest accepted host, including navigation flushes
+        if (valid) {
           this.customTargetHostValidationState = 'valid';
           this.settingsService.updateSettings({
             oscCustomTargetHost: host,


### PR DESCRIPTION
Custom OSC targets now resolve hostnames such as localhost to IPv4 for validation and sending. Settings reject names that cannot resolve and ignore outdated validation results across navigation.

Verified with Rust address-resolution and UDP tests, nine frontend tests, TypeScript checking, and the real desktop settings and script editor. A local listener received the test message through the saved hostname target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Custom OSC destinations now accept valid hostnames, including `localhost`.
  - OSC connections resolve hostnames reliably before sending messages.
  - Invalid, unreachable, IPv6-only, and out-of-range destinations are rejected with clearer validation behavior.
  - Hostname validation now handles rapid edits and navigation changes correctly, preventing outdated results from overwriting newer settings.
  - Accepted hostnames are trimmed and saved consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->