### PR TITLE
fix(OYASUMIVR-51): keep devices in tracked-index order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed OpenVR device updates changing the tracked-index order of the device list.
+
 - Fixed missing image content types on the first request to the image cache.
 
 - Fixed overlay notification readiness and notification IDs used for dismissal.

--- a/src-ui/app/services/openvr.service.spec.ts
+++ b/src-ui/app/services/openvr.service.spec.ts
@@ -1,0 +1,37 @@
+import { ApplicationRef } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { expect, it, vi } from 'vitest';
+import { OVRDevice } from '../models/ovr-device';
+import { AppSettingsService } from './app-settings.service';
+import { OpenVRService } from './openvr.service';
+import { TelemetryService } from './telemetry.service';
+
+it('keeps devices in tracked-index order across arrivals and repeated updates', async () => {
+  const service = new OpenVRService(
+    { tick: vi.fn() } as unknown as ApplicationRef,
+    {} as AppSettingsService,
+    {} as TelemetryService
+  );
+  const device = (index: number): OVRDevice => ({
+    index,
+    class: 'GenericTracker',
+    role: 'Invalid',
+    battery: 50,
+    pose: null,
+    canPowerOff: true,
+    isTurningOff: false,
+  });
+
+  for (const index of [12, 0, 3]) service.onDeviceUpdate(device(index));
+  expect((await firstValueFrom(service.devices)).map((d) => d.index)).toEqual([0, 3, 12]);
+
+  for (const index of [12, 3, 12]) {
+    service.onDeviceUpdate({ ...device(index), battery: 40, isTurningOff: true });
+    const devices = await firstValueFrom(service.devices);
+    expect(devices.map((d) => d.index)).toEqual([0, 3, 12]);
+    expect(devices.find((d) => d.index === index)).toMatchObject({
+      battery: 40,
+      isTurningOff: true,
+    });
+  }
+});

--- a/src-ui/app/services/openvr.service.ts
+++ b/src-ui/app/services/openvr.service.ts
@@ -95,7 +95,7 @@ export class OpenVRService {
     this._devices.next(
       orderBy(
         [device, ...this._devices.value.filter((d) => d.index !== device.index)],
-        ['deviceIndex'],
+        ['index'],
         ['asc']
       )
     );


### PR DESCRIPTION
Sort OpenVR device updates by tracked index so updates preserve the device list order.

The regression test and TypeScript check pass. Verified Overview and Device Manager in the desktop app across native updates from nine devices, including a controller battery change.