### PR TITLE
fix(OYASUMIVR-30): release controller actions when OpenVR disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ with [SemVer](https://semver.org/) prerelease suffixes:
 
 ### Fixed
 
+- Controller actions no longer stay pressed after SteamVR disconnects.
 - Run Automations now saves pending command edits when you leave the page.
 
 - Fixed VRChat log timestamps allowing the Quick Eeper achievement after its 20-minute window.

--- a/src-ui/app/models/ovr-input-event.ts
+++ b/src-ui/app/models/ovr-input-event.ts
@@ -18,5 +18,5 @@ export interface OVRInputEvent {
   action: OVRInputEventActionValue;
   pressed: boolean;
   timeAgo: number;
-  device: OVRDevice;
+  device: OVRDevice | null;
 }

--- a/src-ui/app/services/openvr-input.service.spec.ts
+++ b/src-ui/app/services/openvr-input.service.spec.ts
@@ -1,0 +1,171 @@
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listen, type EventCallback } from '@tauri-apps/api/event';
+import { OpenVRInputService } from './openvr-input.service';
+import type { OpenVRService, OpenVRStatus } from './openvr.service';
+import { OVRInputEventAction, type OVRInputEvent } from '../models/ovr-input-event';
+import type { OVRDevice } from '../models/ovr-device';
+import { OverlayService } from './overlay/overlay.service';
+import { SystemMicMuteAutomationService } from './system-mic-mute-automation.service';
+import { APP_SETTINGS_DEFAULT } from '../models/settings';
+import { AUTOMATION_CONFIGS_DEFAULT } from '../models/automations';
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => {}) }));
+vi.mock('@tauri-apps/plugin-log', () => ({ info: vi.fn(), warn: vi.fn() }));
+
+const controller: OVRDevice = {
+  index: 1,
+  class: 'Controller',
+  role: 'LeftHand',
+  battery: 80,
+  pose: null,
+  isTurningOff: false,
+};
+
+async function createInput(initial: OpenVRStatus = 'INITIALIZED') {
+  const status = new BehaviorSubject<OpenVRStatus>(initial);
+  const input = new OpenVRInputService({ status } as unknown as OpenVRService);
+  await input.init();
+  const callback = vi
+    .mocked(listen)
+    .mock.calls.find(
+      ([name]) => name === 'OVR_INPUT_EVENT_DIGITAL'
+    )![1] as EventCallback<OVRInputEvent>;
+  const emit = (
+    action: OVRInputEventAction,
+    pressed = true,
+    device: OVRDevice | null = controller
+  ) =>
+    callback({
+      event: 'OVR_INPUT_EVENT_DIGITAL',
+      id: 1,
+      payload: { action, pressed, device, timeAgo: 0 },
+    });
+  return { input, status, emit };
+}
+
+describe('OpenVR input session reset', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each(['INACTIVE', 'INITIALIZING'] as const)(
+    'clears all held actions on %s and accepts reused indices',
+    async (nextStatus) => {
+      const { input, status, emit } = await createInput();
+      const updates = vi.fn();
+      input.state.subscribe(updates);
+      for (const action of Object.values(OVRInputEventAction)) emit(action);
+      expect(
+        Object.values(await firstValueFrom(input.state)).every((devices) => devices.length === 1)
+      ).toBe(true);
+
+      status.next(nextStatus);
+      expect(
+        Object.values(await firstValueFrom(input.state)).every((devices) => devices.length === 0)
+      ).toBe(true);
+      const resetCount = updates.mock.calls.length;
+      status.next(nextStatus);
+      for (const action of Object.values(OVRInputEventAction)) emit(action);
+      expect(updates).toHaveBeenCalledTimes(resetCount);
+
+      status.next('INITIALIZED');
+      for (const action of Object.values(OVRInputEventAction)) emit(action);
+      expect(
+        Object.values(await firstValueFrom(input.state)).every((devices) => devices[0]?.index === 1)
+      ).toBe(true);
+      for (const action of Object.values(OVRInputEventAction)) emit(action, false);
+      expect(
+        Object.values(await firstValueFrom(input.state)).every((devices) => devices.length === 0)
+      ).toBe(true);
+    }
+  );
+
+  it.each(['INACTIVE', 'INITIALIZING', 'INITIALIZED'] as const)(
+    'ignores null-device events while %s',
+    async (initial) => {
+      const { input, emit } = await createInput(initial);
+      const updates = vi.fn();
+      input.state.subscribe(updates);
+      for (const action of Object.values(OVRInputEventAction)) {
+        emit(action, true, null);
+        emit(action, false, null);
+      }
+      expect(updates).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('does not toggle the overlay on reset, but the first new-session press does', async () => {
+    const { input, status, emit } = await createInput();
+    const client = { toggleOverlayMenu: vi.fn() };
+    const settings = new BehaviorSubject({
+      ...APP_SETTINGS_DEFAULT,
+      overlayMenuEnabled: true,
+      overlayMenuOnlyOpenWhenVRChatIsRunning: false,
+    });
+    const overlay = new OverlayService(
+      {
+        overlaySidecarClient: new BehaviorSubject(client),
+        getOverlaySidecarClient: () => client,
+      } as unknown as ConstructorParameters<typeof OverlayService>[0],
+      input,
+      { settings } as unknown as ConstructorParameters<typeof OverlayService>[2],
+      { vrchatProcessActive: new BehaviorSubject(false) } as unknown as ConstructorParameters<
+        typeof OverlayService
+      >[3]
+    );
+    await overlay.init();
+    emit(OVRInputEventAction.OpenOverlay);
+    expect(client.toggleOverlayMenu).toHaveBeenCalledOnce();
+    status.next('INACTIVE');
+    expect(client.toggleOverlayMenu).toHaveBeenCalledOnce();
+    status.next('INITIALIZED');
+    emit(OVRInputEventAction.OpenOverlay);
+    expect(client.toggleOverlayMenu).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['TOGGLE', 'PUSH_TO_TALK'] as const)(
+    'delivers release and new-session press to %s microphone bindings',
+    async (behavior) => {
+      const { input, status, emit } = await createInput();
+      const configs = structuredClone(AUTOMATION_CONFIGS_DEFAULT);
+      Object.assign(configs.SYSTEM_MIC_MUTE_AUTOMATIONS, {
+        controllerBinding: true,
+        controllerBindingBehavior: behavior,
+      });
+      const mic = new SystemMicMuteAutomationService(
+        { configs: new BehaviorSubject(configs) } as unknown as ConstructorParameters<
+          typeof SystemMicMuteAutomationService
+        >[0],
+        {
+          activeDevices: new BehaviorSubject([]),
+          getAudioDeviceForPersistentId: () => ({ mute: true }),
+        } as unknown as ConstructorParameters<typeof SystemMicMuteAutomationService>[1],
+        input,
+        {} as ConstructorParameters<typeof SystemMicMuteAutomationService>[3],
+        {} as ConstructorParameters<typeof SystemMicMuteAutomationService>[4],
+        { playSound: vi.fn(async () => {}) } as unknown as ConstructorParameters<
+          typeof SystemMicMuteAutomationService
+        >[5],
+        {} as ConstructorParameters<typeof SystemMicMuteAutomationService>[6],
+        {} as ConstructorParameters<typeof SystemMicMuteAutomationService>[7]
+      );
+      mic['config'] = configs.SYSTEM_MIC_MUTE_AUTOMATIONS;
+      const setMute = vi.spyOn(mic, 'setMute').mockResolvedValue(null);
+      mic['handleControllerBinding']();
+      await Promise.resolve();
+      setMute.mockClear();
+
+      emit(OVRInputEventAction.MuteMicrophone);
+      await vi.waitFor(() => expect(setMute).toHaveBeenCalledWith(false));
+      setMute.mockClear();
+      status.next('INACTIVE');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(setMute.mock.calls).toEqual(behavior === 'PUSH_TO_TALK' ? [[true]] : []);
+      setMute.mockClear();
+      status.next('INITIALIZED');
+      emit(OVRInputEventAction.MuteMicrophone);
+      await vi.waitFor(() => expect(setMute).toHaveBeenCalledWith(false));
+    }
+  );
+});

--- a/src-ui/app/services/openvr-input.service.ts
+++ b/src-ui/app/services/openvr-input.service.ts
@@ -6,7 +6,7 @@ import {
   OVRInputEventActionSet,
 } from '../models/ovr-input-event';
 import { listen } from '@tauri-apps/api/event';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, firstValueFrom, merge, scan, Subject } from 'rxjs';
 import { isEqual } from 'lodash';
 import { OVRDevice } from '../models/ovr-device';
 import { OVRActionBinding } from '../models/ovr-action-binding';
@@ -28,34 +28,47 @@ export class OpenVRInputService {
   constructor(private openvr: OpenVRService) {}
 
   async init() {
-    // release held actions when the OpenVR session ends
-    let initialized = false;
-    this.openvr.status.subscribe((status) => {
-      initialized = status === 'INITIALIZED';
-      if (initialized || !Object.values(this._state.value).some((devices) => devices.length))
-        return;
-      this._state.next({
-        [OVRInputEventAction.OpenOverlay]: [],
-        [OVRInputEventAction.MuteMicrophone]: [],
-        [OVRInputEventAction.IndicatePresence]: [],
-        [OVRInputEventAction.OverlayInteract]: [],
-      });
-    });
-
-    await listen<OVRInputEvent>('OVR_INPUT_EVENT_DIGITAL', (event) => {
-      const { action, pressed, device } = event.payload;
-      if (!initialized || !device) return;
-      const state = structuredClone(this._state.value);
-      const devices = state[action];
-      if (pressed && !devices.some((d) => d.index === device.index)) {
-        devices.push(device);
-      } else if (!pressed && devices.some((d) => d.index === device.index)) {
-        const index = devices.findIndex((d) => d.index === device.index);
-        if (index !== -1) devices.splice(index, 1);
-      }
-      state[action] = devices;
-      if (!isEqual(state, this._state.value)) this._state.next(state);
-    });
+    const events = new Subject<OVRInputEvent>();
+    merge(this.openvr.status, events)
+      .pipe(
+        scan(
+          (state, event) => {
+            if (typeof event === 'string') {
+              return {
+                initialized: event === 'INITIALIZED',
+                actions:
+                  event === 'INITIALIZED'
+                    ? state.actions
+                    : {
+                        [OVRInputEventAction.OpenOverlay]: [],
+                        [OVRInputEventAction.MuteMicrophone]: [],
+                        [OVRInputEventAction.IndicatePresence]: [],
+                        [OVRInputEventAction.OverlayInteract]: [],
+                      },
+              };
+            }
+            const { action, pressed, device } = event;
+            if (!state.initialized || !device) return state;
+            const actions = structuredClone(state.actions);
+            const devices = actions[action] ?? [];
+            if (pressed && !devices.some((d) => d.index === device.index)) {
+              devices.push(device);
+            } else if (!pressed) {
+              const index = devices.findIndex((d) => d.index === device.index);
+              if (index !== -1) devices.splice(index, 1);
+            }
+            actions[action] = devices;
+            return { ...state, actions };
+          },
+          {
+            initialized: false,
+            actions: this._state.value,
+          }
+        ),
+        distinctUntilChanged((previous, current) => isEqual(previous.actions, current.actions))
+      )
+      .subscribe(({ actions }) => this._state.next(actions));
+    await listen<OVRInputEvent>('OVR_INPUT_EVENT_DIGITAL', (event) => events.next(event.payload));
   }
 
   async launchBindingConfiguration(showOnDesktop: boolean) {

--- a/src-ui/app/services/openvr-input.service.ts
+++ b/src-ui/app/services/openvr-input.service.ts
@@ -6,7 +6,7 @@ import {
   OVRInputEventActionSet,
 } from '../models/ovr-input-event';
 import { listen } from '@tauri-apps/api/event';
-import { BehaviorSubject, distinctUntilChanged, firstValueFrom, merge, scan, Subject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Subject, withLatestFrom } from 'rxjs';
 import { isEqual } from 'lodash';
 import { OVRDevice } from '../models/ovr-device';
 import { OVRActionBinding } from '../models/ovr-action-binding';
@@ -28,46 +28,35 @@ export class OpenVRInputService {
   constructor(private openvr: OpenVRService) {}
 
   async init() {
-    const events = new Subject<OVRInputEvent>();
-    merge(this.openvr.status, events)
-      .pipe(
-        scan(
-          (state, event) => {
-            if (typeof event === 'string') {
-              return {
-                initialized: event === 'INITIALIZED',
-                actions:
-                  event === 'INITIALIZED'
-                    ? state.actions
-                    : {
-                        [OVRInputEventAction.OpenOverlay]: [],
-                        [OVRInputEventAction.MuteMicrophone]: [],
-                        [OVRInputEventAction.IndicatePresence]: [],
-                        [OVRInputEventAction.OverlayInteract]: [],
-                      },
-              };
-            }
-            const { action, pressed, device } = event;
-            if (!state.initialized || !device) return state;
-            const actions = structuredClone(state.actions);
-            const devices = actions[action] ?? [];
-            if (pressed && !devices.some((d) => d.index === device.index)) {
-              devices.push(device);
-            } else if (!pressed) {
-              const index = devices.findIndex((d) => d.index === device.index);
-              if (index !== -1) devices.splice(index, 1);
-            }
-            actions[action] = devices;
-            return { ...state, actions };
-          },
-          {
-            initialized: false,
-            actions: this._state.value,
-          }
-        ),
-        distinctUntilChanged((previous, current) => isEqual(previous.actions, current.actions))
+    this.openvr.status.subscribe((status) => {
+      if (
+        status === 'INITIALIZED' ||
+        !Object.values(this._state.value).some((devices) => devices.length)
       )
-      .subscribe(({ actions }) => this._state.next(actions));
+        return;
+      this._state.next({
+        [OVRInputEventAction.OpenOverlay]: [],
+        [OVRInputEventAction.MuteMicrophone]: [],
+        [OVRInputEventAction.IndicatePresence]: [],
+        [OVRInputEventAction.OverlayInteract]: [],
+      });
+    });
+
+    const events = new Subject<OVRInputEvent>();
+    events.pipe(withLatestFrom(this.openvr.status)).subscribe(([event, status]) => {
+      const { action, pressed, device } = event;
+      if (status !== 'INITIALIZED' || !device) return;
+      const state = structuredClone(this._state.value);
+      const devices = state[action];
+      if (pressed && !devices.some((d) => d.index === device.index)) {
+        devices.push(device);
+      } else if (!pressed && devices.some((d) => d.index === device.index)) {
+        const index = devices.findIndex((d) => d.index === device.index);
+        if (index !== -1) devices.splice(index, 1);
+      }
+      state[action] = devices;
+      if (!isEqual(state, this._state.value)) this._state.next(state);
+    });
     await listen<OVRInputEvent>('OVR_INPUT_EVENT_DIGITAL', (event) => events.next(event.payload));
   }
 

--- a/src-ui/app/services/openvr-input.service.ts
+++ b/src-ui/app/services/openvr-input.service.ts
@@ -28,19 +28,32 @@ export class OpenVRInputService {
   constructor(private openvr: OpenVRService) {}
 
   async init() {
+    // release held actions when the OpenVR session ends
+    let initialized = false;
+    this.openvr.status.subscribe((status) => {
+      initialized = status === 'INITIALIZED';
+      if (initialized || !Object.values(this._state.value).some((devices) => devices.length))
+        return;
+      this._state.next({
+        [OVRInputEventAction.OpenOverlay]: [],
+        [OVRInputEventAction.MuteMicrophone]: [],
+        [OVRInputEventAction.IndicatePresence]: [],
+        [OVRInputEventAction.OverlayInteract]: [],
+      });
+    });
+
     await listen<OVRInputEvent>('OVR_INPUT_EVENT_DIGITAL', (event) => {
+      const { action, pressed, device } = event.payload;
+      if (!initialized || !device) return;
       const state = structuredClone(this._state.value);
-      const devices = state[event.payload.action];
-      if (event.payload.pressed && !devices.some((d) => d.index === event.payload.device.index)) {
-        devices.push(event.payload.device);
-      } else if (
-        !event.payload.pressed &&
-        devices.some((d) => d.index === event.payload.device.index)
-      ) {
-        const index = devices.findIndex((d) => d.index === event.payload.device.index);
+      const devices = state[action];
+      if (pressed && !devices.some((d) => d.index === device.index)) {
+        devices.push(device);
+      } else if (!pressed && devices.some((d) => d.index === device.index)) {
+        const index = devices.findIndex((d) => d.index === device.index);
         if (index !== -1) devices.splice(index, 1);
       }
-      state[event.payload.action] = devices;
+      state[action] = devices;
       if (!isEqual(state, this._state.value)) this._state.next(state);
     });
   }

--- a/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts
+++ b/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.spec.ts
@@ -12,6 +12,7 @@ import type { SleepDetectorStateReport } from '../../models/events';
 import { OVRInputEventAction } from '../../models/ovr-input-event';
 import type { SleepModeStatusChangeReason } from '../../models/sleep-mode';
 import type { SleepingPose } from '../../models/sleeping-pose';
+import type { OVRDevice } from '../../models/ovr-device';
 import {
   type SleepDetectorStateReportHandlingResult,
   SleepModeForSleepDetectorAutomationService,
@@ -52,7 +53,7 @@ function createService() {
   const configs = new BehaviorSubject(enabledConfigs());
   const sleepMode = new BehaviorSubject(false);
   const pose = new BehaviorSubject<SleepingPose>('UNKNOWN');
-  const inputState = new BehaviorSubject({
+  const inputState = new BehaviorSubject<Record<OVRInputEventAction, OVRDevice[]>>({
     [OVRInputEventAction.OpenOverlay]: [],
     [OVRInputEventAction.MuteMicrophone]: [],
     [OVRInputEventAction.IndicatePresence]: [],
@@ -89,7 +90,7 @@ function createService() {
     if (result) results.push(result);
   });
 
-  return { configs, eventLog, notifications, results, service, sleep };
+  return { configs, eventLog, inputState, notifications, results, service, sleep };
 }
 
 async function armSleepCheck(service: SleepModeForSleepDetectorAutomationService) {
@@ -164,6 +165,29 @@ describe('SleepModeForSleepDetectorAutomationService sleep check', () => {
     });
     expect(notifications.playSound).toHaveBeenCalledOnce();
     expect(notifications.clearNotification).toHaveBeenCalledWith('sleep-check-notification');
+  });
+
+  it('ignores a released or reset controller and cancels on a new press', async () => {
+    const { inputState, results, service } = createService();
+    const controller: OVRDevice = {
+      index: 1,
+      class: 'Controller',
+      role: 'LeftHand',
+      battery: 80,
+      pose: null,
+      isTurningOff: false,
+    };
+    inputState.next({ ...inputState.value, [OVRInputEventAction.IndicatePresence]: [controller] });
+    await service.init();
+    await vi.advanceTimersByTimeAsync(15000);
+    await armSleepCheck(service);
+
+    inputState.next({ ...inputState.value, [OVRInputEventAction.IndicatePresence]: [] });
+    await Promise.resolve();
+    expect(results).toEqual([]);
+    inputState.next({ ...inputState.value, [OVRInputEventAction.IndicatePresence]: [controller] });
+    await Promise.resolve();
+    expect(results).toEqual(['SLEEP_CHECK_USER_AWAKE']);
   });
 
   it('does not publish success after duplicate manual enable', async () => {

--- a/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
+++ b/src-ui/app/services/sleep-detection-automations/sleep-mode-for-sleep-detector-automation.service.ts
@@ -9,6 +9,7 @@ import {
 import {
   BehaviorSubject,
   distinctUntilChanged,
+  filter,
   firstValueFrom,
   map,
   Observable,
@@ -105,12 +106,11 @@ export class SleepModeForSleepDetectorAutomationService {
         const result = await this.handleStateReportForEnable(event.payload);
         this._lastStateReportHandlingResult.next(result);
       });
-      // Dismiss sleep check for head shake
       await listen<{ gesture: string }>('GESTURE_DETECTED', (event) => {
         if (event.payload.gesture !== 'head_shake') return;
         this.dismissSleepCheck();
       });
-      // Detect controller button presence indication
+      // dismiss sleep checks only for newly pressed controllers
       this.openvrInputService.state
         .pipe(
           map((s) => s[OVRInputEventAction.IndicatePresence]),
@@ -120,12 +120,11 @@ export class SleepModeForSleepDetectorAutomationService {
               (currentDevice) =>
                 !previous.some((previousDevice) => previousDevice.index === currentDevice.index)
             )
-          )
+          ),
+          filter(Boolean)
         )
         .subscribe(() => {
-          // Dismiss sleep check for controller button presence indication
           this.dismissSleepCheck();
-          // Register last controller button presence indication time
           this.lastControllerButtonPresenceIndication = Date.now();
         });
     });


### PR DESCRIPTION
Controller actions now release when OpenVR disconnects. Events without an active session or a device are ignored, and only a new controller press dismisses a sleep check.

Verified push-to-talk release and the first reconnect press in the desktop app with simulated native events and audio responses. Toggle mode ignores the reset. Fifteen targeted tests, the full 195-test frontend suite, typecheck, and lint pass. Real controller disconnection was not exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Controller actions are now released correctly when SteamVR disconnects or the session resets.
  * Missing or unavailable controller input no longer leaves actions active.
  * Sleep checks are dismissed by head-shake gestures or controller activity indicating the user is awake.
  * Controller releases and resets are handled correctly during sleep-check countdowns.

* **Tests**
  * Added coverage for controller resets, reconnection, sleep checks, overlay resets, unavailable devices, and microphone mute modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->