### PR TITLE
fix(OYASUMIVR-79): bound notification retention and splash lifetime

### DIFF
--- a/src-overlay-sidecar/Overlays/SplashOverlay.cs
+++ b/src-overlay-sidecar/Overlays/SplashOverlay.cs
@@ -6,7 +6,7 @@ namespace overlay_sidecar;
 public class SplashOverlay : BaseWebOverlay {
   private static readonly TrackedDevicePose_t[] _poseBuffer = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
   private bool _updatedPositionOnce;
-  private readonly DateTime _expiresAt = DateTime.UtcNow.AddSeconds(10);
+  private DateTime _expiresAt = DateTime.UtcNow.AddSeconds(10);
 
   public SplashOverlay() :
     base("/splash", 1024, "co.raphii.oyasumivr:SplashOverlay", "OyasumiVR Splash Overlay")
@@ -14,6 +14,16 @@ public class SplashOverlay : BaseWebOverlay {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);
     OpenVR.Overlay.ShowOverlay(OverlayHandle);
+  }
+
+  public override void OnUiReady()
+  {
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed || UiReady) return;
+      _expiresAt = DateTime.UtcNow.AddSeconds(10);
+      base.OnUiReady();
+    }
   }
 
   public override void UpdateFrame()

--- a/src-overlay-sidecar/Overlays/SplashOverlay.cs
+++ b/src-overlay-sidecar/Overlays/SplashOverlay.cs
@@ -6,6 +6,7 @@ namespace overlay_sidecar;
 public class SplashOverlay : BaseWebOverlay {
   private static readonly TrackedDevicePose_t[] _poseBuffer = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
   private bool _updatedPositionOnce;
+  private readonly DateTime _expiresAt = DateTime.UtcNow.AddSeconds(10);
 
   public SplashOverlay() :
     base("/splash", 1024, "co.raphii.oyasumivr:SplashOverlay", "OyasumiVR Splash Overlay")
@@ -17,6 +18,11 @@ public class SplashOverlay : BaseWebOverlay {
 
   public override void UpdateFrame()
   {
+    if (DateTime.UtcNow >= _expiresAt)
+    {
+      Dispose();
+      return;
+    }
     base.UpdateFrame();
     if (!Disposed) UpdatePosition();
   }

--- a/src-overlay-ui/app/overlays/notifications/notifications-overlay.spec.ts
+++ b/src-overlay-ui/app/overlays/notifications/notifications-overlay.spec.ts
@@ -48,5 +48,16 @@ it('subscribes before readiness and dismisses accepted notifications by ID', () 
   notificationAdded.next({ id: 'timed', message: 'timed', duration: 3000 });
   vi.advanceTimersByTime(3000);
   expect(overlay.shown).toEqual([]);
+
+  for (let i = 0; i < 100; i++) {
+    notificationAdded.next({ id: `burst-${i}`, message: 'burst', duration: 3000 });
+  }
+  expect(overlay.shown.map((n) => n.id)).toEqual(['burst-70', 'burst-69', 'burst-0']);
+  vi.advanceTimersByTime(3000);
+  expect(overlay.shown.map((n) => n.id)).toEqual(['burst-71', 'burst-70', 'burst-69']);
+  notificationCleared.next('burst-70');
+  expect(overlay.shown.map((n) => n.id)).toEqual(['burst-72', 'burst-71', 'burst-69']);
+  vi.advanceTimersByTime(30 * 3000);
+  expect(overlay.shown).toEqual([]);
   cleanup.forEach((fn) => fn());
 });

--- a/src-overlay-ui/app/overlays/notifications/notifications-overlay.ts
+++ b/src-overlay-ui/app/overlays/notifications/notifications-overlay.ts
@@ -12,6 +12,8 @@ import { Notification } from '../../components/notification/notification';
 import { IpcService } from '../../ipc/ipc.service';
 import { AddNotificationParams } from '../../ipc/oyasumi-ipc';
 
+const MAX_NOTIFICATIONS = 32;
+
 @Component({
   selector: 'app-notifications-overlay',
   imports: [Notification],
@@ -32,7 +34,11 @@ export class NotificationsOverlay implements OnInit {
 
   constructor() {
     this.ipc.notificationAdded.pipe(takeUntilDestroyed()).subscribe((notification) => {
-      this.notifications.update((notifications) => [...notifications, notification]);
+      this.notifications.update((notifications) =>
+        notifications.length < MAX_NOTIFICATIONS
+          ? [...notifications, notification]
+          : [notifications[0], ...notifications.slice(-(MAX_NOTIFICATIONS - 2)), notification]
+      );
       this.updateActiveNotification();
     });
     this.ipc.notificationCleared.pipe(takeUntilDestroyed()).subscribe((id) => {


### PR DESCRIPTION
Sustained notification input can retain an unlimited queue. This caps it at 32 entries, keeping the active notification and the newest waiting entries. The oldest waiting entries are dropped when full.

The splash expires after ten seconds if its page never becomes ready. Once ready, it gets ten seconds to finish its animation and request disposal.

Validation: the notification burst/drain test, overlay UI build, sidecar build and scoped ESLint passed. Headset timing remains untested.

Stacked on #307, which is stacked on #306. This PR contains only the retention limits and their notification test. Related to #296.
