### PR TITLE
fix(OYASUMIVR-19): gate overlay notifications on readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed overlay notification readiness and notification IDs used for dismissal.
+
 - Fixed custom OSC targets rejecting hostnames such as localhost
 
 - Fixed OpenVR device caches retaining records after a session ends

--- a/src-overlay-sidecar/Managers/OyasumiOverlaySidecarService.cs
+++ b/src-overlay-sidecar/Managers/OyasumiOverlaySidecarService.cs
@@ -21,7 +21,9 @@ public class OyasumiOverlaySidecarService : OyasumiOverlaySidecar.OyasumiOverlay
       request.Message,
       TimeSpan.FromMilliseconds(request.Duration)
     );
-    if (id == null) return Task.FromResult(new AddNotificationResponse());
+    if (id == null)
+      throw new RpcException(new Status(StatusCode.FailedPrecondition,
+        "Notification overlay is not ready or could not accept the notification"));
 
     return Task.FromResult(new AddNotificationResponse
     {

--- a/src-overlay-sidecar/Overlays/NotificationOverlay.cs
+++ b/src-overlay-sidecar/Overlays/NotificationOverlay.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
+using System.Globalization;
 using System.Web;
 using CefSharp;
+using Serilog;
 using Valve.VR;
 
 namespace overlay_sidecar;
@@ -29,20 +31,28 @@ public class NotificationOverlay : BaseWebOverlay {
 
   public string? AddNotification(string message, TimeSpan? duration = null)
   {
+    if (!UiReady || Disposed) return null;
+
+    var id = Guid.NewGuid().ToString();
     var script = $@"window.OyasumiIPCIn.addNotification({{
+            id: ""{id}"",
             message: ""{HttpUtility.JavaScriptStringEncode(message)}"",
-            duration: {duration?.TotalMilliseconds ?? 3000}
+            duration: {(duration?.TotalMilliseconds ?? 3000).ToString(CultureInfo.InvariantCulture)}
         }});";
     var task = Browser.EvaluateScriptAsync(script, TimeSpan.FromMilliseconds(5000));
     task.Wait();
-    return task.Result.Result as string;
+    return task.Result.Success ? id : null;
   }
 
   public void ClearNotification(string notificationId)
   {
+    if (!UiReady || Disposed) return;
+
     var script = $@"window.OyasumiIPCIn.clearNotification(""{HttpUtility.JavaScriptStringEncode(notificationId)}"");";
     var task = Browser.EvaluateScriptAsync(script, TimeSpan.FromMilliseconds(5000));
     task.Wait();
+    if (!task.Result.Success)
+      Log.Warning("Could not clear notification {Id}: {Error}", notificationId, task.Result.Message);
   }
 
   private void UpdatePosition()

--- a/src-overlay-ui/app/overlays/notifications/notifications-overlay.spec.ts
+++ b/src-overlay-ui/app/overlays/notifications/notifications-overlay.spec.ts
@@ -1,0 +1,52 @@
+import '@angular/compiler';
+import { DestroyRef, Injector, runInInjectionContext } from '@angular/core';
+import { Subject } from 'rxjs';
+import { afterEach, expect, it, vi } from 'vitest';
+import { IpcService } from '../../ipc/ipc.service';
+import { NotificationsOverlay } from './notifications-overlay';
+
+vi.mock('../../ipc/ipc.service', () => ({ IpcService: class {} }));
+vi.mock('../../components/notification/notification', () => ({ Notification: class {} }));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+it('subscribes before readiness and dismisses accepted notifications by ID', () => {
+  vi.useFakeTimers();
+  const notificationAdded = new Subject<{ id: string; message: string; duration: number }>();
+  const notificationCleared = new Subject<string>();
+  const cleanup: Array<() => void> = [];
+  const injector = Injector.create({
+    providers: [
+      { provide: IpcService, useValue: { notificationAdded, notificationCleared } },
+      { provide: DestroyRef, useValue: { onDestroy: (fn: () => void) => cleanup.push(fn) } },
+    ],
+  });
+  const onUiReady = vi.fn(() => {
+    expect(notificationAdded.observed).toBe(true);
+    expect(notificationCleared.observed).toBe(true);
+    notificationAdded.next({ id: 'accepted', message: 'test', duration: 3000 });
+    return Promise.resolve();
+  });
+  vi.stubGlobal('window', { OyasumiIPCOut: { onUiReady } });
+  class TestOverlay extends NotificationsOverlay {
+    get shown() {
+      return this.shownNotifications();
+    }
+  }
+
+  notificationAdded.next({ id: 'early', message: 'early', duration: 3000 });
+  const overlay = runInInjectionContext(injector, () => new TestOverlay());
+  expect(onUiReady).not.toHaveBeenCalled();
+  overlay.ngOnInit();
+  expect(overlay.shown.map((n) => n.id)).toEqual(['accepted']);
+  notificationCleared.next('accepted');
+  expect(overlay.shown).toEqual([]);
+
+  notificationAdded.next({ id: 'timed', message: 'timed', duration: 3000 });
+  vi.advanceTimersByTime(3000);
+  expect(overlay.shown).toEqual([]);
+  cleanup.forEach((fn) => fn());
+});

--- a/src-overlay-ui/app/overlays/notifications/notifications-overlay.ts
+++ b/src-overlay-ui/app/overlays/notifications/notifications-overlay.ts
@@ -4,6 +4,7 @@ import {
   computed,
   DestroyRef,
   inject,
+  OnInit,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -18,7 +19,7 @@ import { AddNotificationParams } from '../../ipc/oyasumi-ipc';
   styleUrl: './notifications-overlay.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NotificationsOverlay {
+export class NotificationsOverlay implements OnInit {
   private readonly ipc = inject(IpcService);
 
   private readonly notifications = signal<AddNotificationParams[]>([]);
@@ -39,6 +40,11 @@ export class NotificationsOverlay {
       this.updateActiveNotification();
     });
     inject(DestroyRef).onDestroy(() => clearTimeout(this.dismissTimer));
+  }
+
+  ngOnInit(): void {
+    // accept delivery after both notification subscriptions exist
+    void window.OyasumiIPCOut.onUiReady();
   }
 
   protected isActive(notification: AddNotificationParams): boolean {


### PR DESCRIPTION
Overlay notifications now wait for the page's existing readiness signal. Early adds return failure, early clears do nothing, and accepted notifications return an ID that can dismiss them.

Verified the sidecar build, overlay TypeScript check, and subscription-order test. A real SteamVR-connected sidecar rejected early and failed-script requests, then rendered and cleared a harmless notification through its gRPC service. Verification captured the live CEF page; headset-eye viewing was not checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification overlay readiness handling to prevent notifications from being silently lost when the overlay is unavailable.
  - Notifications can now be dismissed reliably using their unique notification IDs.
  - Improved handling of notification timing and cleanup, including safer behavior when the overlay is not ready or has been disposed.
  - Added clearer diagnostics when a notification cannot be displayed or dismissed.

- **Tests**
  - Added coverage for notification subscription, dismissal, UI readiness, and automatic removal after the configured duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->