### PR TITLE
refactor: migrate OpenVR integration to raphii-openvr-rs

### DIFF
--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -167,19 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aquamarine"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
-dependencies = [
- "itertools 0.9.0",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,125 +365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "autocxx"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae6bbbec65d053b6fd803a4d63d21d0bd4a92f84f917847f216fec8bb8ae6ae"
-dependencies = [
- "aquamarine",
- "autocxx-macro",
- "cxx",
- "moveit",
-]
-
-[[package]]
-name = "autocxx-bindgen"
-version = "0.73.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecaaf84d9cf1a772409c0abdac7d2477a31fd890dbdf606d8f684dc60129aa94"
-dependencies = [
- "bitflags 2.13.1",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "log",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.3.0",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "autocxx-build"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16fa879472d80dc40ca826a59347772b3f15e69a7a74df41c4935942f62cf30"
-dependencies = [
- "autocxx-engine",
- "env_logger",
- "indexmap 1.9.3",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "autocxx-engine"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9866b109f7091a3470a49906d35c7f34597828be8885508e9395d1194f8283ca"
-dependencies = [
- "aquamarine",
- "autocxx-bindgen",
- "autocxx-parser",
- "cc",
- "cxx-gen",
- "indexmap 1.9.3",
- "indoc",
- "itertools 0.10.5",
- "log",
- "miette",
- "once_cell",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "regex_static",
- "rustversion",
- "serde_json",
- "syn 2.0.101",
- "tempfile",
- "thiserror 1.0.69",
- "version_check",
-]
-
-[[package]]
-name = "autocxx-macro"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26712d744702e6fe61fdc618cc107a581a009ec8bfaffc67707d82501dbd907"
-dependencies = [
- "autocxx-parser",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "autocxx-parser"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcfc473ec409e612fb0e0c5c4a1b5b7611eca2bac71bc27b3cda98f15a25124"
-dependencies = [
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.101",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -674,7 +546,7 @@ dependencies = [
  "dbus",
  "dbus-tokio",
  "futures",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "serde",
  "serde-xml-rs",
@@ -849,7 +721,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -857,15 +729,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfb"
@@ -926,17 +789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.7",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,17 +831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -1311,81 +1152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
-name = "cxx"
-version = "1.0.199"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824894a4a85dca76d4c95c2b9098c036f5a29f627b30c12780774f6654e60974"
-dependencies = [
- "cc",
- "cxx-build",
- "cxxbridge-cmd",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "foldhash 0.2.0",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.199"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ae0b651ea5b0000b19513aef5a03f194d7e3486f2d9258b658da8677fe9036"
-dependencies = [
- "cc",
- "codespan-reporting",
- "indexmap 2.14.0",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "cxx-gen"
-version = "0.7.199"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e54565cd4c9385e30c81b73b0f3702a7c92b3c86aad59c6d5d50d6dd9fb870"
-dependencies = [
- "codespan-reporting",
- "indexmap 2.14.0",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "cxxbridge-cmd"
-version = "1.0.199"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb05f91d3fb8435d9bab6ac5ce6ac1868be774325fb7fb2a91be39393b21388e"
-dependencies = [
- "clap",
- "codespan-reporting",
- "indexmap 2.14.0",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.199"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf293202e0e3e98495785745389e8d0755b217e66f19194a5c695c25e03282ef"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.199"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca001d746947c7249ed9d332a10f7a59daedbafeb0ec68c5c18a7db7a93f6ccc"
-dependencies = [
- "indexmap 2.14.0",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,16 +1169,6 @@ checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core 0.20.11",
  "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1444,19 +1200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,17 +1217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.101",
 ]
@@ -1910,27 +1642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumset"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
-dependencies = [
- "enumset_derive",
-]
-
-[[package]]
-name = "enumset_derive"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
-dependencies = [
- "darling 0.21.3",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,19 +1649,6 @@ checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2736,15 +2434,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
@@ -2868,12 +2557,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -3216,12 +2899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
-
-[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,24 +2949,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3515,12 +3174,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3538,15 +3197,6 @@ dependencies = [
  "bitflags 2.13.1",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3695,29 +3345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "miette-derive",
- "once_cell",
- "thiserror 1.0.69",
- "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,15 +3391,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "moveit"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d7335204cb6ef7bd647fa6db0be3e4d7aa25b5823a7aa030027ddf512cefba"
-dependencies = [
- "cxx",
 ]
 
 [[package]]
@@ -3918,15 +3536,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "normpath"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4527,32 +4136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ovr_overlay"
-version = "0.0.0"
-source = "git+https://github.com/Raphiiko/ovr_overlay_oyasumi?rev=f7b58630b53df4ae671f8c52e7b457a0213e95b7#f7b58630b53df4ae671f8c52e7b457a0213e95b7"
-dependencies = [
- "byteorder",
- "derive_more 2.1.1",
- "enumset",
- "lazy_static",
- "log",
- "ovr_overlay_sys",
- "slice-of-array",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "ovr_overlay_sys"
-version = "0.0.0"
-source = "git+https://github.com/Raphiiko/ovr_overlay_oyasumi?rev=f7b58630b53df4ae671f8c52e7b457a0213e95b7#f7b58630b53df4ae671f8c52e7b457a0213e95b7"
-dependencies = [
- "autocxx",
- "autocxx-build",
- "cxx",
- "normpath",
-]
-
-[[package]]
 name = "oyasumivr"
 version = "26.8.0-beta.6"
 dependencies = [
@@ -4565,7 +4148,6 @@ dependencies = [
  "cronjob",
  "dirs",
  "discord-sdk",
- "enumset",
  "futures",
  "futures-util",
  "hidapi",
@@ -4579,11 +4161,11 @@ dependencies = [
  "mime_guess",
  "nalgebra",
  "named_pipe",
- "ovr_overlay",
  "oyasumivr-shared",
  "oyasumivr_oscquery",
  "prost",
  "public-ip",
+ "raphii-openvr-rs",
  "readonly",
  "regex",
  "reqwest 0.13.4",
@@ -5069,7 +4651,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 0.38.44",
  "tracing",
@@ -5200,7 +4782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5221,7 +4803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5520,6 +5102,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "raphii-openvr-rs"
+version = "0.1.0"
+source = "git+https://github.com/Raphiiko/raphii-openvr-rs?rev=a722cf7a6aa5832eaca55bd640bc5b5f87ed0661#a722cf7a6aa5832eaca55bd640bc5b5f87ed0661"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,7 +5161,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5582,54 +5172,14 @@ checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "regex_static"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6126d61c5e4b41929098f73b42fc1d257116cc95d19739248c51591f77cc0021"
-dependencies = [
- "once_cell",
- "regex",
- "regex_static_macro",
-]
-
-[[package]]
-name = "regex_static_impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3755019886a70e772e6360b0b58501d75cf7dc17a53e08aa97e59ecb2c2bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex-syntax 0.6.29",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "regex_static_macro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b15495fd034158635bc8b762a132dfc83864d6992aeda1ffabf01b03b611a1"
-dependencies = [
- "proc-macro2",
- "regex_static_impl",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "reqwest"
@@ -6045,12 +5595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scratch"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6446,12 +5990,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -6503,12 +6041,6 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "slice-of-array"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f120bb98cb4cb0dab21c882968c3cbff79dd23b46f07b1cf5c25044945ce84"
 
 [[package]]
 name = "smallvec"
@@ -7698,15 +7230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8416,12 +7939,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -30,7 +30,6 @@ chrono = "0.4.45"
 cronjob = "0.4.17"
 dirs = "6.0.0"
 discord-sdk = "0.4.0"
-enumset = "1.1.14"
 futures = "0.3.33"
 futures-util = "0.3.33"
 hidapi = "2.6.6"
@@ -124,11 +123,9 @@ winreg = "0.56.0"
 git = "https://github.com/Raphiiko/ipgeolocate_oyasumi.git"
 rev = "5f24925"
 
-[dependencies.ovr_overlay]
-git = "https://github.com/Raphiiko/ovr_overlay_oyasumi"
-rev = "f7b58630b53df4ae671f8c52e7b457a0213e95b7"
-# path = "../../ovr_overlay_oyasumi"
-features = ["ovr_system", "ovr_settings"]
+[dependencies.raphii-openvr-rs]
+git = "https://github.com/Raphiiko/raphii-openvr-rs"
+rev = "a722cf7a6aa5832eaca55bd640bc5b5f87ed0661"
 
 [dependencies.oyasumivr_oscquery]
 git = "https://github.com/Raphiiko/oyasumivr_oscquery.git"

--- a/src-core/src/openvr/brightness_analog.rs
+++ b/src-core/src/openvr/brightness_analog.rs
@@ -3,7 +3,7 @@ use std::ffi::CStr;
 use super::devices::get_devices;
 use super::models::TrackedDeviceClass;
 use super::{settings_interface_available, OVR_CONTEXT};
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 
 pub async fn get_analog_gain() -> Result<f32, String> {
     let devices = get_devices().await;
@@ -16,12 +16,12 @@ pub async fn get_analog_gain() -> Result<f32, String> {
             Some(context) => context,
             None => return Err("OPENVR_NOT_INITIALISED".to_string()),
         };
-        if !settings_interface_available() {
+        if !settings_interface_available(context) {
             return Err("OPENVR_NOT_INITIALISED".to_string());
         }
-        let mut settings = context.settings_mngr();
+        let settings = context.settings();
         let analog_gain = settings.get_float(
-            CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
+            CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
             c"analogGain",
         );
         match analog_gain {
@@ -44,12 +44,12 @@ pub async fn set_analog_gain(analog_gain: f32) -> Result<(), String> {
             Some(context) => context,
             None => return Err("OPENVR_NOT_INITIALISED".to_string()),
         };
-        if !settings_interface_available() {
+        if !settings_interface_available(context) {
             return Err("OPENVR_NOT_INITIALISED".to_string());
         }
-        let settings = &mut context.settings_mngr();
+        let settings = &context.settings();
         let _ = settings.set_float(
-            CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
+            CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
             c"analogGain",
             analog_gain,
         );

--- a/src-core/src/openvr/brightness_overlay.rs
+++ b/src-core/src/openvr/brightness_overlay.rs
@@ -1,22 +1,21 @@
-use super::{overlay_interface_available, OVR_CONTEXT};
+use super::OVR_CONTEXT;
 use log::error;
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 use std::sync::LazyLock;
 use tokio::sync::Mutex;
 
-static OVERLAY_HANDLE: LazyLock<Mutex<Option<ovr_overlay::overlay::OverlayHandle>>> =
+static OVERLAY_HANDLE: LazyLock<Mutex<Option<raphii_openvr_rs::overlay::OverlayHandle>>> =
     LazyLock::new(Default::default);
 static BRIGHTNESS: LazyLock<Mutex<f64>> = LazyLock::new(|| Mutex::new(1.0));
 
 pub async fn on_ovr_init(context: &ovr::Context) -> Result<(), String> {
-    // Dispose of any existing overlay
     *OVERLAY_HANDLE.lock().await = None;
     // Create the overlay
     let overlay_handle = match create_overlay(context).await {
         Ok(handle) => handle,
         Err(_) => return Err("Failed to create overlay".to_string()),
     };
-    // Save the handle
+
     *OVERLAY_HANDLE.lock().await = Some(overlay_handle);
     Ok(())
 }
@@ -36,17 +35,17 @@ pub async fn set_brightness(brightness: f64, perceived_brightness_adjustment_gam
     let alpha = 1.0 - brightness;
     // Store the brightness
     *BRIGHTNESS.lock().await = brightness;
-    // Get the context
+
     let mut context_guard = OVR_CONTEXT.lock().await;
     let context = match context_guard.as_mut() {
         Some(manager) => manager,
         None => return,
     };
-    if !overlay_interface_available() {
+    if !context.overlay_interface_available() {
         return;
     }
-    // Get the manager
-    let mut manager = context.overlay_mngr();
+
+    let manager = context.overlays();
     // Get the overlay handle
     let overlay_handle_guard = OVERLAY_HANDLE.lock().await;
     let overlay_handle = match overlay_handle_guard.as_ref() {
@@ -60,20 +59,20 @@ pub async fn set_brightness(brightness: f64, perceived_brightness_adjustment_gam
 }
 
 async fn create_overlay(
-    context: &ovr_overlay::Context,
-) -> Result<ovr_overlay::overlay::OverlayHandle, ()> {
-    if !overlay_interface_available() {
+    context: &raphii_openvr_rs::Context,
+) -> Result<raphii_openvr_rs::overlay::OverlayHandle, ()> {
+    if !context.overlay_interface_available() {
         error!("[Core] The OpenVR overlay interface is unavailable");
         return Err(());
     }
-    // Get the manager
-    let mut manager = context.overlay_mngr();
+
+    let manager = context.overlays();
     // Create the overlay
     let result = manager.create_overlay(
         "co.raphii.oyasumi:BrightnessOverlay",
         "OyasumiVR Brightness Overlay",
     );
-    let overlay: ovr_overlay::overlay::OverlayHandle = match result {
+    let overlay: raphii_openvr_rs::overlay::OverlayHandle = match result {
         Ok(handle) => handle,
         Err(_) => return Err(()),
     };
@@ -83,11 +82,14 @@ async fn create_overlay(
         return Err(());
     }
     // Transform the overlay
-    let transformation_matrix =
-        ovr_overlay::pose::Matrix3x4([[1., 0., 0., 0.], [0., 1., 0., 0.], [0., 0., 1., -0.15]]);
+    let transformation_matrix = raphii_openvr_rs::pose::Matrix3x4([
+        [1., 0., 0., 0.],
+        [0., 1., 0., 0.],
+        [0., 0., 1., -0.15],
+    ]);
     if let Err(e) = manager.set_transform_tracked_device_relative(
         overlay,
-        ovr_overlay::TrackedDeviceIndex::new(0).unwrap(), // HMD is always at 0
+        raphii_openvr_rs::TrackedDeviceIndex::HMD,
         &transformation_matrix,
     ) {
         error!("[Core] Failed to set overlay transform: {e}");
@@ -113,7 +115,7 @@ async fn create_overlay(
         error!("[Core] Failed to set overlay visibility: {e}");
         return Err(());
     }
-    // Return overlay
+
     Ok(overlay)
 }
 

--- a/src-core/src/openvr/chaperone.rs
+++ b/src-core/src/openvr/chaperone.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 
 use super::{settings_interface_available, OVR_CONTEXT};
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 
 pub async fn get_fade_distance() -> Result<f32, String> {
     let context_guard = OVR_CONTEXT.lock().await;
@@ -9,12 +9,12 @@ pub async fn get_fade_distance() -> Result<f32, String> {
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
     let fade_distance = settings.get_float(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_CollisionBounds_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_CollisionBounds_Section).unwrap(),
         c"CollisionBoundsFadeDistance",
     );
     match fade_distance {
@@ -29,12 +29,12 @@ pub async fn set_fade_distance(fade_distance: f32) -> Result<(), String> {
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
     let _ = settings.set_float(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_CollisionBounds_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_CollisionBounds_Section).unwrap(),
         c"CollisionBoundsFadeDistance",
         fade_distance,
     );

--- a/src-core/src/openvr/colortemp_analog.rs
+++ b/src-core/src/openvr/colortemp_analog.rs
@@ -1,4 +1,4 @@
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 use std::ffi::CStr;
 
 use crate::openvr::{
@@ -18,7 +18,7 @@ pub async fn set_color_temp(mut temperature: Option<u32>) -> Result<(f64, f64, f
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
     if temperature.is_none() {
@@ -53,20 +53,20 @@ pub async fn set_color_temp(mut temperature: Option<u32>) -> Result<(f64, f64, f
         let blue = 138.5177312231 * blue.ln() - 305.0447927307;
         blue.clamp(0.0, 255.0)
     } / 255.0;
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
     let _ = settings.set_float(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_HmdDisplayColorGainR_Float).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_HmdDisplayColorGainR_Float).unwrap(),
         red as f32,
     );
     let _ = settings.set_float(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_HmdDisplayColorGainG_Float).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_HmdDisplayColorGainG_Float).unwrap(),
         green as f32,
     );
     let _ = settings.set_float(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_HmdDisplayColorGainB_Float).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_HmdDisplayColorGainB_Float).unwrap(),
         blue as f32,
     );
     Ok((red, green, blue))

--- a/src-core/src/openvr/commands.rs
+++ b/src-core/src/openvr/commands.rs
@@ -2,12 +2,11 @@ use crate::globals::STEAM_APP_KEY;
 
 use super::{
     models::{BindingOriginData, OVRDevice, OVRFrameLimits},
-    overlay_interface_available, OVR_CONTEXT,
+    OVR_CONTEXT,
 };
-use enumset::EnumSet;
 use log::error;
 use ovr::input::{InputString, InputValueHandle};
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 use std::fmt::Display;
 use substring::Substring;
 
@@ -33,17 +32,15 @@ fn assemble_binding_origins(
     localized_controller_types: &[String],
     localized_hands: &[String],
     localized_input_sources: &[String],
-    binding_infos: &[ovr::sys::InputBindingInfo_t],
+    binding_infos: &[ovr::raw::InputBindingInfo_t],
 ) -> Option<Vec<BindingOriginData>> {
     (0..origin_count)
         .map(|i| {
             let binding_info = binding_infos.get(i)?;
-            let device_path_name = crate::utils::convert_char_array_to_string(
-                &binding_info.rchDevicePathName,
-            )?;
-            let input_path_name = crate::utils::convert_char_array_to_string(
-                &binding_info.rchInputPathName,
-            )?;
+            let device_path_name =
+                crate::utils::convert_char_array_to_string(&binding_info.rchDevicePathName)?;
+            let input_path_name =
+                crate::utils::convert_char_array_to_string(&binding_info.rchInputPathName)?;
             let localized_controller_type = localized_controller_types.get(i)?;
             let localized_hand = localized_hands.get(i)?;
             let localized_input_source = localized_input_sources.get(i)?;
@@ -154,8 +151,8 @@ pub async fn openvr_set_image_brightness(
 #[tauri::command]
 pub async fn openvr_launch_binding_configuration(show_on_desktop: bool) {
     let context = OVR_CONTEXT.lock().await;
-    let mut input = match context.as_ref() {
-        Some(context) => context.input_mngr(),
+    let input = match context.as_ref() {
+        Some(context) => context.input(),
         None => return,
     };
     let input_handle = match input.get_input_source_handle("/user/hand/right") {
@@ -173,21 +170,18 @@ pub async fn openvr_launch_binding_configuration(show_on_desktop: bool) {
 #[tauri::command]
 pub async fn openvr_is_dashboard_visible() -> bool {
     let context = OVR_CONTEXT.lock().await;
-    if !overlay_interface_available() {
-        return false;
-    }
-    let mut manager = match context.as_ref() {
-        Some(context) => context.overlay_mngr(),
+    let manager = match context.as_ref() {
+        Some(context) => context.overlays(),
         None => return false,
     };
-    manager.is_dashboard_visible()
+    manager.is_dashboard_visible().unwrap_or(false)
 }
 
 #[tauri::command]
 pub async fn openvr_reregister_manifest() -> Result<(), String> {
     let ctx = OVR_CONTEXT.lock().await;
     let ctx = ctx.as_ref().ok_or("OPENVR_NOT_INITIALIZED")?;
-    let mut applications = ctx.applications_mngr();
+    let applications = ctx.applications();
     let manifest_path_buf = std::fs::canonicalize("resources/manifest.vrmanifest")
         .map_err(|e| format!("MANIFEST_NOT_FOUND: {e}"))?;
     let manifest_path: &std::path::Path = manifest_path_buf.as_ref();
@@ -206,9 +200,7 @@ pub async fn openvr_reregister_manifest() -> Result<(), String> {
                             install_for_flavours.contains(&crate::flavour::BUILD_FLAVOUR);
                         if should_install_for_flavour {
                             match applications.add_application_manifest(manifest_path, false) {
-                                Ok(_) => {
-                                    Ok(())
-                                }
+                                Ok(_) => Ok(()),
                                 Err(e) => {
                                     error!("[Core] Failed to add VR manifest: {e}");
                                     Err(String::from("MANIFEST_ADD_FAILED"))
@@ -228,7 +220,7 @@ pub async fn openvr_reregister_manifest() -> Result<(), String> {
         Err(e) => {
             error!(
                 "[Core] Failed to check if VR manifest is registered: {:#?}",
-                e.description()
+                e.to_string()
             );
             Err(String::from("MANIFEST_CHECK_FAILED"))
         }
@@ -257,8 +249,8 @@ pub async fn openvr_get_binding_origins(
     };
     // Get the input service
     let context = OVR_CONTEXT.lock().await;
-    let mut input = match context.as_ref() {
-        Some(context) => context.input_mngr(),
+    let input = match context.as_ref() {
+        Some(context) => context.input(),
         None => return Err(String::from("OPENVR_NOT_INITIALIZED")),
     };
     if let Err(e) = input.update_actions(input_ctx.active_sets.as_mut_slice()) {
@@ -282,32 +274,26 @@ pub async fn openvr_get_binding_origins(
         origins.iter().map(|origin| {
             input.get_origin_localized_name(
                 InputValueHandle(*origin),
-                EnumSet::only(InputString::ControllerType),
+                &[InputString::ControllerType],
             )
         }),
         "controller type",
     );
     let localized_hands = collect_localized_names(
         origins.iter().map(|origin| {
-            input.get_origin_localized_name(
-                InputValueHandle(*origin),
-                EnumSet::only(InputString::Hand),
-            )
+            input.get_origin_localized_name(InputValueHandle(*origin), &[InputString::Hand])
         }),
         "hand",
     );
     let localized_input_sources = collect_localized_names(
         origins.iter().map(|origin| {
-            input.get_origin_localized_name(
-                InputValueHandle(*origin),
-                EnumSet::only(InputString::InputSource),
-            )
+            input.get_origin_localized_name(InputValueHandle(*origin), &[InputString::InputSource])
         }),
         "input source",
     );
 
     // Get extra information about each binding
-    let binding_infos: Vec<ovr::sys::InputBindingInfo_t> =
+    let binding_infos: Vec<ovr::raw::InputBindingInfo_t> =
         match input.get_action_binding_info(action) {
             Ok(result) => result,
             Err(e) => {
@@ -343,8 +329,8 @@ mod tests {
         result
     }
 
-    fn binding_info(device_path_name: &str) -> ovr::sys::InputBindingInfo_t {
-        ovr::sys::InputBindingInfo_t {
+    fn binding_info(device_path_name: &str) -> ovr::raw::InputBindingInfo_t {
+        ovr::raw::InputBindingInfo_t {
             rchDevicePathName: char_array(device_path_name),
             rchInputPathName: char_array("/input/a"),
             rchModeName: char_array("button"),
@@ -374,10 +360,7 @@ mod tests {
         assert_eq!(data.len(), 2);
         assert_eq!(data[0].localized_controller_type, "controller one");
         assert_eq!(data[0].device_path_name, "/user/hand/left");
-        assert_eq!(
-            data[1].localized_controller_type,
-            "/user/hand/right"
-        );
+        assert_eq!(data[1].localized_controller_type, "/user/hand/right");
         assert_eq!(data[1].localized_hand, "right");
         assert_eq!(data[1].localized_input_source, "b");
         assert_eq!(data[1].device_path_name, "/user/hand/right");

--- a/src-core/src/openvr/devices.rs
+++ b/src-core/src/openvr/devices.rs
@@ -6,12 +6,11 @@ use super::models::{
 };
 use super::{GestureDetector, SleepDetector, OVR_CONTEXT};
 use crate::utils::send_event;
-use byteorder::{ByteOrder, LE};
 use chrono::{DateTime, Duration, Utc};
 use log::error;
 use ovr::input::InputValueHandle;
-use ovr::sys::EVRInputError;
-use ovr_overlay as ovr;
+use ovr::raw::EVRInputError;
+use raphii_openvr_rs as ovr;
 use std::sync::LazyLock;
 use strum::IntoEnumIterator;
 use tokio::sync::Mutex;
@@ -53,29 +52,28 @@ pub async fn on_ovr_tick() {
 }
 
 pub async fn on_ovr_event(event: ovr::system::VREvent) {
-    let ovr::system::EventType::Known(event_type) = &event.event_type else {
-        return;
-    };
-    match event_type {
-        ovr::sys::EVREventType::VREvent_TrackedDeviceActivated
-        | ovr::sys::EVREventType::VREvent_TrackedDeviceDeactivated => {
-            update_device(event.tracked_device_index, true).await;
+    match event.event_type() {
+        ovr::raw::EVREventType::VREvent_TrackedDeviceActivated
+        | ovr::raw::EVREventType::VREvent_TrackedDeviceDeactivated => {
+            update_device(event.tracked_device_index(), true).await;
         }
-        ovr::sys::EVREventType::VREvent_PropertyChanged => {
-            let tracked_device_property: u32 = LE::read_u32(&event.data[12..16]);
+        ovr::raw::EVREventType::VREvent_PropertyChanged => {
+            let Some(tracked_device_property) = event.changed_property() else {
+                return;
+            };
             let matching_properties = [
-                ovr::sys::ETrackedDeviceProperty::Prop_DeviceBatteryPercentage_Float as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_DeviceProvidesBatteryStatus_Bool as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_DeviceCanPowerOff_Bool as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_DeviceIsCharging_Bool as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_ConnectedWirelessDongle_String as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_SerialNumber_String as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_HardwareRevision_String as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_ManufacturerName_String as u32,
-                ovr::sys::ETrackedDeviceProperty::Prop_ModelNumber_String as u32,
+                ovr::raw::ETrackedDeviceProperty::Prop_DeviceBatteryPercentage_Float,
+                ovr::raw::ETrackedDeviceProperty::Prop_DeviceProvidesBatteryStatus_Bool,
+                ovr::raw::ETrackedDeviceProperty::Prop_DeviceCanPowerOff_Bool,
+                ovr::raw::ETrackedDeviceProperty::Prop_DeviceIsCharging_Bool,
+                ovr::raw::ETrackedDeviceProperty::Prop_ConnectedWirelessDongle_String,
+                ovr::raw::ETrackedDeviceProperty::Prop_SerialNumber_String,
+                ovr::raw::ETrackedDeviceProperty::Prop_HardwareRevision_String,
+                ovr::raw::ETrackedDeviceProperty::Prop_ManufacturerName_String,
+                ovr::raw::ETrackedDeviceProperty::Prop_ModelNumber_String,
             ];
             if matching_properties.contains(&tracked_device_property) {
-                update_device(event.tracked_device_index, true).await;
+                update_device(event.tracked_device_index(), true).await;
             }
         }
         _ => {}
@@ -129,8 +127,8 @@ async fn update_handle_types() {
 async fn update_handle_type(handle_type: OVRHandleType) {
     let context = OVR_CONTEXT.lock().await;
     let mut device_handle_cache = DEVICE_HANDLE_TYPE_CACHE.lock().await;
-    let mut input = match context.as_ref() {
-        Some(context) => context.input_mngr(),
+    let input = match context.as_ref() {
+        Some(context) => context.input(),
         None => return,
     };
 
@@ -165,18 +163,21 @@ async fn update_handle_type(handle_type: OVRHandleType) {
 }
 
 async fn update_all_devices(emit: bool) {
-    for n in 0..(ovr::sys::k_unMaxTrackedDeviceCount as usize) {
+    for n in 0..(ovr::raw::k_unMaxTrackedDeviceCount as usize) {
         update_device(ovr::TrackedDeviceIndex(n.try_into().unwrap()), emit).await;
     }
 }
 
 async fn update_device(device_index: ovr::TrackedDeviceIndex, emit: bool) {
     let context = OVR_CONTEXT.lock().await;
-    let mut system = match context.as_ref() {
-        Some(context) => context.system_mngr(),
+    let system = match context.as_ref() {
+        Some(context) => context.system(),
         None => return,
     };
-    let class: TrackedDeviceClass = system.get_tracked_device_class(device_index).into();
+    let class: TrackedDeviceClass = system
+        .get_tracked_device_class(device_index)
+        .unwrap_or(ovr::raw::ETrackedDeviceClass::TrackedDeviceClass_Invalid)
+        .into();
     let mut device_class_cache = DEVICE_CLASS_CACHE.lock().await;
     let device_handle_cache = DEVICE_HANDLE_TYPE_CACHE.lock().await;
     // Stop here if the class is invalid and we don't have it cached
@@ -197,85 +198,87 @@ async fn update_device(device_index: ovr::TrackedDeviceIndex, emit: bool) {
     let battery: Option<f32> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_DeviceBatteryPercentage_Float,
+            ovr::raw::ETrackedDeviceProperty::Prop_DeviceBatteryPercentage_Float,
         )
         .ok();
     let provides_battery_status: Option<bool> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_DeviceProvidesBatteryStatus_Bool,
+            ovr::raw::ETrackedDeviceProperty::Prop_DeviceProvidesBatteryStatus_Bool,
         )
         .ok();
     let can_power_off: Option<bool> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_DeviceCanPowerOff_Bool,
+            ovr::raw::ETrackedDeviceProperty::Prop_DeviceCanPowerOff_Bool,
         )
         .ok();
     let is_charging: Option<bool> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_DeviceIsCharging_Bool,
+            ovr::raw::ETrackedDeviceProperty::Prop_DeviceIsCharging_Bool,
         )
         .ok();
     let dongle_id: Option<String> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_ConnectedWirelessDongle_String,
+            ovr::raw::ETrackedDeviceProperty::Prop_ConnectedWirelessDongle_String,
         )
         .ok();
     let serial_number: Option<String> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_SerialNumber_String,
+            ovr::raw::ETrackedDeviceProperty::Prop_SerialNumber_String,
         )
         .ok();
     let hardware_revision: Option<String> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_HardwareRevision_String,
+            ovr::raw::ETrackedDeviceProperty::Prop_HardwareRevision_String,
         )
         .ok();
     let manufacturer_name: Option<String> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_ManufacturerName_String,
+            ovr::raw::ETrackedDeviceProperty::Prop_ManufacturerName_String,
         )
         .ok();
     let model_number: Option<String> = system
         .get_tracked_device_property(
             device_index,
-            ovr::sys::ETrackedDeviceProperty::Prop_ModelNumber_String,
+            ovr::raw::ETrackedDeviceProperty::Prop_ModelNumber_String,
         )
         .ok();
     let mut hmd_on_head = None;
     let mut hmd_activity = None;
     let mut display_frequency = None;
     if class == TrackedDeviceClass::HMD {
-        let activity_level = system.get_tracked_device_activity_level(device_index);
-        hmd_on_head = Some(activity_level == ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction || activity_level == ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction_Timeout);
-        // Serialize activity level
+        let activity_level = system
+            .get_tracked_device_activity_level(device_index)
+            .unwrap_or(ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_Unknown);
+        hmd_on_head = Some(activity_level == ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction || activity_level == ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction_Timeout);
+
         hmd_activity = Some(
             match activity_level {
-                ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_Unknown => "Unknown",
-                ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_Idle => "Idle",
-                ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction => {
+                ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_Idle => "Idle",
+                ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction => {
                     "UserInteraction"
                 }
-                ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction_Timeout => {
+                ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_UserInteraction_Timeout => {
                     "UserInteractionTimeout"
                 }
-                ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_Standby => "Standby",
-                ovr::sys::EDeviceActivityLevel::k_EDeviceActivityLevel_Idle_Timeout => {
+                ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_Standby => "Standby",
+                ovr::raw::EDeviceActivityLevel::k_EDeviceActivityLevel_Idle_Timeout => {
                     "IdleTimeout"
                 }
+                _ => "Unknown",
             }
             .to_string(),
         );
         display_frequency = system
             .get_tracked_device_property(
                 device_index,
-                ovr::sys::ETrackedDeviceProperty::Prop_DisplayFrequency_Float,
+                ovr::raw::ETrackedDeviceProperty::Prop_DisplayFrequency_Float,
             )
             .ok();
     }
@@ -285,6 +288,7 @@ async fn update_device(device_index: ovr::TrackedDeviceIndex, emit: bool) {
         class,
         role: system
             .get_controller_role_for_tracked_device_index(device_index)
+            .unwrap_or(ovr::raw::ETrackedControllerRole::TrackedControllerRole_Invalid)
             .into(),
         battery,
         provides_battery_status,
@@ -324,20 +328,27 @@ async fn update_device(device_index: ovr::TrackedDeviceIndex, emit: bool) {
 async fn refresh_device_poses() {
     let poses = {
         let context = OVR_CONTEXT.lock().await;
-        let mut system = match context.as_ref() {
-            Some(context) => context.system_mngr(),
+        let system = match context.as_ref() {
+            Some(context) => context.system(),
             None => return,
         };
         system.get_device_to_absolute_tracking_pose(
-            ovr::sys::ETrackingUniverseOrigin::TrackingUniverseStanding,
+            ovr::raw::ETrackingUniverseOrigin::TrackingUniverseStanding,
             0.0,
         )
+    };
+    let poses = match poses {
+        Ok(poses) => poses,
+        Err(e) => {
+            error!("[Core] Failed to read OpenVR poses: {e}");
+            return;
+        }
     };
     for (n, pose) in poses.iter().enumerate() {
         if pose.bDeviceIsConnected && pose.bPoseIsValid {
             let matrix = pose.mDeviceToAbsoluteTracking.m;
             // Extract quaternion
-            let q = ovr::sys::HmdQuaternion_t {
+            let q = ovr::raw::HmdQuaternion_t {
                 w: 0.0f64
                     .max((1.0 + matrix[0][0] + matrix[1][1] + matrix[2][2]).into())
                     .sqrt()
@@ -359,7 +370,7 @@ async fn refresh_device_poses() {
                     .copysign((matrix[1][0] - matrix[0][1]).into()),
             };
             // Extract position
-            let pos = ovr::sys::HmdVector3_t {
+            let pos = ovr::raw::HmdVector3_t {
                 v: [matrix[0][3], matrix[1][3], matrix[2][3]],
             };
             // Update sleep and gesture detectors (0 == HMD)
@@ -398,24 +409,23 @@ async fn refresh_device_poses() {
 }
 
 async fn detect_inputs() {
-    // Get known devices, and input
     let devices = OVR_DEVICES.lock().await;
     let mut input_ctx = super::OVR_INPUT_CONTEXT.lock().await;
-    // Get input context
+
     let context = OVR_CONTEXT.lock().await;
-    let mut input = match context.as_ref() {
-        Some(context) => context.input_mngr(),
+    let input = match context.as_ref() {
+        Some(context) => context.input(),
         None => return,
     };
     // Update actions for all sets
     if let Err(e) = input.update_actions(input_ctx.active_sets.as_mut_slice()) {
-        error!("[Core] Failed to update actions: {:?}", e.description());
+        error!("[Core] Failed to update actions: {:?}", e.to_string());
         return;
     }
     for action in input_ctx.actions.iter() {
         match input.get_digital_action_data(
             action.handle,
-            InputValueHandle(ovr::sys::k_ulInvalidInputValueHandle),
+            InputValueHandle(ovr::raw::k_ulInvalidInputValueHandle),
         ) {
             Ok(data) => {
                 if data.0.bChanged {
@@ -428,7 +438,7 @@ async fn detect_inputs() {
                         Err(e) => {
                             error!(
                                 "[Core] Failed to get origin tracked device info: {:?}",
-                                e.description()
+                                e.to_string()
                             );
                             return;
                         }
@@ -445,7 +455,7 @@ async fn detect_inputs() {
                 }
             }
             Err(e) => {
-                error!("[Core] Failed to get action data: {:?}", e.description());
+                error!("[Core] Failed to get action data: {:?}", e.to_string());
                 return;
             }
         };

--- a/src-core/src/openvr/framelimiter.rs
+++ b/src-core/src/openvr/framelimiter.rs
@@ -11,10 +11,10 @@ pub async fn set_app_framelimits(
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
 
     let section_string = format!("steam.app.{app_id}\0");
     let pch_section = CStr::from_bytes_with_nul(section_string.as_bytes()).unwrap();
@@ -47,10 +47,10 @@ pub async fn get_app_framelimits(app_id: u32) -> Result<Option<OVRFrameLimits>, 
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
 
     let section_string = format!("steam.app.{app_id}\0");
     let pch_section = CStr::from_bytes_with_nul(section_string.as_bytes()).unwrap();

--- a/src-core/src/openvr/mod.rs
+++ b/src-core/src/openvr/mod.rs
@@ -20,7 +20,7 @@ use gesture_detector::GestureDetector;
 use log::{error, info, warn};
 use models::OpenVRStatus;
 use ovr::input::ActiveActionSet;
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 use sleep_detector::SleepDetector;
 use std::{
     sync::{
@@ -73,7 +73,7 @@ pub async fn task() {
                     update_status(OpenVRStatus::Inactive).await;
                     continue;
                 }
-                // Update the status
+
                 update_status(OpenVRStatus::Initializing).await;
                 // If we need to delay the initialization, do so
                 if *OVR_INIT_DELAY_FIX.lock().await {
@@ -81,24 +81,19 @@ pub async fn task() {
                 } else {
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }
-                // Try to initialize OpenVR
+
                 let ctx = match ovr::Context::init(
-                    ovr::sys::EVRApplicationType::VRApplication_Background,
+                    ovr::raw::EVRApplicationType::VRApplication_Background,
                 ) {
                     Ok(ctx) => ctx,
                     Err(e) => {
-                        let reason = match e {
-                            ovr::InitError::AlreadyInitialized => {
-                                "OpenVR is already initialized".to_string()
-                            }
-                            ovr::InitError::Sys(e) => e.to_string(),
-                        };
+                        let reason = e.to_string();
                         error!("[Core] Could not initialize OpenVR: {reason}");
                         shutdown_ovr().await;
                         continue;
                     }
                 };
-                // Set the context on the module state
+
                 *OVR_CONTEXT.lock().await = Some(ctx.clone());
                 // Initialize submodules
                 if let Err(e) = brightness_overlay::on_ovr_init(&ctx).await {
@@ -113,7 +108,7 @@ pub async fn task() {
                 // (Un)register manifest if needed
                 'manifest: {
                     let ctx = OVR_CONTEXT.lock().await;
-                    let mut applications = ctx.as_ref().unwrap().applications_mngr();
+                    let applications = ctx.as_ref().unwrap().applications();
 
                     let manifest_path_buf =
                         match std::fs::canonicalize("resources/manifest.vrmanifest") {
@@ -130,7 +125,7 @@ pub async fn task() {
                         Err(e) => {
                             error!(
                                 "[Core] Failed to check if VR manifest is registered: {:#?}",
-                                e.description()
+                                e.to_string()
                             );
                             None
                         }
@@ -155,7 +150,7 @@ pub async fn task() {
                             Err(e) => {
                                 error!(
                                     "[Core] Failed to unregister VR manifest: {:#?}",
-                                    e.description()
+                                    e.to_string()
                                 );
                             }
                         };
@@ -167,7 +162,7 @@ pub async fn task() {
                         {
                             error!(
                                 "[Core] Failed to register VR manifest: {:#?}",
-                                e.description()
+                                e.to_string()
                             );
                         } else {
                             info!("[Core] Steam app manifest registered ({STEAM_APP_KEY})")
@@ -180,7 +175,7 @@ pub async fn task() {
                 let mut active_sets = vec![];
                 'input: {
                     let ctx = OVR_CONTEXT.lock().await;
-                    let mut input = ctx.as_ref().unwrap().input_mngr();
+                    let input = ctx.as_ref().unwrap().input();
                     // Register action manifest
                     info!("[Core] Registering Action Manifest");
                     let manifest_path_buf =
@@ -195,7 +190,7 @@ pub async fn task() {
                     if let Err(e) = input.set_action_manifest(manifest_path) {
                         error!(
                             "[Core] Failed to register action manifest: {:#?}",
-                            e.description()
+                            e.to_string()
                         );
                     } else {
                         // Get action handles
@@ -212,7 +207,7 @@ pub async fn task() {
                                 Err(error) => {
                                     error!(
                                         "[Core] Failed get action handle: {:?}",
-                                        error.description()
+                                        error.to_string()
                                     );
                                     continue;
                                 }
@@ -229,18 +224,12 @@ pub async fn task() {
                                 Err(error) => {
                                     error!(
                                         "[Core] Failed get action set handle: {:?}",
-                                        error.description()
+                                        error.to_string()
                                     );
                                     continue;
                                 }
                             };
-                            active_sets.push(ActiveActionSet(ovr::sys::VRActiveActionSet_t {
-                                ulActionSet: handle.0,
-                                ulRestrictedToDevice: ovr::sys::k_ulInvalidInputValueHandle,
-                                ulSecondaryActionSet: 0,
-                                unPadding: 0,
-                                nPriority: 0,
-                            }));
+                            active_sets.push(ActiveActionSet::new(handle));
                             action_sets.push(OpenVRActionSet {
                                 name: action_set.to_string(),
                                 handle,
@@ -273,15 +262,18 @@ pub async fn task() {
                     let Some(ctx) = ctx.as_ref() else {
                         continue 'ovr_loop;
                     };
-                    let mut system = ctx.system_mngr();
-                    let event = system.poll_next_event();
-                    if event.is_none() {
-                        break;
+                    let system = ctx.system();
+                    match system.poll_next_event() {
+                        Ok(Some(event)) => event,
+                        Ok(None) => break,
+                        Err(e) => {
+                            error!("[Core] Failed to poll OpenVR events: {e}");
+                            break;
+                        }
                     }
-                    event.unwrap()
                 };
                 // Handle Quit event
-                if event.is(ovr::sys::EVREventType::VREvent_Quit) {
+                if event.is(ovr::raw::EVREventType::VREvent_Quit) {
                     info!("[Core] OpenVR is Quitting. Shutting down OpenVR module");
                     ovr_active = false;
                     update_status(OpenVRStatus::Inactive).await;
@@ -305,29 +297,21 @@ pub async fn task() {
     }
 }
 
-/// Every path that clears `OVR_CONTEXT` has to use this, or OpenVR stays initialized without a
-/// context and every later initialization attempt fails.
+/// Clears runtime, overlay and device state before reconnecting.
 async fn shutdown_ovr() {
-    // the lock stays held across the shutdown: VR_Shutdown invalidates every interface pointer
     let mut context = OVR_CONTEXT.lock().await;
     brightness_overlay::on_ovr_quit().await;
-    unsafe {
-        ovr::sys::VR_Shutdown();
+    if let Some(context) = context.as_ref() {
+        context.shutdown();
     }
     *context = None;
     drop(context);
     devices::on_ovr_quit().await;
 }
 
-/// Constructing an overlay manager while this is false panics. Callers must hold `OVR_CONTEXT`.
-pub fn overlay_interface_available() -> bool {
-    !unsafe { ovr::sys::VROverlay() }.is_null()
-}
-
-/// Constructing a settings manager while this is false panics. Callers must hold `OVR_CONTEXT`.
-pub fn settings_interface_available() -> bool {
+pub fn settings_interface_available(context: &ovr::Context) -> bool {
     static WARNED: AtomicBool = AtomicBool::new(false);
-    let available = !unsafe { ovr::sys::VRSettings() }.is_null();
+    let available = context.settings_interface_available();
     if available {
         WARNED.store(false, Ordering::Relaxed);
     } else if !WARNED.swap(true, Ordering::Relaxed) {

--- a/src-core/src/openvr/models.rs
+++ b/src-core/src/openvr/models.rs
@@ -1,10 +1,32 @@
-use ovr_overlay::input::{ActionHandle, ActionSetHandle};
+use raphii_openvr_rs::input::{ActionHandle, ActionSetHandle};
 use serde::{Deserialize, Serialize};
 use strum_macros::{EnumIter, IntoStaticStr};
 
 pub struct OpenVRAction {
     pub name: String,
     pub handle: ActionHandle,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TrackedControllerRole, TrackedDeviceClass};
+    use raphii_openvr_rs::raw;
+
+    #[test]
+    fn unknown_runtime_device_values_keep_application_fallbacks() {
+        assert!(matches!(
+            TrackedDeviceClass::from(raw::ETrackedDeviceClass(9999)),
+            TrackedDeviceClass::Invalid
+        ));
+        assert!(matches!(
+            TrackedControllerRole::from(raw::ETrackedControllerRole(9999)),
+            TrackedControllerRole::Invalid
+        ));
+        assert!(matches!(
+            TrackedControllerRole::from(raw::ETrackedControllerRole::TrackedControllerRole_Stylus),
+            TrackedControllerRole::Stylus
+        ));
+    }
 }
 
 pub struct OpenVRActionSet {
@@ -52,27 +74,28 @@ pub enum TrackedControllerRole {
     Stylus,
 }
 
-impl From<ovr_overlay::sys::ETrackedControllerRole> for TrackedControllerRole {
-    fn from(item: ovr_overlay::sys::ETrackedControllerRole) -> Self {
+impl From<raphii_openvr_rs::raw::ETrackedControllerRole> for TrackedControllerRole {
+    fn from(item: raphii_openvr_rs::raw::ETrackedControllerRole) -> Self {
         match item {
-            ovr_overlay::sys::ETrackedControllerRole::TrackedControllerRole_Invalid => {
+            raphii_openvr_rs::raw::ETrackedControllerRole::TrackedControllerRole_Invalid => {
                 TrackedControllerRole::Invalid
             }
-            ovr_overlay::sys::ETrackedControllerRole::TrackedControllerRole_LeftHand => {
+            raphii_openvr_rs::raw::ETrackedControllerRole::TrackedControllerRole_LeftHand => {
                 TrackedControllerRole::LeftHand
             }
-            ovr_overlay::sys::ETrackedControllerRole::TrackedControllerRole_RightHand => {
+            raphii_openvr_rs::raw::ETrackedControllerRole::TrackedControllerRole_RightHand => {
                 TrackedControllerRole::RightHand
             }
-            ovr_overlay::sys::ETrackedControllerRole::TrackedControllerRole_OptOut => {
+            raphii_openvr_rs::raw::ETrackedControllerRole::TrackedControllerRole_OptOut => {
                 TrackedControllerRole::OptOut
             }
-            ovr_overlay::sys::ETrackedControllerRole::TrackedControllerRole_Treadmill => {
+            raphii_openvr_rs::raw::ETrackedControllerRole::TrackedControllerRole_Treadmill => {
                 TrackedControllerRole::Treadmill
             }
-            ovr_overlay::sys::ETrackedControllerRole::TrackedControllerRole_Stylus => {
+            raphii_openvr_rs::raw::ETrackedControllerRole::TrackedControllerRole_Stylus => {
                 TrackedControllerRole::Stylus
             }
+            _ => TrackedControllerRole::Invalid,
         }
     }
 }
@@ -88,25 +111,25 @@ pub enum TrackedDeviceClass {
     DisplayRedirect,
 }
 
-impl From<ovr_overlay::sys::ETrackedDeviceClass> for TrackedDeviceClass {
-    fn from(item: ovr_overlay::sys::ETrackedDeviceClass) -> Self {
+impl From<raphii_openvr_rs::raw::ETrackedDeviceClass> for TrackedDeviceClass {
+    fn from(item: raphii_openvr_rs::raw::ETrackedDeviceClass) -> Self {
         match item {
-            ovr_overlay::sys::ETrackedDeviceClass::TrackedDeviceClass_Invalid => {
+            raphii_openvr_rs::raw::ETrackedDeviceClass::TrackedDeviceClass_Invalid => {
                 TrackedDeviceClass::Invalid
             }
-            ovr_overlay::sys::ETrackedDeviceClass::TrackedDeviceClass_HMD => {
+            raphii_openvr_rs::raw::ETrackedDeviceClass::TrackedDeviceClass_HMD => {
                 TrackedDeviceClass::HMD
             }
-            ovr_overlay::sys::ETrackedDeviceClass::TrackedDeviceClass_Controller => {
+            raphii_openvr_rs::raw::ETrackedDeviceClass::TrackedDeviceClass_Controller => {
                 TrackedDeviceClass::Controller
             }
-            ovr_overlay::sys::ETrackedDeviceClass::TrackedDeviceClass_GenericTracker => {
+            raphii_openvr_rs::raw::ETrackedDeviceClass::TrackedDeviceClass_GenericTracker => {
                 TrackedDeviceClass::GenericTracker
             }
-            ovr_overlay::sys::ETrackedDeviceClass::TrackedDeviceClass_TrackingReference => {
+            raphii_openvr_rs::raw::ETrackedDeviceClass::TrackedDeviceClass_TrackingReference => {
                 TrackedDeviceClass::TrackingReference
             }
-            ovr_overlay::sys::ETrackedDeviceClass::TrackedDeviceClass_DisplayRedirect => {
+            raphii_openvr_rs::raw::ETrackedDeviceClass::TrackedDeviceClass_DisplayRedirect => {
                 TrackedDeviceClass::DisplayRedirect
             }
             _ => TrackedDeviceClass::Invalid,

--- a/src-core/src/openvr/supersampling.rs
+++ b/src-core/src/openvr/supersampling.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 
 use super::{settings_interface_available, OVR_CONTEXT};
-use ovr_overlay as ovr;
+use raphii_openvr_rs as ovr;
 
 pub async fn get_supersample_scale() -> Result<Option<f32>, String> {
     let context_guard = OVR_CONTEXT.lock().await;
@@ -9,12 +9,12 @@ pub async fn get_supersample_scale() -> Result<Option<f32>, String> {
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
     let supersample_manual_override = settings.get_bool(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
         c"supersampleManualOverride",
     );
     let supersample_manual_override = match supersample_manual_override {
@@ -27,7 +27,7 @@ pub async fn get_supersample_scale() -> Result<Option<f32>, String> {
     }
     // Supersampling is set to custom
     let supersample_scale = settings.get_float(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
         c"supersampleScale",
     );
     match supersample_scale {
@@ -42,18 +42,18 @@ pub async fn set_supersample_scale(supersample_scale: Option<f32>) -> Result<(),
         Some(context) => context,
         None => return Err("OPENVR_NOT_INITIALISED".to_string()),
     };
-    if !settings_interface_available() {
+    if !settings_interface_available(context) {
         return Err("OPENVR_NOT_INITIALISED".to_string());
     }
-    let settings = &mut context.settings_mngr();
+    let settings = &context.settings();
     let _ = settings.set_bool(
-        CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
+        CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
         c"supersampleManualOverride",
         supersample_scale.is_some(),
     );
     if let Some(scale) = supersample_scale {
         let _ = settings.set_float(
-            CStr::from_bytes_with_nul(ovr::sys::k_pch_SteamVR_Section).unwrap(),
+            CStr::from_bytes_with_nul(ovr::raw::k_pch_SteamVR_Section).unwrap(),
             c"supersampleScale",
             scale,
         );


### PR DESCRIPTION
Replace the Rust core's `ovr_overlay` dependency with [raphii-openvr-rs](https://github.com/Raphiiko/raphii-openvr-rs), pinned to commit `a722cf7`. This removes OpenVR binding generation and its LLVM/libclang dependency from application builds.

The migration uses the wrapper's session ownership, interface accessors and typed property-change events. It preserves device-value fallbacks, settings and input behavior. The C# overlay sidecar and bundled OpenVR DLL are unchanged.

Validation: Windows core check and build, three Rust OpenVR regression tests, and the frontend OpenVR service test. An earlier Windows smoke test of the same wrapper implementation covered SteamVR initialization, live devices, activity and localized bindings. Software brightness was also confirmed in the headset.

SteamVR restart/reconnect and real Linux runtime testing remain unverified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated OpenVR integration across brightness, chaperone, color temperature, command, device, frame-rate, and supersampling features.
  - Improved handling of OpenVR events, device properties, poses, settings, and errors.
  - Preserved existing overlay, manifest, input, and SteamVR configuration behavior.
  - Unknown controller roles now safely map to an invalid state.

- **Tests**
  - Added coverage for controller-role conversion, including stylus and unknown runtime values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->