### PR TITLE
fix(OYASUMIVR-7): read log timestamps as epoch milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Fixed VRChat log timestamps allowing the Quick Eeper achievement after its 20-minute window.
+
 - Fixed OpenVR device updates changing the tracked-index order of the device list.
 
 - Fixed missing image content types on the first request to the image cache.

--- a/src-core/src/vrc_log_parser/mod.rs
+++ b/src-core/src/vrc_log_parser/mod.rs
@@ -369,7 +369,8 @@ pub fn start_log_locator_task() -> CancellationToken {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_current_enough, pick_log_path};
+    use super::{is_current_enough, parse_datetime_from_line, pick_log_path, VRCLogEvent};
+    use chrono::{Local, TimeZone, Utc};
     use std::{
         fs,
         path::Path,
@@ -377,6 +378,24 @@ mod tests {
         time::{Duration, SystemTime},
     };
     use tempfile::tempdir;
+
+    #[test]
+    fn event_time_is_serialized_in_epoch_milliseconds() {
+        let instant = Utc.with_ymd_and_hms(2026, 8, 23, 20, 42, 35).unwrap();
+        let line = instant
+            .with_timezone(&Local)
+            .format("%Y.%m.%d %H:%M:%S")
+            .to_string();
+        let event = VRCLogEvent {
+            time: parse_datetime_from_line(line).unwrap(),
+            event: "OnPlayerJoined".to_string(),
+            data: "Me (usr_me)".to_string(),
+            initial_load: false,
+        };
+        let payload = serde_json::to_value(event).unwrap();
+        assert_eq!(payload["time"], 1_787_517_755_000_u64);
+        assert_eq!(payload["initialLoad"], false);
+    }
 
     fn create_log(dir: &Path, name: &str, contents: &[u8]) -> (String, SystemTime) {
         let path = dir.join(name);

--- a/src-ui/app/services/steam.service.ts
+++ b/src-ui/app/services/steam.service.ts
@@ -162,6 +162,7 @@ export class SteamService {
   private async handleAchievement_QUICK_EEPER() {
     this.sleep.onSleepModeChange
       .pipe(
+        // wait for automatic sleep detection
         filter((change) => {
           return (
             change.mode === true &&
@@ -169,6 +170,7 @@ export class SteamService {
             change.reason.automation === 'SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR'
           );
         }),
+        // read the active VRChat session's join time
         switchMap(() => this.vrchat.vrchatProcessActive.pipe(take(1))),
         filter(Boolean),
         switchMap(() =>
@@ -178,7 +180,12 @@ export class SteamService {
           )
         ),
         filter(Boolean),
-        filter((timestamp) => Date.now() - timestamp < 1000 * 60 * 20),
+        // restrict eligibility to the first twenty minutes
+        filter((timestamp) => {
+          const elapsed = Date.now() - timestamp;
+          return elapsed >= 0 && elapsed < 1000 * 60 * 20;
+        }),
+        // unlock only if the achievement is still locked
         tap(() => debug('[Steam] QUICK_EEPER achievement triggered')),
         switchMap(() => this.getAchievement(SteamAchievements.QUICK_EEPER)),
         filter((unlocked) => !unlocked),

--- a/src-ui/app/services/vrchat-log.service.spec.ts
+++ b/src-ui/app/services/vrchat-log.service.spec.ts
@@ -1,0 +1,81 @@
+import { BehaviorSubject, firstValueFrom, Subject } from 'rxjs';
+import { afterEach, expect, it, vi } from 'vitest';
+import type { VRChatOnPlayerJoinedEvent } from '../models/vrchat-log-event';
+import type { WorldContext } from '../models/vrchat';
+import { VRChatLogService } from './vrchat-log.service';
+import { VRChatService } from './vrchat-api/vrchat.service';
+import { SteamAchievements, SteamService } from './steam.service';
+import type { SleepService } from './sleep.service';
+import type { AppSettingsService } from './app-settings.service';
+import type { MqttService } from './mqtt/mqtt.service';
+
+vi.mock('@tauri-apps/plugin-log', () => ({ debug: vi.fn(), info: vi.fn(), error: vi.fn() }));
+vi.mock('src-ui/app/services/modal.service', () => ({ ModalService: class {} }));
+vi.mock('./vrchat-api/vrchat-api', () => ({ VRChatAPI: class {} }));
+vi.mock('./vrchat-api/vrchat-auth', () => ({ VRChatAuth: class {} }));
+vi.mock('./vrchat-api/vrchat-socket', () => ({ VRChatSocket: class {} }));
+vi.mock('./error-reporting.service', () => ({ ErrorReportingService: class {} }));
+vi.mock('src-ui/app/models/vrchat-api-settings', () => import('../models/vrchat-api-settings'));
+
+const time = 1787517755000;
+afterEach(() => vi.useRealTimers());
+
+it.each(['OnPlayerJoined', 'OnPlayerLeft', 'OnLocationChange'])(
+  'preserves native epoch milliseconds for %s',
+  async (event) => {
+    const service = new VRChatLogService();
+    const parsed = firstValueFrom(service.logEvents);
+    service['handleLogEvent']({ time, event, data: 'Me (usr_me)', initialLoad: true });
+    expect((await parsed).timestamp.toISOString()).toBe('2026-08-23T20:42:35.000Z');
+    expect((await parsed).initialLoad).toBe(true);
+  }
+);
+
+it.each([-1, 0, 20 * 60_000 - 1, 20 * 60_000, 21 * 60_000])(
+  'checks Quick Eeper at %i milliseconds after the current user joins',
+  async (elapsed) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(time + elapsed);
+    // parse the current user's native join event
+    const logs = new VRChatLogService();
+    const parsed = firstValueFrom(logs.logEvents);
+    logs['handleLogEvent']({
+      time,
+      event: 'OnPlayerJoined',
+      data: 'Me (usr_me)',
+      initialLoad: false,
+    });
+
+    // store the join time through the world handler
+    const world = new BehaviorSubject<WorldContext>({ loaded: false, players: [] });
+    const vrchat: VRChatService = Object.assign(Object.create(VRChatService.prototype), {
+      auth: { user: new BehaviorSubject({ id: 'usr_me' }) },
+      worldSubject: world,
+      world: world.asObservable(),
+      vrchatProcessActive: new BehaviorSubject(true),
+    });
+    await vrchat['handlePlayerJoined']((await parsed) as VRChatOnPlayerJoinedEvent);
+    expect(world.value.joinedAt).toBe(time);
+
+    // trigger sleep detection with Steam writes simulated
+    const changes = new Subject<{ mode: boolean; reason: object }>();
+    const steam = new SteamService(
+      { onSleepModeChange: changes } as unknown as SleepService,
+      vrchat,
+      {} as AppSettingsService,
+      {} as MqttService
+    );
+    vi.spyOn(steam, 'getAchievement').mockResolvedValue(false);
+    const unlock = vi.spyOn(steam, 'setAchievement').mockResolvedValue();
+    await steam['handleAchievement_QUICK_EEPER']();
+    changes.next({
+      mode: true,
+      reason: { type: 'AUTOMATION', automation: 'SLEEP_MODE_ENABLE_FOR_SLEEP_DETECTOR' },
+    });
+    await vi.runAllTimersAsync();
+    expect(unlock.mock.calls).toEqual(
+      elapsed >= 0 && elapsed < 20 * 60_000 ? [[SteamAchievements.QUICK_EEPER, true]] : []
+    );
+    changes.complete();
+  }
+);

--- a/src-ui/app/services/vrchat-log.service.ts
+++ b/src-ui/app/services/vrchat-log.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { VRChatLogEvent } from '../models/vrchat-log-event';
-import * as moment from 'moment';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 
 interface RawLogEvent {
+  /** Epoch milliseconds from the native log parser. */
   time: number;
   event: string;
   data: string;
@@ -45,7 +45,7 @@ export class VRChatLogService {
         const { displayName, userId } = this.parseNameAndId(event.data);
         this._logEvents.next({
           type: 'OnPlayerJoined',
-          timestamp: moment.unix(event.time).toDate(),
+          timestamp: new Date(event.time),
           initialLoad: event.initialLoad,
           displayName,
           userId,
@@ -56,7 +56,7 @@ export class VRChatLogService {
         const { displayName, userId } = this.parseNameAndId(event.data);
         this._logEvents.next({
           type: 'OnPlayerLeft',
-          timestamp: moment.unix(event.time).toDate(),
+          timestamp: new Date(event.time),
           initialLoad: event.initialLoad,
           displayName,
           userId,
@@ -66,7 +66,7 @@ export class VRChatLogService {
       case 'OnLocationChange':
         this._logEvents.next({
           type: 'OnLocationChange',
-          timestamp: moment.unix(event.time).toDate(),
+          timestamp: new Date(event.time),
           instanceId: event.data,
           initialLoad: event.initialLoad,
         });


### PR DESCRIPTION
Read native VRChat log timestamps as milliseconds and restrict Quick Eeper eligibility to the first twenty minutes after joining.

Tests cover native serialization, join/leave/location dates, world state, and the exact achievement boundary. TypeScript checks pass. Desktop checks covered eligible, expired, future, and repeated joins plus manual sleep toggling, with Steam achievement writes simulated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Quick Eeper achievement so it only triggers when joining a VRChat session within the valid 20-minute window.
  * Prevented future or incorrectly interpreted VRChat log timestamps from qualifying for the achievement.
  * Improved event timestamp handling to preserve accurate times for player joins, leaves, and location changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->