### PR TITLE
fix(OYASUMIVR-69): save command edits before leaving automations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Run Automations now saves pending command edits when you leave the page.
+
 - Fixed VRChat log timestamps allowing the Quick Eeper achievement after its 20-minute window.
 
 - Fixed OpenVR device updates changing the tracked-index order of the device list.

--- a/src-ui/app/views/dashboard-view/views/run-automations-view/run-automations-view.component.spec.ts
+++ b/src-ui/app/views/dashboard-view/views/run-automations-view/run-automations-view.component.spec.ts
@@ -1,0 +1,87 @@
+import '@angular/compiler';
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../../../../models/automations';
+import { RunAutomationsViewComponent } from './run-automations-view.component';
+
+const fields = [
+  ['onSleepModeEnable', 'updateOnSleepModeEnable'],
+  ['onSleepModeDisable', 'updateOnSleepModeDisable'],
+  ['onSleepPreparation', 'updateOnSleepPreparation'],
+] as const;
+
+async function setup() {
+  const callbacks = new Set<() => void>();
+  const destroy = {
+    destroyed: false,
+    onDestroy: (callback: () => void) => {
+      callbacks.add(callback);
+      return () => callbacks.delete(callback);
+    },
+    run: () => {
+      destroy.destroyed = true;
+      [...callbacks].forEach((callback) => callback());
+    },
+  };
+  const commands = {
+    getCommands: vi.fn(async () => 'rem saved command'),
+    updateCommands: vi.fn(async () => {}),
+    testCommands: vi.fn(),
+  };
+  const configs = structuredClone(AUTOMATION_CONFIGS_DEFAULT);
+  configs.RUN_AUTOMATIONS.onSleepModeEnableCommands = 'rem saved command';
+  type Dependencies = ConstructorParameters<typeof RunAutomationsViewComponent>;
+  const component = new RunAutomationsViewComponent(
+    destroy,
+    {
+      configs: new BehaviorSubject(configs),
+    } as Dependencies[1],
+    commands as unknown as Dependencies[2]
+  );
+  component.ngOnInit();
+  await vi.advanceTimersByTimeAsync(500);
+  return { component, commands, destroy };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+it.each(fields)('saves the latest %s edit once when leaving early', async (event, edit) => {
+  const h = await setup();
+  expect(h.component[`${event}Commands`]).toBe('rem saved command');
+  await h.component[edit]('rem first edit');
+  await vi.advanceTimersByTimeAsync(200);
+  await h.component[edit]('rem latest edit');
+  expect(h.commands.updateCommands).not.toHaveBeenCalled();
+
+  h.destroy.run();
+  await vi.advanceTimersByTimeAsync(2000);
+
+  expect(h.commands.updateCommands).toHaveBeenCalledExactlyOnceWith(event, 'rem latest edit');
+  expect(h.commands.testCommands).not.toHaveBeenCalled();
+});
+
+it.each(fields)('keeps the one-second save delay for %s', async (event, edit) => {
+  const h = await setup();
+  await h.component[edit]('rem changed command');
+  await vi.advanceTimersByTimeAsync(999);
+  expect(h.commands.updateCommands).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(1);
+  expect(h.commands.updateCommands).toHaveBeenCalledExactlyOnceWith(event, 'rem changed command');
+
+  h.destroy.run();
+  expect(h.commands.updateCommands).toHaveBeenCalledTimes(1);
+  expect(h.commands.testCommands).not.toHaveBeenCalled();
+});
+
+it.each(fields)('does not write unchanged %s text on destruction', async (_event, edit) => {
+  const h = await setup();
+  await h.component[edit]('rem saved command');
+  h.destroy.run();
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(h.commands.updateCommands).not.toHaveBeenCalled();
+  expect(h.commands.testCommands).not.toHaveBeenCalled();
+});

--- a/src-ui/app/views/dashboard-view/views/run-automations-view/run-automations-view.component.ts
+++ b/src-ui/app/views/dashboard-view/views/run-automations-view/run-automations-view.component.ts
@@ -7,6 +7,7 @@ import { RunAutomationsService } from 'src-ui/app/services/run-automations.servi
 import { distinctUntilChanged, map, debounceTime, share, tap, switchMap, filter, take } from 'rxjs';
 import { Subject } from 'rxjs';
 import { isEqual } from 'lodash';
+import { flushOnDestroy } from '../../../../utils/rxjs-utils';
 
 @Component({
   selector: 'app-run-automations-view',
@@ -22,7 +23,6 @@ export class RunAutomationsViewComponent implements OnInit {
   onSleepModeDisableCommands: string = '';
   onSleepPreparationCommands: string = '';
 
-  // Collapse/expand state for each automation
   onSleepModeEnableExpanded: boolean = false;
   onSleepModeDisableExpanded: boolean = false;
   onSleepPreparationExpanded: boolean = false;
@@ -60,7 +60,7 @@ export class RunAutomationsViewComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async (config) => {
-        // Initialize expanded states based on automation enabled state only on first load
+        // expand enabled automations after the first configuration loads
         this.onSleepModeEnableExpanded = config.onSleepModeEnable;
         this.onSleepModeDisableExpanded = config.onSleepModeDisable;
         this.onSleepPreparationExpanded = config.onSleepPreparation;
@@ -78,6 +78,7 @@ export class RunAutomationsViewComponent implements OnInit {
         }
       });
 
+    // load each command field when its configuration changes
     for (const event of events) {
       config
         .pipe(
@@ -97,7 +98,12 @@ export class RunAutomationsViewComponent implements OnInit {
         });
     }
 
-    // Set up debounced command updates
+    // save pending command text before navigation tears down subscriptions
+    flushOnDestroy(this.onSleepModeEnableSubject, this.destroyRef);
+    flushOnDestroy(this.onSleepModeDisableSubject, this.destroyRef);
+    flushOnDestroy(this.onSleepPreparationSubject, this.destroyRef);
+
+    // save each edited command after one second without typing
     this.onSleepModeEnableSubject
       .pipe(debounceTime(1000), takeUntilDestroyed(this.destroyRef))
       .subscribe(async (value) => {
@@ -123,7 +129,6 @@ export class RunAutomationsViewComponent implements OnInit {
       onSleepModeEnable: newValue,
     });
 
-    // Auto expand when enabled, auto collapse when disabled
     if (newValue && !this.onSleepModeEnableExpanded) {
       this.onSleepModeEnableExpanded = true;
     } else if (!newValue && this.onSleepModeEnableExpanded) {
@@ -143,7 +148,6 @@ export class RunAutomationsViewComponent implements OnInit {
       onSleepModeDisable: newValue,
     });
 
-    // Auto expand when enabled, auto collapse when disabled
     if (newValue && !this.onSleepModeDisableExpanded) {
       this.onSleepModeDisableExpanded = true;
     } else if (!newValue && this.onSleepModeDisableExpanded) {
@@ -163,7 +167,6 @@ export class RunAutomationsViewComponent implements OnInit {
       onSleepPreparation: newValue,
     });
 
-    // Auto expand when enabled, auto collapse when disabled
     if (newValue && !this.onSleepPreparationExpanded) {
       this.onSleepPreparationExpanded = true;
     } else if (!newValue && this.onSleepPreparationExpanded) {


### PR DESCRIPTION
Command edits now save when leaving Run Automations before the one-second delay ends. All three editors retain the latest text, and the normal delayed save remains unchanged.

Verified all three editors in the desktop app by typing and leaving within one second, plus a delayed-save control. Nine regression tests, frontend typecheck, lint, and development build pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending command edits in Run Automations are now saved when leaving the page.
  * Recent command changes are saved after a brief delay, while unchanged text is not written unnecessarily.

* **Documentation**
  * Updated the unreleased changelog with the Run Automations fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->