### PR TITLE
fix: merge overlay lifecycle fixes into develop

### DIFF
--- a/src-overlay-sidecar/Managers/BrowserManager.cs
+++ b/src-overlay-sidecar/Managers/BrowserManager.cs
@@ -26,7 +26,13 @@ public class BrowserManager {
         if (cachedBrowser.IsFree && cachedBrowser.Width == width && cachedBrowser.Height == height)
         {
           cachedBrowser.IsFree = false;
-          cachedBrowser.Browser.LoadUrl(url);
+          try { cachedBrowser.Browser.LoadUrl(url); }
+          catch
+          {
+            _browsers.Remove(cachedBrowser);
+            cachedBrowser.Browser.Dispose();
+            throw;
+          }
           return cachedBrowser.Browser;
         }
       }
@@ -43,16 +49,40 @@ public class BrowserManager {
   {
     lock (_browsers)
     {
-      foreach (var cachedBrowser in _browsers)
+      var cached = _browsers.Find(entry => entry.Browser == browser);
+      if (cached == null || cached.IsFree) return;
+      browser.SetTextureTarget(null);
+      browser.JavascriptObjectRepository.UnRegisterAll();
+      if (_browsers.Any(entry => entry.IsFree && entry.Width == cached.Width && entry.Height == cached.Height))
       {
-        if (cachedBrowser.Browser == browser)
-        {
-          cachedBrowser.Browser.JavascriptObjectRepository.UnRegisterAll();
-          cachedBrowser.Browser.LoadHtml("");
-          cachedBrowser.IsFree = true;
-          return;
-        }
+        _browsers.Remove(cached);
+        browser.Dispose();
+        return;
       }
+      try
+      {
+        browser.LoadHtml("");
+        cached.IsFree = true;
+      }
+      catch
+      {
+        _browsers.Remove(cached);
+        browser.Dispose();
+        throw;
+      }
+    }
+  }
+
+  public void DisposeAll()
+  {
+    lock (_browsers)
+    {
+      foreach (var cached in _browsers)
+      {
+        try { cached.Browser.Dispose(); }
+        catch (Exception error) { Log.Error(error, "Could not dispose a browser during shutdown."); }
+      }
+      _browsers.Clear();
     }
   }
 

--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -7,6 +7,7 @@ namespace overlay_sidecar;
 
 public class OvrManager
 {
+  public static readonly object LifecycleLock = new();
   public static OvrManager Instance { get; } = new();
 
   private bool _initialized;
@@ -20,7 +21,8 @@ public class OvrManager
   private NotificationOverlay? _notificationOverlay;
   private DashboardOverlay? _dashboardOverlay;
 
-  private bool _active;
+  private volatile bool _active;
+  private DateTime? _splashAt;
   private CVRSystem? _system;
   private CVRInput? _input;
   private Dictionary<string, List<OvrInputDevice>> inputActions = new();
@@ -41,14 +43,12 @@ public class OvrManager
       : new NonAcceleratedOvrDXDeviceHander();
   }
 
-  public async void Init()
+  public void Init()
   {
     if (_initialized) return;
     _initialized = true;
-    // Start main loop
     _mainThread = new Thread(MainLoop);
     _mainThread.Start();
-    // Start frame updates for web overlays
     _renderThread = new Thread(OverlayRenderLoop);
     _renderThread.Start();
   }
@@ -61,10 +61,9 @@ public class OvrManager
       if (Active)
       {
         timer.TickStart();
-        lock (_overlays)
+        lock (LifecycleLock)
         {
-          foreach (var overlay in _overlays)
-            overlay.UpdateFrame();
+          UpdateOverlays();
         }
 
         timer.SleepUntilNextTick();
@@ -75,6 +74,22 @@ public class OvrManager
       }
     }
     // ReSharper disable once FunctionNeverReturns
+  }
+
+  private void UpdateOverlays()
+  {
+    if (!_active) return;
+    foreach (var overlay in _overlays.ToArray())
+    {
+      try { overlay.UpdateFrame(); }
+      catch (Exception error)
+      {
+        Log.Error(error, "Overlay update failed. Disposing the overlay.");
+        try { overlay.Dispose(); }
+        catch (Exception cleanupError) { Log.Error(cleanupError, "Could not dispose the failed overlay."); }
+        throw;
+      }
+    }
   }
 
   private void MainLoop()
@@ -95,118 +110,136 @@ public class OvrManager
       {
       }
 
-      if (Enabled)
+      lock (LifecycleLock)
       {
-        _system = OpenVR.System;
-        if (_system == null)
+        try
         {
-          if (DateTime.UtcNow.CompareTo(nextInit) <= 0) continue;
-
-          var err = EVRInitError.None;
-          _system = OpenVR.Init(ref err, EVRApplicationType.VRApplication_Background);
-          nextInit = DateTime.UtcNow.AddSeconds(5);
-          if (_system == null) continue;
-          _system = OpenVR.System;
-
-          _input = OpenVR.Input;
-          // the overlays below and DetectInput dereference these interfaces immediately
-          if (_input == null || OpenVR.Overlay == null)
+          if (Enabled)
           {
-            // the retry runs every 5 seconds, so only the first attempt reports it
-            if (!loggedMissingInterfaces)
+            _system = OpenVR.System;
+            if (_system == null)
             {
-              Log.Warning("OpenVR interfaces are not available yet. Retrying initialization later...");
-              loggedMissingInterfaces = true;
+              if (_active) Shutdown();
+              if (DateTime.UtcNow.CompareTo(nextInit) <= 0) continue;
+
+              var err = EVRInitError.None;
+              _system = OpenVR.Init(ref err, EVRApplicationType.VRApplication_Background);
+              nextInit = DateTime.UtcNow.AddSeconds(5);
+              if (_system == null) continue;
+              _system = OpenVR.System;
+
+              _input = OpenVR.Input;
+              // the overlays below and DetectInput dereference these interfaces immediately
+              if (_input == null || OpenVR.Overlay == null)
+              {
+                // the retry runs every 5 seconds, so only the first attempt reports it
+                if (!loggedMissingInterfaces)
+                {
+                  Log.Warning("OpenVR interfaces are not available yet. Retrying initialization later...");
+                  loggedMissingInterfaces = true;
+                }
+
+                OpenVR.Shutdown();
+                continue;
+              }
+
+              loggedMissingInterfaces = false;
+
+              var inputError = _input.SetActionManifestPath(GetActionManifestPath());
+              if (inputError != 0)
+              {
+                Log.Error($"Could not set action manifest path: {Enum.GetName(typeof(EVRInputError), inputError)}");
+                OpenVR.Shutdown();
+                continue;
+              }
+
+              actionSetHandles.Clear();
+              foreach (var actionSetKey in new[]
+                       {
+                         "/actions/main", "/actions/hidden"
+                       })
+              {
+                ulong handle = 0;
+                var result = _input.GetActionSetHandle(actionSetKey, ref handle);
+                if (result != 0)
+                {
+                  Log.Error(
+                    $"Could not get action set handle for {actionSetKey}: {Enum.GetName(typeof(EVRInputError), result)}");
+                  continue;
+                }
+
+                actionSetHandles.Add(actionSetKey, handle);
+              }
+
+              actionHandles.Clear();
+              inputActions.Clear();
+              foreach (var actionKey in new[]
+                       {
+                         "/actions/hidden/in/OverlayInteract",
+                         "/actions/hidden/in/IndicatePresence",
+                       })
+              {
+                ulong handle = 0;
+                var result = _input.GetActionHandle(actionKey, ref handle);
+                if (result != 0)
+                {
+                  Log.Error($"Could not get action handle for {actionKey}: {Enum.GetName(typeof(EVRInputError), result)}");
+                  continue;
+                }
+
+                inputActions.Add(actionKey, new List<OvrInputDevice>());
+                actionHandles.Add(actionKey, handle);
+              }
+
+              _active = true;
+              Log.Information("OpenVR Manager Started");
+              _dxDeviceHander.Initialize();
+              _overlayPointer = new OverlayPointer();
+              _micMuteIndicatorOverlay = new MicMuteIndicatorOverlay();
+              _notificationOverlay = new NotificationOverlay();
+              BrowserManager.Instance.PreInitializeBrowser(1024, 1024);
+              _splashAt = DateTime.UtcNow.AddSeconds(1);
             }
 
-            OpenVR.Shutdown();
-            continue;
-          }
-
-          loggedMissingInterfaces = false;
-
-          var inputError = _input.SetActionManifestPath(GetActionManifestPath());
-          if (inputError != 0)
-          {
-            Log.Error($"Could not set action manifest path: {Enum.GetName(typeof(EVRInputError), inputError)}");
-            OpenVR.Shutdown();
-            continue;
-          }
-
-          actionSetHandles.Clear();
-          foreach (var actionSetKey in new[]
-                   {
-                     "/actions/main", "/actions/hidden"
-                   })
-          {
-            ulong handle = 0;
-            var result = _input.GetActionSetHandle(actionSetKey, ref handle);
-            if (result != 0)
+            if (_splashAt.HasValue && DateTime.UtcNow >= _splashAt.Value)
             {
-              Log.Error(
-                $"Could not get action set handle for {actionSetKey}: {Enum.GetName(typeof(EVRInputError), result)}");
-              continue;
+              _splashAt = null;
+              new SplashOverlay();
             }
+            DetectInput(actionSetHandles, actionHandles);
 
-            actionSetHandles.Add(actionSetKey, handle);
-          }
-
-          actionHandles.Clear();
-          inputActions.Clear();
-          foreach (var actionKey in new[]
-                   {
-                     "/actions/hidden/in/OverlayInteract",
-                     "/actions/hidden/in/IndicatePresence",
-                   })
-          {
-            ulong handle = 0;
-            var result = _input.GetActionHandle(actionKey, ref handle);
-            if (result != 0)
+            while (_system.PollNextEvent(ref e, (uint)Marshal.SizeOf(e)))
             {
-              Log.Error($"Could not get action handle for {actionKey}: {Enum.GetName(typeof(EVRInputError), result)}");
-              continue;
+              var type = (EVREventType)e.eventType;
+              if (type == EVREventType.VREvent_Quit)
+              {
+                Log.Information("Received quit event from SteamVR. Stopping OpenVR Manager...");
+                _active = false;
+                nextInit = DateTime.UtcNow.AddSeconds(5);
+                actionHandles.Clear();
+                actionSetHandles.Clear();
+                inputActions.Clear();
+                Shutdown();
+                break;
+              }
             }
-
-            inputActions.Add(actionKey, new List<OvrInputDevice>());
-            actionHandles.Add(actionKey, handle);
           }
-
-          _active = true;
-          Log.Information("OpenVR Manager Started");
-          _dxDeviceHander.Initialize();
-          _overlayPointer = new OverlayPointer();
-          _micMuteIndicatorOverlay = new MicMuteIndicatorOverlay();
-          _notificationOverlay = new NotificationOverlay();
-          BrowserManager.Instance.PreInitializeBrowser(1024, 1024);
-          StartSplash();
-        }
-
-        DetectInput(actionSetHandles, actionHandles);
-
-        while (_system.PollNextEvent(ref e, (uint)Marshal.SizeOf(e)))
-        {
-          var type = (EVREventType)e.eventType;
-          if (type == EVREventType.VREvent_Quit)
+          else if (_active)
           {
-            Log.Information("Received quit event from SteamVR. Stopping OpenVR Manager...");
             _active = false;
             nextInit = DateTime.UtcNow.AddSeconds(5);
             actionHandles.Clear();
             actionSetHandles.Clear();
             inputActions.Clear();
             Shutdown();
-            break;
           }
         }
-      }
-      else if (_active)
-      {
-        _active = false;
-        nextInit = DateTime.UtcNow.AddSeconds(5);
-        actionHandles.Clear();
-        actionSetHandles.Clear();
-        inputActions.Clear();
-        Shutdown();
+        catch (Exception error)
+        {
+          Log.Error(error, "OpenVR update failed. Releasing overlays before retrying.");
+          nextInit = DateTime.UtcNow.AddSeconds(5);
+          Shutdown();
+        }
       }
     }
   }
@@ -214,14 +247,21 @@ public class OvrManager
 
   private void Shutdown()
   {
-    _overlayPointer?.Dispose();
+    _active = false;
+    _splashAt = null;
+    try { _overlayPointer?.Dispose(); }
+    catch (Exception error) { Log.Error(error, "Could not dispose overlay pointers during shutdown."); }
     _overlayPointer = null;
-    _micMuteIndicatorOverlay?.Dispose();
+    foreach (var overlay in _overlays.ToArray())
+    {
+      try { overlay.Dispose(); }
+      catch (Exception error) { Log.Error(error, "Could not dispose an overlay during shutdown."); }
+    }
+    _overlays.Clear();
     _micMuteIndicatorOverlay = null;
-    _notificationOverlay?.Dispose();
     _notificationOverlay = null;
-    _dashboardOverlay?.Dispose();
     _dashboardOverlay = null;
+    BrowserManager.Instance.DisposeAll();
     _input = null;
     _system = null;
     OpenVR.Shutdown();
@@ -231,52 +271,50 @@ public class OvrManager
 
   public void OpenDashboard(ETrackedControllerRole role)
   {
-    if (_dashboardOverlay != null)
+    lock (LifecycleLock)
     {
-      CloseDashboard();
+      if (!_active) return;
+      _dashboardOverlay?.Dispose();
+      var overlay = new DashboardOverlay();
+      _dashboardOverlay = overlay;
+      overlay.OnClose += () =>
+      {
+        if (_dashboardOverlay == overlay) _dashboardOverlay = null;
+      };
+      overlay.Open(role);
     }
-
-    var o = new DashboardOverlay();
-    _dashboardOverlay = o;
-    _dashboardOverlay.Open(role);
-
-    void OnCloseHandler()
-    {
-      o.OnClose -= OnCloseHandler;
-      o.Dispose();
-    }
-
-    _dashboardOverlay.OnClose += OnCloseHandler;
   }
 
   public void CloseDashboard()
   {
-    if (_dashboardOverlay == null) return;
-    _dashboardOverlay.Close();
-    _dashboardOverlay = null;
+    lock (LifecycleLock) _dashboardOverlay?.Close();
   }
 
   public void ToggleDashboard(ETrackedControllerRole role)
   {
-    var index = OpenVR.System.GetTrackedDeviceIndexForControllerRole(role);
-    if (index is >= 1 and < OpenVR.k_unMaxTrackedDeviceCount)
+    lock (LifecycleLock)
     {
-      OpenVR.System.TriggerHapticPulse(index, 0, 65535);
-    }
+      if (!_active) return;
+      var index = OpenVR.System.GetTrackedDeviceIndexForControllerRole(role);
+      if (index is >= 1 and < OpenVR.k_unMaxTrackedDeviceCount)
+      {
+        OpenVR.System.TriggerHapticPulse(index, 0, 65535);
+      }
 
-    if (_dashboardOverlay == null)
-    {
-      OpenDashboard(role);
-    }
-    else
-    {
-      CloseDashboard();
+      if (_dashboardOverlay == null || _dashboardOverlay.IsClosing)
+      {
+        OpenDashboard(role);
+      }
+      else
+      {
+        CloseDashboard();
+      }
     }
   }
 
   public void RegisterOverlay(RenderableOverlay overlay)
   {
-    lock (_overlays)
+    lock (LifecycleLock)
     {
       if (!_overlays.Contains(overlay)) _overlays.Add(overlay);
     }
@@ -284,19 +322,10 @@ public class OvrManager
 
   public void UnregisterOverlay(RenderableOverlay overlay)
   {
-    lock (_overlays)
+    lock (LifecycleLock)
     {
       if (_overlays.Contains(overlay)) _overlays.Remove(overlay);
     }
-  }
-
-  private async void StartSplash()
-  {
-    await Utils.DelayedAction(() =>
-    {
-      if (!_active) return;
-      new SplashOverlay();
-    }, TimeSpan.FromSeconds(1));
   }
 
   private string GetActionManifestPath()
@@ -312,7 +341,10 @@ public class OvrManager
 
   public void SetMicrophoneActive(bool active)
   {
-    _micMuteIndicatorOverlay?.SetMicrophoneActive(active);
+    lock (LifecycleLock)
+    {
+      _micMuteIndicatorOverlay?.SetMicrophoneActive(active);
+    }
   }
 
   private void DetectInput(Dictionary<string, ulong> actionSetHandles, Dictionary<string, ulong> actionHandles)
@@ -392,7 +424,7 @@ public class OvrManager
 
     if (update)
     {
-      OnInputActionsChanged.Invoke(this, inputActions);
+      OnInputActionsChanged?.Invoke(this, inputActions);
     }
   }
 

--- a/src-overlay-sidecar/Managers/OvrManager.cs
+++ b/src-overlay-sidecar/Managers/OvrManager.cs
@@ -274,7 +274,7 @@ public class OvrManager
     lock (LifecycleLock)
     {
       if (!_active) return;
-      _dashboardOverlay?.Dispose();
+      _dashboardOverlay?.Close();
       var overlay = new DashboardOverlay();
       _dashboardOverlay = overlay;
       overlay.OnClose += () =>

--- a/src-overlay-sidecar/Managers/OyasumiOverlaySidecarService.cs
+++ b/src-overlay-sidecar/Managers/OyasumiOverlaySidecarService.cs
@@ -13,11 +13,12 @@ public class OyasumiOverlaySidecarService : OyasumiOverlaySidecar.OyasumiOverlay
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
         "OpenVR Manager is not active"));
 
-    if (OvrManager.Instance.NotificationOverlay == null)
+    var overlay = OvrManager.Instance.NotificationOverlay;
+    if (overlay == null)
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
         "Notification overlay is currently unavailable"));
 
-    var id = OvrManager.Instance.NotificationOverlay.AddNotification(
+    var id = overlay.AddNotification(
       request.Message,
       TimeSpan.FromMilliseconds(request.Duration)
     );
@@ -38,11 +39,12 @@ public class OyasumiOverlaySidecarService : OyasumiOverlaySidecar.OyasumiOverlay
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
         "OpenVR Manager is not active"));
 
-    if (OvrManager.Instance.NotificationOverlay == null)
+    var overlay = OvrManager.Instance.NotificationOverlay;
+    if (overlay == null)
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
         "Notification overlay is currently unavailable"));
 
-    OvrManager.Instance.NotificationOverlay.ClearNotification(request.NotificationId);
+    overlay.ClearNotification(request.NotificationId);
     return Task.FromResult(new Empty());
   }
 

--- a/src-overlay-sidecar/Managers/StateManager.cs
+++ b/src-overlay-sidecar/Managers/StateManager.cs
@@ -5,7 +5,6 @@ namespace overlay_sidecar;
 public class StateManager {
   public static StateManager Instance { get; } = new();
   private OyasumiSidecarState _state = NewDefaultState();
-  private readonly object _lock = new();
 
   public event EventHandler<OyasumiSidecarState>? StateChanged;
 
@@ -15,7 +14,7 @@ public class StateManager {
 
   public OyasumiSidecarState GetAppState()
   {
-    lock (_lock)
+    lock (OvrManager.LifecycleLock)
     {
       return _state.Clone();
     }
@@ -24,12 +23,11 @@ public class StateManager {
   public void SyncState(OyasumiSidecarState? newState)
   {
     if (newState == null) return;
-    lock (_lock)
+    lock (OvrManager.LifecycleLock)
     {
-      // Update the state
       newState.Settings ??= new OyasumiSidecarOverlaySettings();
       _state = newState;
-      StateChanged?.Invoke(this, _state);
+      StateChanged?.Invoke(this, newState);
     }
   }
 

--- a/src-overlay-sidecar/Overlays/BaseWebOverlay.cs
+++ b/src-overlay-sidecar/Overlays/BaseWebOverlay.cs
@@ -34,62 +34,65 @@ public class BaseWebOverlay : RenderableOverlay
       ? "http://localhost:5173"
       : IpcManager.Instance.StaticBaseUrl) + path + "?corePort=" + IpcManager.Instance.CoreHttpPort;
     _overlayKey = overlayKey;
-    // Set up state management
     _requiresState = requiresState;
-    StateManager.Instance.StateChanged += OnStateChanged;
-    // Set up browser
-    if (Program.InDevMode()) Log.Information("Using UI URL: {url}", uiUrl);
-    Browser = BrowserManager.Instance.GetBrowser(uiUrl, resolution, resolution);
-    Browser!.JavascriptObjectRepository.Register("OyasumiIPCOut", this);
-    // Set up overlay
-    ulong overlayHandle = 0;
+    try
     {
-      var err = OvrUtils.getOrCreateOverlay(overlayKey, overlayName, ref overlayHandle);
-      if (err != EVROverlayError.None)
+      if (Program.InDevMode()) Log.Information("Using UI URL: {url}", uiUrl);
+      Browser = BrowserManager.Instance.GetBrowser(uiUrl, resolution, resolution);
+      Browser.JavascriptObjectRepository.Register("OyasumiIPCOut", this);
+      ulong overlayHandle = 0;
+      var error = OvrUtils.getOrCreateOverlay(overlayKey, overlayName, ref overlayHandle);
+      if (error != EVROverlayError.None)
+        throw new InvalidOperationException($"Could not create overlay: {error}");
+      _overlayHandle = overlayHandle;
+      _texture = Utils.InitTexture2D(resolution, !Program.GpuAccelerated);
+      Browser.SetTextureTarget(_texture);
+      StateManager.Instance.StateChanged += OnStateChanged;
+      OvrManager.Instance.RegisterOverlay(this);
+    }
+    catch
+    {
+      Dispose();
+      throw;
+    }
+  }
+
+  public virtual void Dispose()
+  {
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed) return;
+      Disposed = true;
+      try { OvrManager.Instance.OverlayPointer?.StopForOverlay(this); }
+      catch (Exception error) { Log.Warning(error, "Could not stop the pointer for a disposed overlay."); }
+      OvrManager.Instance.UnregisterOverlay(this);
+      StateManager.Instance.StateChanged -= OnStateChanged;
+      if (_overlayHandle.HasValue) OpenVR.Overlay?.DestroyOverlay(_overlayHandle.Value);
+      try
       {
-        Log.Error("Could not create overlay: " + err);
-        Dispose();
-        return;
+        if (Browser != null)
+        {
+          Browser.SetTextureTarget(null);
+          BrowserManager.Instance.FreeBrowser(Browser);
+        }
+      }
+      finally
+      {
+        Browser = null;
+        _texture?.Dispose();
+        _texture = null;
       }
     }
-    _overlayHandle = overlayHandle;
-    // Initialize remaining asynchronous actions
-    Init(resolution);
-    // Start frame updates
-    OvrManager.Instance.RegisterOverlay(this);
   }
 
-  private async void Init(uint resolution)
+  public virtual void OnUiReady()
   {
-    _texture = await Utils.InitTexture2D(resolution, !Program.GpuAccelerated);
-    Browser!.SetTextureTarget(_texture);
-  }
-
-  public void Dispose()
-  {
-    if (Disposed) return;
-    Disposed = true;
-    OvrManager.Instance.OverlayPointer?.StopForOverlay(this);
-    OvrManager.Instance.UnregisterOverlay(this);
-    StateManager.Instance.StateChanged -= OnStateChanged;
-    if (_overlayHandle.HasValue) OpenVR.Overlay.DestroyOverlay(_overlayHandle!.Value);
-    if (Browser != null)
+    lock (OvrManager.LifecycleLock)
     {
-      // The browser is pooled and keeps painting into whatever target it holds, so it has to
-      // let go of this texture before we dispose it.
-      Browser.SetTextureTarget(null);
-      BrowserManager.Instance.FreeBrowser(Browser);
+      if (Disposed) return;
+      UiReady = true;
+      SyncState();
     }
-
-    _texture?.Dispose();
-    _texture = null;
-    GC.Collect();
-  }
-
-  public void OnUiReady()
-  {
-    UiReady = true;
-    SyncState();
   }
 
   public string GetDebugTranslations()
@@ -99,11 +102,13 @@ public class BaseWebOverlay : RenderableOverlay
 
   public void SyncState(OyasumiSidecarState? state = null)
   {
-    if (!UiReady || !_requiresState)
-      return;
-    state ??= StateManager.Instance.GetAppState();
-    Browser.ExecuteScriptAsync(
-      @$"window.OyasumiIPCIn.setState(""{HttpUtility.JavaScriptStringEncode(state.ToByteString().ToBase64())}"");");
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed || !UiReady || !_requiresState) return;
+      state ??= StateManager.Instance.GetAppState();
+      Browser.ExecuteScriptAsync(
+        @$"window.OyasumiIPCIn.setState(""{HttpUtility.JavaScriptStringEncode(state.ToByteString().ToBase64())}"");");
+    }
   }
 
   public void SendEventVoid(string eventName)
@@ -180,9 +185,8 @@ public class BaseWebOverlay : RenderableOverlay
     ShowToolTipInternal(text);
   }
 
-  public void UpdateFrame()
+  public virtual void UpdateFrame()
   {
-    // Stop here if we are not ready, already disposed, or if the browser hasn't painted anything new for the past second or so.
     if (_texture == null || Disposed || Browser == null ||
         DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - Browser.LastPaint >= 1000) return;
 
@@ -191,7 +195,6 @@ public class BaseWebOverlay : RenderableOverlay
     {
       handle = _texture.NativePointer
     };
-    // Render the texture to the overlay
     if (Disposed || _texture.IsDisposed) return;
     var err = OpenVR.Overlay.SetOverlayTexture(_overlayHandle!.Value, ref texture);
     if (err != EVROverlayError.None && err != _lastTextureError)
@@ -201,7 +204,6 @@ public class BaseWebOverlay : RenderableOverlay
 
   protected virtual void ShowToolTipInternal(string? text)
   {
-    // Method to be overridden by overlays in case they support tool tips
   }
 
   private void OnStateChanged(object? sender, OyasumiSidecarState e)

--- a/src-overlay-sidecar/Overlays/DashboardOverlay.cs
+++ b/src-overlay-sidecar/Overlays/DashboardOverlay.cs
@@ -1,7 +1,6 @@
 using System.Numerics;
 using CefSharp;
 using Valve.VR;
-using static overlay_sidecar.Utils;
 
 namespace overlay_sidecar;
 
@@ -9,7 +8,9 @@ public class DashboardOverlay : BaseWebOverlay {
   private static readonly TrackedDevicePose_t[] _poseBuffer = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
 
   private bool _isOpen;
-  private bool _closing;
+  private DateTime? _closeAt;
+  private bool _shown;
+  public bool IsClosing => _closeAt.HasValue;
   private Matrix4x4? _targetTransform;
   private readonly TooltipOverlay _tooltipOverlay;
 
@@ -19,55 +20,89 @@ public class DashboardOverlay : BaseWebOverlay {
   public DashboardOverlay() :
     base("/dashboard", 1024, "co.raphii.oyasumivr:DashboardOverlay_" + Guid.NewGuid(), "OyasumiVR Dashboard Overlay")
   {
-    Browser!.JavascriptObjectRepository.Register("OyasumiIPCOut_Dashboard", this);
-    _tooltipOverlay = new TooltipOverlay();
-    OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.45f);
-    new Thread(UpdateTooltipPosition).Start();
-  }
-
-  public new void Dispose()
-  {
-    _tooltipOverlay.Dispose();
-    base.Dispose();
-  }
-
-  public async void Open(ETrackedControllerRole role)
-  {
-    if (_isOpen) return;
-    _targetTransform = GetTargetTransform(role);
-    if (!_targetTransform.HasValue) return;
-    _isOpen = true;
-    while (!UiReady) await Task.Delay(TimeSpan.FromMilliseconds(16));
-    var transform = _targetTransform.Value.ToHmdMatrix34_t();
-    OpenVR.Overlay.SetOverlayTransformAbsolute(OverlayHandle,
-      ETrackingUniverseOrigin.TrackingUniverseStanding,
-      ref transform
-    );
-    _closing = false;
-    OvrManager.Instance.OverlayPointer!.StartForOverlay(this);
-    ShowDashboard();
-    OpenVR.Overlay.ShowOverlay(OverlayHandle);
-    // Browser.ShowDevTools();
-  }
-
-  public async void Close()
-  {
-    if (_closing) return;
-    _closing = true;
-    ShowToolTip("");
-    if (UiReady) HideDashboard();
-    OvrManager.Instance.OverlayPointer!.StopForOverlay(this);
-    await DelayedAction(() =>
+    try
     {
-      OnClose?.Invoke();
-      _isOpen = false;
-      OpenVR.Overlay.DestroyOverlay(OverlayHandle);
-    }, TimeSpan.FromSeconds(1));
+      Browser!.JavascriptObjectRepository.Register("OyasumiIPCOut_Dashboard", this);
+      _tooltipOverlay = new TooltipOverlay();
+      OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.45f);
+    }
+    catch
+    {
+      Dispose();
+      throw;
+    }
   }
 
-  //
-  // Internals
-  //
+  public override void Dispose()
+  {
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed) return;
+      try { _tooltipOverlay?.Dispose(); }
+      finally
+      {
+        try { base.Dispose(); }
+        finally
+        {
+          _isOpen = false;
+          var onClose = OnClose;
+          OnClose = null;
+          onClose?.Invoke();
+        }
+      }
+    }
+  }
+
+  public void Open(ETrackedControllerRole role)
+  {
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed || _isOpen) return;
+      _targetTransform = GetTargetTransform(role);
+      if (!_targetTransform.HasValue)
+      {
+        Dispose();
+        return;
+      }
+      _isOpen = true;
+    }
+  }
+
+  public void Close()
+  {
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed || IsClosing) return;
+      _closeAt = DateTime.UtcNow.AddSeconds(1);
+      ShowToolTip(null);
+      if (UiReady) HideDashboard();
+      OvrManager.Instance.OverlayPointer?.StopForOverlay(this);
+    }
+  }
+
+  public override void UpdateFrame()
+  {
+    base.UpdateFrame();
+    if (Disposed) return;
+    if (IsClosing)
+    {
+      if (DateTime.UtcNow >= _closeAt!.Value) Dispose();
+      return;
+    }
+    if (_isOpen && UiReady && !_shown)
+    {
+      var transform = _targetTransform!.Value.ToHmdMatrix34_t();
+      OpenVR.Overlay.SetOverlayTransformAbsolute(OverlayHandle,
+        ETrackingUniverseOrigin.TrackingUniverseStanding, ref transform);
+      OvrManager.Instance.OverlayPointer?.StartForOverlay(this);
+      ShowDashboard();
+      OpenVR.Overlay.ShowOverlay(OverlayHandle);
+      _shown = true;
+    }
+    var position = OvrManager.Instance.OverlayPointer?.GetPointerLocationForOverlay(this);
+    if (position.HasValue) _tooltipOverlay.SetPosition(position.Value);
+  }
+
   protected override void ShowToolTipInternal(string? text)
   {
     _tooltipOverlay.SetText(text);
@@ -109,15 +144,4 @@ public class DashboardOverlay : BaseWebOverlay {
     Browser.ExecuteScriptAsync("window.OyasumiIPCIn.showDashboard();");
   }
 
-  private void UpdateTooltipPosition()
-  {
-    var timer = new RefreshRateTimer();
-    while (!Disposed)
-    {
-      timer.TickStart();
-      var position = OvrManager.Instance.OverlayPointer?.GetPointerLocationForOverlay(this);
-      if (position.HasValue) _tooltipOverlay.SetPosition(position.Value);
-      timer.SleepUntilNextTick();
-    }
-  }
 }

--- a/src-overlay-sidecar/Overlays/Helpers/OverlayPointer.cs
+++ b/src-overlay-sidecar/Overlays/Helpers/OverlayPointer.cs
@@ -36,12 +36,15 @@ public class OverlayPointer {
     // load the pointer texture
     var pointerImage = Utils.ConvertPngToBgra(Utils.LoadEmbeddedFile("oyasumivr-overlay-sidecar.Resources.pointer.png"));
     var intPtr = Marshal.AllocHGlobal(pointerImage.Item1.Length);
-    Marshal.Copy(pointerImage.Item1, 0, intPtr, pointerImage.Item1.Length);
-    OpenVR.Overlay.SetOverlayRaw(_rightPointer.OverlayHandle, intPtr, (uint)pointerImage.Item2,
-      (uint)pointerImage.Item3, 4);
-    OpenVR.Overlay.SetOverlayRaw(_leftPointer.OverlayHandle, intPtr, (uint)pointerImage.Item2,
-      (uint)pointerImage.Item3, 4);
-    Marshal.FreeHGlobal(intPtr);
+    try
+    {
+      Marshal.Copy(pointerImage.Item1, 0, intPtr, pointerImage.Item1.Length);
+      OpenVR.Overlay.SetOverlayRaw(_rightPointer.OverlayHandle, intPtr, (uint)pointerImage.Item2,
+        (uint)pointerImage.Item3, 4);
+      OpenVR.Overlay.SetOverlayRaw(_leftPointer.OverlayHandle, intPtr, (uint)pointerImage.Item2,
+        (uint)pointerImage.Item3, 4);
+    }
+    finally { Marshal.FreeHGlobal(intPtr); }
     // start input and pose updates
     OvrManager.Instance.OnInputActionsChanged += OnInputAction;
     new Thread(Start).Start();
@@ -55,11 +58,18 @@ public class OverlayPointer {
       if (_disposed) return;
       _disposed = true;
       OvrManager.Instance.OnInputActionsChanged -= OnInputAction;
-      LeaveOverlay(_leftPointer);
-      LeaveOverlay(_rightPointer);
-      _overlays.Clear();
-      OpenVR.Overlay.DestroyOverlay(_leftPointer.OverlayHandle);
-      OpenVR.Overlay.DestroyOverlay(_rightPointer.OverlayHandle);
+      try
+      {
+        LeaveOverlay(_leftPointer);
+        LeaveOverlay(_rightPointer);
+      }
+      finally
+      {
+        _overlays.Clear();
+        _mouseOwners.Clear();
+        OpenVR.Overlay?.DestroyOverlay(_leftPointer.OverlayHandle);
+        OpenVR.Overlay?.DestroyOverlay(_rightPointer.OverlayHandle);
+      }
     }
   }
 
@@ -106,6 +116,7 @@ public class OverlayPointer {
     while (!_disposed)
     {
       timer.TickStart();
+      lock (OvrManager.LifecycleLock)
       lock (_overlays)
       {
         if (_disposed) break;
@@ -245,7 +256,7 @@ public class OverlayPointer {
       _mouseOwners.Remove(overlay);
     }
 
-    OpenVR.Overlay.HideOverlay(pointer.OverlayHandle);
+    OpenVR.Overlay?.HideOverlay(pointer.OverlayHandle);
     pointer.Pressed = false;
     pointer.LastPosition = null;
     pointer.LastUvPosition = null;

--- a/src-overlay-sidecar/Overlays/Helpers/RenderableOverlay.cs
+++ b/src-overlay-sidecar/Overlays/Helpers/RenderableOverlay.cs
@@ -1,6 +1,6 @@
 namespace overlay_sidecar;
 
-public interface RenderableOverlay {
+public interface RenderableOverlay : IDisposable {
 
   public void UpdateFrame();
 }

--- a/src-overlay-sidecar/Overlays/MicMuteIndicatorOverlay.cs
+++ b/src-overlay-sidecar/Overlays/MicMuteIndicatorOverlay.cs
@@ -33,23 +33,22 @@ public class MicMuteIndicatorOverlay : RenderableOverlay {
     _unmuteImage =
       Utils.ConvertPngToBgra(Utils.LoadEmbeddedFile("oyasumivr-overlay-sidecar.Resources.mic_unmute.png"));
     _textureWriter = new TextureWriter(512);
-    // Create the overlay
-    OvrUtils.getOrCreateOverlay("co.raphii.oyasumivr:MicMuteIndicatorOverlay", "OyasumiVR Mic Mute Indicator Overlay",
-      ref _overlayHandle);
-    Init();
-  }
-
-  private async void Init()
-  {
     try
     {
-      await _textureWriter.init();
+      OvrUtils.getOrCreateOverlay("co.raphii.oyasumivr:MicMuteIndicatorOverlay", "OyasumiVR Mic Mute Indicator Overlay",
+        ref _overlayHandle);
+      Init();
     }
-    catch (Exception e)
+    catch
     {
-      Log.Error("[MicMuteIndicatorOverlay] Failed to init texture writer: " + e);
-      return;
+      Dispose();
+      throw;
     }
+  }
+
+  private void Init()
+  {
+    _textureWriter.Init();
 
     // Configure the overlay
     OpenVR.Overlay.SetOverlayAlpha(_overlayHandle, 0f);
@@ -68,22 +67,29 @@ public class MicMuteIndicatorOverlay : RenderableOverlay {
 
   private void OnStateChanged(object? sender, OyasumiSidecarState state)
   {
-    if (state.SystemMicMuted != _muteState) setMuteState(state.SystemMicMuted);
-    _maxOpacity = state.Settings.SystemMicIndicatorOpacity;
-    _fadeOut = state.Settings.SystemMicIndicatorFadeout;
-    setEnabled(state.Settings.SystemMicIndicatorEnabled);
+    lock (OvrManager.LifecycleLock)
+    {
+      if (_disposed) return;
+      if (state.SystemMicMuted != _muteState) setMuteState(state.SystemMicMuted);
+      _maxOpacity = state.Settings.SystemMicIndicatorOpacity;
+      _fadeOut = state.Settings.SystemMicIndicatorFadeout;
+      setEnabled(state.Settings.SystemMicIndicatorEnabled);
+    }
   }
 
   public void Dispose()
   {
-    _disposed = true;
-    OvrManager.Instance.UnregisterOverlay(this);
-    OpenVR.Overlay.DestroyOverlay(_overlayHandle);
-    _textureWriter.Dispose();
-    _textureWriter = null;
-    GC.Collect();
-    StateManager.Instance.StateChanged -= OnStateChanged;
-    OvrManager.Instance.OnInputActionsChanged -= OnInputActionsChanged;
+    lock (OvrManager.LifecycleLock)
+    {
+      if (_disposed) return;
+      _disposed = true;
+      OvrManager.Instance.UnregisterOverlay(this);
+      OpenVR.Overlay?.DestroyOverlay(_overlayHandle);
+      _textureWriter.Dispose();
+      _textureWriter = null;
+      StateManager.Instance.StateChanged -= OnStateChanged;
+      OvrManager.Instance.OnInputActionsChanged -= OnInputActionsChanged;
+    }
   }
 
   public void SetMicrophoneActive(bool active)
@@ -100,14 +106,18 @@ public class MicMuteIndicatorOverlay : RenderableOverlay {
 
   private void OnInputActionsChanged(object? sender, Dictionary<string, List<OvrManager.OvrInputDevice>> e)
   {
-    var deviceIds = e["/actions/hidden/in/IndicatePresence"].Select(d => d.Id).ToList();
-    if (deviceIds.Any(d => !_lastPresenceIndicationDevices.Contains(d)))
+    lock (OvrManager.LifecycleLock)
     {
-      _lastPresenceIndication = DateTime.UtcNow;
-    }
+      if (_disposed) return;
+      var deviceIds = e["/actions/hidden/in/IndicatePresence"].Select(d => d.Id).ToList();
+      if (deviceIds.Any(d => !_lastPresenceIndicationDevices.Contains(d)))
+      {
+        _lastPresenceIndication = DateTime.UtcNow;
+      }
 
-    _lastPresenceIndicationDevices.Clear();
-    _lastPresenceIndicationDevices.AddRange(deviceIds);
+      _lastPresenceIndicationDevices.Clear();
+      _lastPresenceIndicationDevices.AddRange(deviceIds);
+    }
   }
 
   private void setMuteState(bool state)
@@ -132,7 +142,7 @@ public class MicMuteIndicatorOverlay : RenderableOverlay {
 
   public void UpdateFrame()
   {
-    if (!_enabled) return;
+    if (_disposed || !_enabled) return;
 
     var timeSinceLastStateChange = (DateTime.UtcNow - _lastStateChange).TotalMilliseconds;
     var timeSinceLastPresenceIndication = (DateTime.UtcNow - _lastPresenceIndication).TotalMilliseconds;

--- a/src-overlay-sidecar/Overlays/NotificationOverlay.cs
+++ b/src-overlay-sidecar/Overlays/NotificationOverlay.cs
@@ -17,42 +17,49 @@ public class NotificationOverlay : BaseWebOverlay {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);
     OpenVR.Overlay.ShowOverlay(OverlayHandle);
-    new Thread(() =>
-    {
-      var timer = new RefreshRateTimer();
-      while (!Disposed)
-      {
-        timer.TickStart();
-        UpdatePosition();
-        timer.SleepUntilNextTick();
-      }
-    }).Start();
+  }
+
+  public override void UpdateFrame()
+  {
+    base.UpdateFrame();
+    if (!Disposed) UpdatePosition();
   }
 
   public string? AddNotification(string message, TimeSpan? duration = null)
   {
-    if (!UiReady || Disposed) return null;
-
     var id = Guid.NewGuid().ToString();
     var script = $@"window.OyasumiIPCIn.addNotification({{
             id: ""{id}"",
             message: ""{HttpUtility.JavaScriptStringEncode(message)}"",
             duration: {(duration?.TotalMilliseconds ?? 3000).ToString(CultureInfo.InvariantCulture)}
         }});";
-    var task = Browser.EvaluateScriptAsync(script, TimeSpan.FromMilliseconds(5000));
-    task.Wait();
-    return task.Result.Success ? id : null;
+    Task<JavascriptResponse> task;
+    lock (OvrManager.LifecycleLock)
+    {
+      if (!UiReady || Disposed) return null;
+      task = Browser.EvaluateScriptAsync(script, TimeSpan.FromMilliseconds(5000));
+    }
+    return WaitForResponse(task) is { Success: true } ? id : null;
   }
 
   public void ClearNotification(string notificationId)
   {
-    if (!UiReady || Disposed) return;
-
     var script = $@"window.OyasumiIPCIn.clearNotification(""{HttpUtility.JavaScriptStringEncode(notificationId)}"");";
-    var task = Browser.EvaluateScriptAsync(script, TimeSpan.FromMilliseconds(5000));
-    task.Wait();
-    if (!task.Result.Success)
-      Log.Warning("Could not clear notification {Id}: {Error}", notificationId, task.Result.Message);
+    Task<JavascriptResponse> task;
+    lock (OvrManager.LifecycleLock)
+    {
+      if (!UiReady || Disposed) return;
+      task = Browser.EvaluateScriptAsync(script, TimeSpan.FromMilliseconds(5000));
+    }
+    var response = WaitForResponse(task);
+    if (response is not { Success: true })
+      Log.Warning("Could not clear notification {Id}: {Error}", notificationId, response?.Message ?? "Evaluation canceled");
+  }
+
+  private static JavascriptResponse? WaitForResponse(Task<JavascriptResponse> task)
+  {
+    try { return task.GetAwaiter().GetResult(); }
+    catch (OperationCanceledException) { return null; }
   }
 
   private void UpdatePosition()

--- a/src-overlay-sidecar/Overlays/SplashOverlay.cs
+++ b/src-overlay-sidecar/Overlays/SplashOverlay.cs
@@ -6,6 +6,7 @@ namespace overlay_sidecar;
 public class SplashOverlay : BaseWebOverlay {
   private static readonly TrackedDevicePose_t[] _poseBuffer = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
   private bool _updatedPositionOnce;
+  private DateTime _expiresAt = DateTime.UtcNow.AddSeconds(10);
 
   public SplashOverlay() :
     base("/splash", 1024, "co.raphii.oyasumivr:SplashOverlay", "OyasumiVR Splash Overlay")
@@ -15,8 +16,23 @@ public class SplashOverlay : BaseWebOverlay {
     OpenVR.Overlay.ShowOverlay(OverlayHandle);
   }
 
+  public override void OnUiReady()
+  {
+    lock (OvrManager.LifecycleLock)
+    {
+      if (Disposed || UiReady) return;
+      _expiresAt = DateTime.UtcNow.AddSeconds(10);
+      base.OnUiReady();
+    }
+  }
+
   public override void UpdateFrame()
   {
+    if (DateTime.UtcNow >= _expiresAt)
+    {
+      Dispose();
+      return;
+    }
     base.UpdateFrame();
     if (!Disposed) UpdatePosition();
   }

--- a/src-overlay-sidecar/Overlays/SplashOverlay.cs
+++ b/src-overlay-sidecar/Overlays/SplashOverlay.cs
@@ -13,16 +13,12 @@ public class SplashOverlay : BaseWebOverlay {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);
     OpenVR.Overlay.ShowOverlay(OverlayHandle);
-    new Thread(() =>
-    {
-      var timer = new RefreshRateTimer();
-      while (!Disposed)
-      {
-        timer.TickStart();
-        UpdatePosition();
-        timer.SleepUntilNextTick();
-      }
-    }).Start();
+  }
+
+  public override void UpdateFrame()
+  {
+    base.UpdateFrame();
+    if (!Disposed) UpdatePosition();
   }
 
   private void UpdatePosition()

--- a/src-overlay-sidecar/Overlays/TooltipOverlay.cs
+++ b/src-overlay-sidecar/Overlays/TooltipOverlay.cs
@@ -9,7 +9,7 @@ public class TooltipOverlay : BaseWebOverlay {
   private static readonly TrackedDevicePose_t[] _poseBuffer = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
 
   private bool _shown;
-  private bool _closing;
+  private DateTime? _hideAt;
   private Vector3? _targetPosition;
   private string? _text = "";
 
@@ -18,16 +18,6 @@ public class TooltipOverlay : BaseWebOverlay {
   {
     OpenVR.Overlay.SetOverlayWidthInMeters(OverlayHandle, 0.35f);
     OpenVR.Overlay.SetOverlaySortOrder(OverlayHandle, 150);
-    new Thread(() =>
-    {
-      var timer = new RefreshRateTimer();
-      while (!Disposed)
-      {
-        timer.TickStart();
-        UpdatePosition();
-        timer.SleepUntilNextTick();
-      }
-    }).Start();
   }
 
   public void SetPosition(Vector3 position)
@@ -35,35 +25,45 @@ public class TooltipOverlay : BaseWebOverlay {
     _targetPosition = Vector3.Add(position, new Vector3(0, 0.025f, 0));
   }
 
-  public async void SetText(string? text)
+  public void SetText(string? text)
   {
-    _text = text;
-    if (!UiReady) return;
-    var content = text != null ? $@"""{HttpUtility.JavaScriptStringEncode(text)}""" : "null";
-    Browser.ExecuteScriptAsync($"window.OyasumiIPCIn.showToolTip({content})");
-    if (text != null)
+    lock (OvrManager.LifecycleLock)
     {
-      _shown = true;
-      _closing = false;
-      OpenVR.Overlay.ShowOverlay(OverlayHandle);
-    }
-    else
-    {
-      _closing = true;
-      await Utils.DelayedAction(() =>
+      if (Disposed) return;
+      _text = text;
+      if (!UiReady) return;
+      var content = text != null ? $@"""{HttpUtility.JavaScriptStringEncode(text)}""" : "null";
+      Browser.ExecuteScriptAsync($"window.OyasumiIPCIn.showToolTip({content})");
+      if (text != null)
       {
-        if (!_closing) return;
-        _closing = false;
-        _shown = false;
-        OpenVR.Overlay.HideOverlay(OverlayHandle);
-      }, TimeSpan.FromSeconds(1));
+        _shown = true;
+        _hideAt = null;
+        OpenVR.Overlay.ShowOverlay(OverlayHandle);
+      }
+      else _hideAt = DateTime.UtcNow.AddSeconds(1);
     }
   }
 
-  public new void OnUiReady()
+  public override void OnUiReady()
   {
-    base.OnUiReady();
-    SetText(_text);
+    lock (OvrManager.LifecycleLock)
+    {
+      base.OnUiReady();
+      SetText(_text);
+    }
+  }
+
+  public override void UpdateFrame()
+  {
+    base.UpdateFrame();
+    if (Disposed) return;
+    if (_hideAt.HasValue && DateTime.UtcNow >= _hideAt.Value)
+    {
+      _hideAt = null;
+      _shown = false;
+      OpenVR.Overlay.HideOverlay(OverlayHandle);
+    }
+    UpdatePosition();
   }
 
   private void UpdatePosition()

--- a/src-overlay-sidecar/Utils/OVRUtils.cs
+++ b/src-overlay-sidecar/Utils/OVRUtils.cs
@@ -44,16 +44,19 @@ public class OvrUtils {
 
   public static float GetRefreshRate(bool force = false)
   {
-    if (!force && DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - _refreshRateLastSet <= 5000) return _refreshRate;
-    var system = OpenVR.System;
-    // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-    if (system == null) return _refreshRate; // This can be null sometimes...
-    ETrackedPropertyError error = default;
-    var displayFrequency =
-      OpenVR.System.GetFloatTrackedDeviceProperty(0, ETrackedDeviceProperty.Prop_DisplayFrequency_Float, ref error);
-    if (error != ETrackedPropertyError.TrackedProp_Success) return _refreshRate;
-    _refreshRate = displayFrequency;
-    _refreshRateLastSet = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-    return _refreshRate;
+    lock (OvrManager.LifecycleLock)
+    {
+      if (!force && DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - _refreshRateLastSet <= 5000) return _refreshRate;
+      var system = OpenVR.System;
+      // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+      if (system == null) return _refreshRate; // This can be null sometimes...
+      ETrackedPropertyError error = default;
+      var displayFrequency =
+        OpenVR.System.GetFloatTrackedDeviceProperty(0, ETrackedDeviceProperty.Prop_DisplayFrequency_Float, ref error);
+      if (error != ETrackedPropertyError.TrackedProp_Success) return _refreshRate;
+      _refreshRate = displayFrequency;
+      _refreshRateLastSet = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+      return _refreshRate;
+    }
   }
 }

--- a/src-overlay-sidecar/Utils/TextureWriter.cs
+++ b/src-overlay-sidecar/Utils/TextureWriter.cs
@@ -11,6 +11,8 @@ public class TextureWriter
   private GCHandle _paintBuffer;
 
   private Texture2D? _texture;
+  private Device? _device;
+  private bool _disposed;
   private uint _resolution;
   private bool _initialized;
 
@@ -37,7 +39,7 @@ public class TextureWriter
     _paintBufferLock.EnterReadLock();
     try
     {
-      var context = _texture.Device.ImmediateContext;
+      var context = _device!.ImmediateContext;
       var dataBox = context.MapSubresource(
         _texture,
         0,
@@ -106,11 +108,12 @@ public class TextureWriter
     }
   }
 
-  public async Task init()
+  public void Init()
   {
     try
     {
-      _texture = await Utils.InitTexture2D(_resolution, true);
+      _texture = Utils.InitTexture2D(_resolution, true);
+      _device = _texture.Device.QueryInterface<Device>();
     }
     catch
     {
@@ -123,6 +126,9 @@ public class TextureWriter
 
   public void Dispose()
   {
+    if (_disposed) return;
+    _disposed = true;
+    _initialized = false;
     _paintBufferLock.EnterWriteLock();
     try
     {
@@ -138,6 +144,8 @@ public class TextureWriter
 
     _paintBufferLock.Dispose();
 
+    _device?.Dispose();
+    _device = null;
     if (_texture != null && !_texture.IsDisposed)
     {
       _texture.Dispose();

--- a/src-overlay-sidecar/Utils/Utils.cs
+++ b/src-overlay-sidecar/Utils/Utils.cs
@@ -8,12 +8,6 @@ using SharpDX.DXGI;
 namespace overlay_sidecar;
 
 public static class Utils {
-  public static async Task DelayedAction(Action action, TimeSpan delay)
-  {
-    await Task.Delay(delay);
-    action();
-  }
-
   public static byte[] LoadEmbeddedFile(string embeddedFileName)
   {
     var assembly = Assembly.GetExecutingAssembly();
@@ -46,7 +40,7 @@ public static class Utils {
     }
   }
 
-  public static async Task<Texture2D?> InitTexture2D(uint resolution, bool cpuWritable)
+  public static Texture2D InitTexture2D(uint resolution, bool cpuWritable)
   {
     var timings = new[] { 16, 100, 200, 500, 1000 };
     Texture2D? texture = null;
@@ -80,11 +74,10 @@ public static class Utils {
         {
           Log.Error("Could not create overlay: " + err);
           texture?.Dispose();
-          GC.Collect();
           throw new Exception("Could not create texture");
         }
 
-        await Task.Delay(timings[attempt]);
+        Thread.Sleep(timings[attempt]);
         continue;
       }
 

--- a/src-overlay-ui/app/overlays/notifications/notifications-overlay.spec.ts
+++ b/src-overlay-ui/app/overlays/notifications/notifications-overlay.spec.ts
@@ -48,5 +48,16 @@ it('subscribes before readiness and dismisses accepted notifications by ID', () 
   notificationAdded.next({ id: 'timed', message: 'timed', duration: 3000 });
   vi.advanceTimersByTime(3000);
   expect(overlay.shown).toEqual([]);
+
+  for (let i = 0; i < 100; i++) {
+    notificationAdded.next({ id: `burst-${i}`, message: 'burst', duration: 3000 });
+  }
+  expect(overlay.shown.map((n) => n.id)).toEqual(['burst-70', 'burst-69', 'burst-0']);
+  vi.advanceTimersByTime(3000);
+  expect(overlay.shown.map((n) => n.id)).toEqual(['burst-71', 'burst-70', 'burst-69']);
+  notificationCleared.next('burst-70');
+  expect(overlay.shown.map((n) => n.id)).toEqual(['burst-72', 'burst-71', 'burst-69']);
+  vi.advanceTimersByTime(30 * 3000);
+  expect(overlay.shown).toEqual([]);
   cleanup.forEach((fn) => fn());
 });

--- a/src-overlay-ui/app/overlays/notifications/notifications-overlay.ts
+++ b/src-overlay-ui/app/overlays/notifications/notifications-overlay.ts
@@ -12,6 +12,8 @@ import { Notification } from '../../components/notification/notification';
 import { IpcService } from '../../ipc/ipc.service';
 import { AddNotificationParams } from '../../ipc/oyasumi-ipc';
 
+const MAX_NOTIFICATIONS = 32;
+
 @Component({
   selector: 'app-notifications-overlay',
   imports: [Notification],
@@ -32,7 +34,11 @@ export class NotificationsOverlay implements OnInit {
 
   constructor() {
     this.ipc.notificationAdded.pipe(takeUntilDestroyed()).subscribe((notification) => {
-      this.notifications.update((notifications) => [...notifications, notification]);
+      this.notifications.update((notifications) =>
+        notifications.length < MAX_NOTIFICATIONS
+          ? [...notifications, notification]
+          : [notifications[0], ...notifications.slice(-(MAX_NOTIFICATIONS - 2)), notification]
+      );
       this.updateActiveNotification();
     });
     this.ipc.notificationCleared.pipe(takeUntilDestroyed()).subscribe((id) => {


### PR DESCRIPTION
Restores the merged #307, #308, and #311 changes to `develop`.

Their commits landed on the stacked lifecycle branch after #306 was squash-merged. This branch cherry-picks those three merge commits onto current `develop`.

Verified the sidecar sources match the final merged stack. `dotnet build src-overlay-sidecar/oyasumivr-overlay-sidecar.csproj --no-restore -v quiet` passes with 116 existing warnings and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Splash screens now close automatically after a short period.
  - Overlay positioning and updates are handled more consistently during active rendering.
  - Notifications now remain within a manageable limit while preserving recent messages.

- **Bug Fixes**
  - Improved recovery when browser or overlay initialization fails.
  - Prevented stale notifications, tooltips, and dashboard states during rapid interactions.
  - Improved cleanup when closing dashboards, overlays, and pointer interactions.

- **Tests**
  - Added coverage for notification bursts, queue rotation, and automatic expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->