### PR TITLE
refactor(OYASUMIVR-52): remove the unused device-fetch method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Changed
 
+- Removed an unused frontend OpenVR device-fetch method; device updates still arrive through events.
+
 - Redesigned the About view so growing credits scroll inside the view instead of making the
   window grow
 - OyasumiVR no longer rewrites a settings file when nothing in it changed

--- a/src-ui/app/services/openvr.service.ts
+++ b/src-ui/app/services/openvr.service.ts
@@ -148,19 +148,6 @@ export class OpenVRService {
     }
   }
 
-  private async getDevices(): Promise<Array<OVRDevice>> {
-    // Get devices
-    let devices = await invoke<OVRDevice[]>('openvr_get_devices');
-    // Carry over current local state
-    devices = devices.map((device) => {
-      device.isTurningOff =
-        this._devices.value.find((d) => d.index === device.index)?.isTurningOff ?? false;
-      return device;
-    });
-    // Return newly fetched devices
-    return devices;
-  }
-
   private async applyOpenVrInitDelayFix(enabled: boolean) {
     await invoke('openvr_set_init_delay_fix', { enabled });
   }


### PR DESCRIPTION
Remove the unused private OpenVR device-fetch method. Event subscriptions and the sleeping-pose viewer remain unchanged.

The TypeScript check and device-update regression test pass.