### PR TITLE
fix(OYASUMIVR-77): release browser graphics resources on reuse

### DIFF
--- a/src-overlay-sidecar/Managers/OvrDXDeviceHander.cs
+++ b/src-overlay-sidecar/Managers/OvrDXDeviceHander.cs
@@ -40,10 +40,10 @@ public class NonAcceleratedOvrDXDeviceHander : OvrDXDeviceHander
   {
     try
     {
-      Factory f = new Factory1();
-      // Overlay textures are created on a task continuation while the render loop maps them
-      // on its own thread, so the device cannot skip its internal synchronisation.
-      Device = new Device(f.GetAdapter(GetVrAdapterIndex()),
+      using var factory = new Factory1();
+      using var adapter = factory.GetAdapter(GetVrAdapterIndex());
+      Device?.Dispose();
+      Device = new Device(adapter,
         DeviceCreationFlags.BgraSupport);
     }
     catch (SharpDXException err)
@@ -66,9 +66,10 @@ public class AcceleratedOvrDXDeviceHander : OvrDXDeviceHander
   {
     try
     {
-      var factory = new Factory1();
+      using var factory = new Factory1();
+      using var adapter = factory.GetAdapter(GetVrAdapterIndex());
       Device?.Dispose();
-      Device = new Device(factory.GetAdapter(GetVrAdapterIndex()),
+      Device = new Device(adapter,
         DeviceCreationFlags.BgraSupport);
       UpgradeDevice();
     }

--- a/src-overlay-sidecar/Utils/Browsers/AcceleratedOffscreenBrowser.cs
+++ b/src-overlay-sidecar/Utils/Browsers/AcceleratedOffscreenBrowser.cs
@@ -1,6 +1,4 @@
-// Based on:
-// https://github.com/vrcx-team/VRCX/blob/master/Dotnet/Overlay/OffScreenBrowser.cs
-
+using System.Diagnostics;
 using overlay_sidecar.Browsers;
 using Serilog;
 using SharpDX.Direct3D;
@@ -18,6 +16,9 @@ using System.Threading;
 
 public class AcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
 {
+  private readonly object _textureLock = new();
+  private bool _stopped;
+  private bool _copyFailed;
   private Device? _device;
   private Device1? _device1;
   private DeviceMultithread? _deviceMultithread;
@@ -30,14 +31,14 @@ public class AcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
       automaticallyCreateBrowser: false
     )
   {
-    var windowInfo = new WindowInfo();
+    using var windowInfo = new WindowInfo();
     windowInfo.SetAsWindowless(IntPtr.Zero);
     windowInfo.WindowlessRenderingEnabled = true;
     windowInfo.SharedTextureEnabled = true;
     windowInfo.Width = (int)width;
     windowInfo.Height = (int)height;
 
-    var browserSettings = new BrowserSettings()
+    using var browserSettings = new BrowserSettings()
     {
       WindowlessFrameRate = 60,
       DefaultEncoding = "UTF-8"
@@ -49,58 +50,64 @@ public class AcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
     RenderHandler = this;
   }
 
-  public new void Dispose()
+  protected override void Dispose(bool disposing)
   {
-    RenderHandler = null;
-    if (IsDisposed) return;
-    base.Dispose();
+    if (disposing)
+    {
+      RenderHandler = null;
+      lock (_textureLock)
+      {
+        _stopped = true;
+        SetTextureTarget(null);
+      }
+    }
+    base.Dispose(disposing);
   }
 
   public override void SetTextureTarget(Texture2D? renderTarget)
   {
-    if (renderTarget == null)
+    lock (_textureLock)
     {
-      _renderTarget = null;
-      _device = null;
-      _device1 = null;
-      _deviceMultithread = null;
-      return;
+      ReleaseTextureTarget();
+      if (renderTarget == null || _stopped || IsDisposed) return;
+      try
+      {
+        _device = renderTarget.Device.QueryInterface<Device>();
+        _device1 = _device.QueryInterface<Device1>();
+        _deviceMultithread = _device.QueryInterfaceOrNull<DeviceMultithread>();
+        _deviceMultithread?.SetMultithreadProtected(true);
+        _query = new Query(_device, new QueryDescription
+        {
+          Type = QueryType.Event,
+          Flags = QueryFlags.None
+        });
+        _renderTarget = renderTarget;
+      }
+      catch
+      {
+        ReleaseTextureTarget();
+        throw;
+      }
     }
+  }
 
-    _device = renderTarget.Device;
-    _device1 = _device.QueryInterface<Device1>();
-
-    _deviceMultithread?.Dispose();
-    _deviceMultithread = _device.QueryInterfaceOrNull<DeviceMultithread>();
-    _deviceMultithread?.SetMultithreadProtected(true);
-
-    _renderTarget = renderTarget;
-
+  private void ReleaseTextureTarget()
+  {
+    _renderTarget = null;
+    _lastPaint = 0;
+    _copyFailed = false;
     _query?.Dispose();
-    _query = new Query(_device, new QueryDescription
-    {
-      Type = QueryType.Event,
-      Flags = QueryFlags.None
-    });
+    _query = null;
+    _deviceMultithread?.Dispose();
+    _deviceMultithread = null;
+    _device1?.Dispose();
+    _device1 = null;
+    _device?.Dispose();
+    _device = null;
   }
 
   public override void Render()
   {
-    // No need to render anything here, as the texture is shared
-  }
-
-  private string GetAdapterName()
-  {
-    try
-    {
-      using var dxgiDevice = _device!.QueryInterface<SharpDX.DXGI.Device>();
-      using var adapter = dxgiDevice.Adapter;
-      return adapter.Description.Description.Trim();
-    }
-    catch (Exception)
-    {
-      return "unknown";
-    }
   }
 
   ScreenInfo? IRenderHandler.GetScreenInfo()
@@ -125,41 +132,36 @@ public class AcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
 
   void IRenderHandler.OnAcceleratedPaint(PaintElementType type, Rect dirtyRect, AcceleratedPaintInfo paintInfo)
   {
-    if (type != PaintElementType.View)
-      return;
-
-    if (_device == null || _device1 == null || _renderTarget == null)
-      return;
-
-    try
+    if (type != PaintElementType.View) return;
+    lock (_textureLock)
     {
-      using Texture2D cefTexture = _device1.OpenSharedResource1<Texture2D>(paintInfo.SharedTextureHandle);
-      _device.ImmediateContext.CopyResource(cefTexture, _renderTarget);
-      _device.ImmediateContext.End(_query);
-      _device.ImmediateContext.Flush();
+      if (_device == null || _renderTarget == null) return;
+      try
+      {
+        using var cefTexture = _device1!.OpenSharedResource1<Texture2D>(paintInfo.SharedTextureHandle);
+        var context = _device.ImmediateContext;
+        context.CopyResource(cefTexture, _renderTarget);
+        context.End(_query);
+        context.Flush();
+        var started = Stopwatch.GetTimestamp();
+        while (!context.GetData<RawBool>(_query, AsynchronousFlags.DoNotFlush))
+        {
+          _device.DeviceRemovedReason.CheckError();
+          if (Stopwatch.GetElapsedTime(started) >= TimeSpan.FromMilliseconds(250))
+            throw new TimeoutException("The overlay GPU copy did not finish within 250 ms.");
+          Thread.Sleep(1);
+        }
+        _lastPaint = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        _copyFailed = false;
+      }
+      catch (Exception e)
+      {
+        _lastPaint = 0;
+        if (!_copyFailed)
+          Log.Error(e, "Could not copy Chromium's shared texture. Later paints will retry; disable GPU acceleration if this persists.");
+        _copyFailed = true;
+      }
     }
-    catch (Exception e)
-    {
-      // A shared texture can only be opened on the GPU that produced it. Reaching this means
-      // Chromium picked a different GPU than the one SteamVR renders on, and no overlay can
-      // use the accelerated path until that changes.
-      Log.Error(e,
-        "Could not open Chromium's shared texture on the SteamVR GPU ({adapter}). Chromium is " +
-        "rendering on a different GPU. Disable GPU acceleration under advanced settings to fall " +
-        "back to the software renderer.", GetAdapterName());
-      _device = null;
-      return;
-    }
-
-    RawBool q = _device.ImmediateContext.GetData<RawBool>(_query, AsynchronousFlags.DoNotFlush);
-
-    while (!q)
-    {
-      Thread.Yield();
-      q = _device.ImmediateContext.GetData<RawBool>(_query, AsynchronousFlags.DoNotFlush);
-    }
-
-    _lastPaint = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
   }
 
   void IRenderHandler.OnCursorChange(IntPtr cursor, CursorType type, CursorInfo customCursorInfo)

--- a/src-overlay-sidecar/Utils/Browsers/NonAcceleratedOffscreenBrowser.cs
+++ b/src-overlay-sidecar/Utils/Browsers/NonAcceleratedOffscreenBrowser.cs
@@ -1,6 +1,3 @@
-// Based on:
-// https://github.com/vrcx-team/VRCX/blob/master/Dotnet/Overlay/OffScreenBrowserLegacy.cs
-
 using System.Runtime.InteropServices;
 using overlay_sidecar.Browsers;
 
@@ -16,7 +13,9 @@ using System.Threading;
 
 public class NonAcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
 {
-  private readonly ReaderWriterLockSlim _paintBufferLock;
+  private readonly object _paintBufferLock = new();
+  private Device? _device;
+  private bool _stopped;
   private GCHandle _paintBuffer;
   private int _width;
   private int _height;
@@ -28,16 +27,15 @@ public class NonAcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
       automaticallyCreateBrowser: false
     )
   {
-    _paintBufferLock = new ReaderWriterLockSlim();
 
-    var windowInfo = new WindowInfo();
+    using var windowInfo = new WindowInfo();
     windowInfo.SetAsWindowless(IntPtr.Zero);
     windowInfo.WindowlessRenderingEnabled = true;
     windowInfo.SharedTextureEnabled = false;
     windowInfo.Width = (int)width;
     windowInfo.Height = (int)height;
 
-    var browserSettings = new BrowserSettings()
+    using var browserSettings = new BrowserSettings()
     {
       WindowlessFrameRate = 60,
       DefaultEncoding = "UTF-8"
@@ -49,45 +47,44 @@ public class NonAcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
     RenderHandler = this;
   }
 
-  public new void Dispose()
+  protected override void Dispose(bool disposing)
   {
-    RenderHandler = null;
-    base.Dispose();
-
-    _paintBufferLock.EnterWriteLock();
-    try
+    if (disposing)
     {
-      if (_paintBuffer.IsAllocated)
+      RenderHandler = null;
+      lock (_paintBufferLock)
       {
-        _paintBuffer.Free();
+        _stopped = true;
+        SetTextureTarget(null);
+        if (_paintBuffer.IsAllocated) _paintBuffer.Free();
       }
     }
-    finally
-    {
-      _paintBufferLock.ExitWriteLock();
-    }
-
-    _paintBufferLock.Dispose();
+    base.Dispose(disposing);
   }
 
   public override void SetTextureTarget(Texture2D? renderTarget)
   {
-    _renderTarget = renderTarget;
+    lock (_paintBufferLock)
+    {
+      _renderTarget = null;
+      _lastPaint = 0;
+      _device?.Dispose();
+      _device = null;
+      if (renderTarget == null || _stopped) return;
+      _device = renderTarget.Device.QueryInterface<Device>();
+      _renderTarget = renderTarget;
+    }
   }
 
   public override void Render()
   {
-    // Safeguard against uninitialized texture
-    if (_renderTarget == null)
-      return;
-
-    _paintBufferLock.EnterReadLock();
-    try
+    lock (_paintBufferLock)
     {
+      if (_renderTarget == null || _stopped || _lastPaint == 0) return;
       if (_width > 0 &&
           _height > 0)
       {
-        var context = _renderTarget.Device.ImmediateContext;
+        var context = _device!.ImmediateContext;
         var dataBox = context.MapSubresource(
           _renderTarget,
           0,
@@ -126,10 +123,6 @@ public class NonAcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
         context.UnmapSubresource(_renderTarget, 0);
       }
     }
-    finally
-    {
-      _paintBufferLock.ExitReadLock();
-    }
   }
 
   ScreenInfo? IRenderHandler.GetScreenInfo()
@@ -165,9 +158,9 @@ public class NonAcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
   {
     if (type == PaintElementType.View)
     {
-      _paintBufferLock.EnterWriteLock();
-      try
+      lock (_paintBufferLock)
       {
+        if (_stopped) return;
         if (_width != width ||
             _height != height)
         {
@@ -189,13 +182,7 @@ public class NonAcceleratedOffscreenBrowser : OffscreenBrowser, IRenderHandler
           buffer,
           (uint)(width * height * 4)
         );
-        // LastPaint marks when the browser produced a new frame, which is what tells the
-        // render loop there is something new to copy into the overlay texture.
         _lastPaint = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-      }
-      finally
-      {
-        _paintBufferLock.ExitWriteLock();
       }
     }
   }


### PR DESCRIPTION
Browser target replacement leaked native Direct3D references. This change releases browser-owned devices, queries and interfaces, and disposes DXGI factories and adapters after device creation.

Painting and target disposal share a lock. GPU completion polling stops after 250 ms; a failed copy drops the frame and later paints can retry. 

Validation: sidecar build and a local check using real CefSharp browsers with WARP passed. Native references stayed stable across 100 paint/reuse cycles per mode. The check also covers concurrent replacement, failed-copy retry and disposal through IDisposable. SteamVR rendering remains untested.

Related to #296. The reported 63 GB incident has not been reproduced. Next in the stack: #307 for overlay lifetimes, then #308 for retention limits.