### PR TITLE
fix(OYASUMIVR-80): preserve dashboard closing animations on reopen

### DIFF
--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -274,7 +274,7 @@ public class OvrManager
     lock (LifecycleLock)
     {
       if (!_active) return;
-      _dashboardOverlay?.Dispose();
+      _dashboardOverlay?.Close();
       var overlay = new DashboardOverlay();
       _dashboardOverlay = overlay;
       overlay.OnClose += () =>


### PR DESCRIPTION
Reopening the dashboard now lets the previous dashboard finish its closing animation. The existing lifecycle lock and overlay registry keep one active dashboard and retain closing instances until disposal.

Stacks on #308. Verified the sidecar build and local manager checks for overlapping toggles and reopening before close completion. Headset testing remains pending.